### PR TITLE
Fixed operation not supported error for password only apps in a Cordo…

### DIFF
--- a/javascript/widgets/handler/callback.js
+++ b/javascript/widgets/handler/callback.js
@@ -92,6 +92,19 @@ firebaseui.auth.widget.handler.handleCallback =
         firebaseui.auth.widget.handler.handleCallbackFailure_(
             app, component, /** @type {!Error} */ (error));
       }
+    } else if (error &&
+        error['code'] == 'auth/operation-not-supported-in-this-environment' &&
+        firebaseui.auth.widget.handler.common.isPasswordProviderOnly(app)) {
+      // Operation is not supported in this environment but only password
+      // provider is enabled. So allow this to proceed as a no redirect result.
+      // This will allow developers using password sign-in in Cordova to use
+      // FirebaseUI.
+      firebaseui.auth.widget.handler.handleCallbackResult_(
+          app,
+          component,
+          {
+            'user': null
+          });
     } else {
       // Go to the sign-in page with info bar error.
       firebaseui.auth.widget.handler.handleCallbackFailure_(

--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -804,6 +804,21 @@ firebaseui.auth.widget.handler.common.handleUnrecoverableError = function(
 
 
 /**
+ * Helper function to check if a FirebaseUI instance only supports password
+ * providers.
+ * @param {firebaseui.auth.AuthUI} app The current FirebaseUI instance whose
+ *     configuration is used.
+ * @return {boolean} Whether only password providers are supported by the app's
+ *     current configuration.
+ */
+firebaseui.auth.widget.handler.common.isPasswordProviderOnly = function(app) {
+  var providers = app.getConfig().getProviders();
+  return providers.length == 1 &&
+      providers[0] == firebase.auth.EmailAuthProvider.PROVIDER_ID;
+};
+
+
+/**
  * Calls the appropriate sign-in start handler depending on display mode.
  *
  * @param {firebaseui.auth.AuthUI} app The current FirebaseUI instance whose
@@ -814,9 +829,7 @@ firebaseui.auth.widget.handler.common.handleUnrecoverableError = function(
  */
 firebaseui.auth.widget.handler.common.handleSignInStart = function(
     app, container, opt_email, opt_infoBarMessage) {
-  var providers = app.getConfig().getProviders();
-  if (providers.length == 1 &&
-      providers[0] == firebase.auth.EmailAuthProvider.PROVIDER_ID) {
+  if (firebaseui.auth.widget.handler.common.isPasswordProviderOnly(app)) {
     // If info bar message is available, do not go to accountchooser.com since
     // this is a result of some error in the flow and the error message must be
     // displayed.

--- a/javascript/widgets/handler/common_test.js
+++ b/javascript/widgets/handler/common_test.js
@@ -1604,3 +1604,37 @@ function testGetErrorMessage_unknownError_jsonMessage() {
       firebaseui.auth.log.error.getLastCall().getArgument(0));
   assertEquals('An internal error has occurred.', message);
 }
+
+
+function testIsPasswordProviderOnly_multipleMixedProviders() {
+  // Set a password and federated providers in the FirebaseUI instance
+  // configuration.
+  app.updateConfig(
+      'signInOptions',
+      [
+        firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+        firebase.auth.EmailAuthProvider.PROVIDER_ID
+      ]);
+  assertFalse(
+      firebaseui.auth.widget.handler.common.isPasswordProviderOnly(app));
+}
+
+
+function testIsPasswordProviderOnly_singlePasswordProvider() {
+  // Set a password only provider in the FirebaseUI instance configuration.
+  app.updateConfig(
+      'signInOptions',
+      [firebase.auth.EmailAuthProvider.PROVIDER_ID]);
+  assertTrue(
+      firebaseui.auth.widget.handler.common.isPasswordProviderOnly(app));
+}
+
+
+function testIsPasswordProviderOnly_singleFederatedProvider() {
+  // Set a federated only provider in the FirebaseUI instance configuration.
+  app.updateConfig(
+      'signInOptions',
+      [firebase.auth.GoogleAuthProvider.PROVIDER_ID]);
+  assertFalse(
+      firebaseui.auth.widget.handler.common.isPasswordProviderOnly(app));
+}

--- a/javascript/widgets/handler/testhelper.js
+++ b/javascript/widgets/handler/testhelper.js
@@ -81,6 +81,12 @@ var internalError = {
   'code': 'auth/internal-error',
   'message': 'An internal error occurred.'
 };
+var operationNotSupportedError = {
+  'code': 'auth/operation-not-supported-in-this-environment',
+  'message':  'This operation is not supported in the environment this ' +
+  'application is running on. "location.protocol" must be http, https ' +
+  'or chrome-extension and web storage must be enabled.'
+};
 
 var container;
 var container2;


### PR DESCRIPTION
…va environment.

As only password providers are supported, the operation not supported error should not be shown
when getRedirectResult is called.