### PR TITLE
Fixed Travis configuration and tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - '6'
-  - '6.0'
-  - '6.1'
 install: npm install
 script: npm test -- --saucelabs
 addons:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/firebase/firebaseui-web.svg?branch=master)](https://travis-ci.org/firebase/firebaseui-web)
+
 # FirebaseUI for Web — Auth
 
 FirebaseUI is an open-source JavaScript library for Web that provides simple, customizable UI

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -45,6 +45,11 @@ config = {
   framework: 'jasmine',
   // The jasmine specs to run.
   specs: ['protractor_spec.js'],
+  // Jasmine options. Increase the timeout to 5min instead of the default 30s.
+  jasmineNodeOpts: {
+    // Default time to wait in ms before a test fails.
+    defaultTimeoutInterval: 5 * 60 * 1000
+  }
 };
 
 // Read arguments to the protractor command.


### PR DESCRIPTION
Only one node environment is tested now, the latest 6.x version.

Added Travis Build status to the Readme.

Tests were timing out on some browsers - increased the Jasmine default timeout to 5 minutes.