### PR TITLE
Adds error handling in the signin handler when fetchProvidersForEmail…

### DIFF
--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -887,7 +887,14 @@ firebaseui.auth.widget.handler.common.handleStartEmailFirstFlow =
                 undefined,
                 opt_infoBarMessage);
       },
-      function(error) {}
+      function(error) {
+        // The email provided could be an invalid one or some other error
+        // could occur.
+        var errorMessage =
+            firebaseui.auth.widget.handler.common.getErrorMessage(
+                error);
+        component.showInfoBar(errorMessage);
+      }
   ));
 };
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "closure-builder": "~2.0.0",
+    "closure-builder": "^2.0.17",
     "del": "^2.2.2",
     "firebase-tools": "^3.0.8",
     "google-closure-compiler": "^20160713.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "closure-builder": "^2.0.17",
+    "closure-builder": "~2.0.0",
     "del": "^2.2.2",
     "firebase-tools": "^3.0.8",
     "google-closure-compiler": "^20160713.2.0",


### PR DESCRIPTION
Adds error handling in the signin handler when fetchProvidersForEmail throws some error.

This was noticed when the email entered passes client validation but fails on backend
validation. In that case, we should display and info bar with the backend error.