### PR TITLE
Fixes firebaseui.auth.idp.getAuthCredential credential initializer wh…

### DIFF
--- a/javascript/utils/idp.js
+++ b/javascript/utils/idp.js
@@ -66,9 +66,18 @@ firebaseui.auth.idp.getAuthCredential = function(credentialObject) {
     if (credentialObject['secret'] && credentialObject['accessToken']) {
       credentialObject['oauthToken'] = credentialObject['accessToken'];
       credentialObject['oauthTokenSecret'] = credentialObject['secret'];
+      return firebase.auth[firebaseui.auth.idp.AuthProviders[providerId]]
+          .credential(credentialObject['accessToken'],
+                      credentialObject['secret']);
+    } else if (providerId == firebase.auth.GoogleAuthProvider.PROVIDER_ID) {
+      return firebase.auth[firebaseui.auth.idp.AuthProviders[providerId]]
+          .credential(credentialObject['idToken'],
+                      credentialObject['accessToken']);
+    } else {
+      // GitHub and Facebook.
+      return firebase.auth[firebaseui.auth.idp.AuthProviders[providerId]]
+          .credential(credentialObject['accessToken']);
     }
-    return firebase.auth[firebaseui.auth.idp.AuthProviders[providerId]]
-        .credential(credentialObject);
   }
   return null;
 };

--- a/javascript/utils/idp_test.js
+++ b/javascript/utils/idp_test.js
@@ -33,6 +33,7 @@ function setUp() {
   firebase.auth = {};
   for (var providerId in firebaseui.auth.idp.AuthProviders) {
     firebase.auth[firebaseui.auth.idp.AuthProviders[providerId]] = {
+      'PROVIDER_ID': providerId,
       'credential': goog.testing.recordFunction(function() {
         // Return something.
         return providerId;
@@ -64,15 +65,17 @@ function testIsSupportedProvider() {
 /**
  * Asserts the credential is initialized with correct OAuth response.
  * @param {!Object} provider The provider object.
- * @param {!Object} oauthResponse The response used to initialize the
+ * @param {!Array<string>} oauthParams The OAuth params used to initialize the
  *     credential.
  * @param {!Object} ref The credential reference.
  */
-function assertCredential(provider, oauthResponse, ref) {
+function assertCredential(provider, oauthParams, ref) {
   assertNotNullNorUndefined(ref);
-  var parameter = provider.credential.getLastCall().getArgument(0);
-  for (var key in oauthResponse) {
-    assertEquals(oauthResponse[key], parameter[key]);
+  var parameters = provider.credential.getLastCall().getArguments();
+  assertEquals(oauthParams.length, parameters.length);
+  // Confirm the expected parameters passed when initializing the credential.
+  for (var i = 0; i < parameters.length; i++) {
+    assertEquals(oauthParams[i], parameters[i]);
   }
 }
 
@@ -86,10 +89,7 @@ function testGetAuthCredential_google() {
   var ref = firebaseui.auth.idp.getAuthCredential(cred);
   assertCredential(
       firebase.auth.GoogleAuthProvider,
-      {
-        'idToken': 'ID_TOKEN',
-        'accessToken': 'ACCESS_TOKEN'
-      },
+      ['ID_TOKEN', 'ACCESS_TOKEN'],
       ref);
 }
 
@@ -102,9 +102,7 @@ function testGetAuthCredential_facebook() {
   var ref = firebaseui.auth.idp.getAuthCredential(cred);
   assertCredential(
       firebase.auth.FacebookAuthProvider,
-      {
-        'accessToken': 'ACCESS_TOKEN'
-      },
+      ['ACCESS_TOKEN'],
       ref);
 }
 
@@ -118,10 +116,7 @@ function testGetAuthCredential_twitter() {
   var ref = firebaseui.auth.idp.getAuthCredential(cred);
   assertCredential(
       firebase.auth.TwitterAuthProvider,
-      {
-        'oauthToken': 'ACCESS_TOKEN',
-        'oauthTokenSecret': 'SECRET'
-      },
+      ['ACCESS_TOKEN', 'SECRET'],
       ref);
 }
 
@@ -134,9 +129,7 @@ function testGetAuthCredential_github() {
   var ref = firebaseui.auth.idp.getAuthCredential(cred);
   assertCredential(
       firebase.auth.GithubAuthProvider,
-      {
-        'accessToken': 'ACCESS_TOKEN'
-      },
+      ['ACCESS_TOKEN'],
       ref);
 }
 

--- a/javascript/utils/pendingemailcredential_test.js
+++ b/javascript/utils/pendingemailcredential_test.js
@@ -36,9 +36,12 @@ function setUp() {
   // Mock credential.
   firebase['auth'] = firebase['auth'] || {
     'GoogleAuthProvider' : {
-      'credential' : function(response) {
-        return response;
-      }
+      'credential' : function(idToken, accessToken) {
+        assertEquals(credential['idToken'], idToken);
+        assertEquals(credential['accessToken'], accessToken);
+        return credential;
+      },
+      'PROVIDER_ID': 'google.com'
     }
   };
   credential = {

--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -608,10 +608,11 @@ firebaseui.auth.widget.handler.common.isCredentialExpired = function(error) {
  *     configuration is used.
  * @param {!firebaseui.auth.ui.page.Base} component The current UI component.
  * @param {string} providerId The provider ID of the selected IdP.
+ * @param {?string=} opt_email The optional email to try to sign in with.
  * @package
  */
 firebaseui.auth.widget.handler.common.federatedSignIn = function(
-    app, component, providerId) {
+    app, component, providerId, opt_email) {
   var container = component.getContainer();
   var providerSigninFailedCallback = function(error) {
     // TODO: align redirect and popup flow error handling for similar errors.
@@ -641,6 +642,19 @@ firebaseui.auth.widget.handler.common.federatedSignIn = function(
     for (var i = 0; i < additionalScopes.length; i++) {
       provider['addScope'](additionalScopes[i]);
     }
+  }
+  // If Google provider is requested and email is specified, pass OAuth
+  // parameter login_hint with that email.
+  if (provider &&
+      // In case the Firebase Auth version used is too old.
+      provider.setCustomParameters &&
+      // Only Google supports this parameter.
+      providerId == firebase.auth.GoogleAuthProvider.PROVIDER_ID &&
+      // Only pass login_hint when email available.
+      opt_email) {
+    provider.setCustomParameters({
+      'login_hint': opt_email
+    });
   }
   // Redirect processor.
   var processRedirect = function() {

--- a/javascript/widgets/handler/federatedlinking.js
+++ b/javascript/widgets/handler/federatedlinking.js
@@ -61,8 +61,10 @@ firebaseui.auth.widget.handler.handleFederatedLinking = function(
         // We sign in the user through the normal federated sign-in flow,
         // and the callback handler will take care of linking the
         // pending credential to the successfully signed in user.
+        // Pass the email since some OAuth providers support OAuth flow
+        // with a specified email.
         firebaseui.auth.widget.handler.common.federatedSignIn(app, component,
-            providerId);
+            providerId, email);
       });
   component.render(container);
   // Set current UI component.

--- a/javascript/widgets/handler/federatedlinking_test.js
+++ b/javascript/widgets/handler/federatedlinking_test.js
@@ -56,10 +56,28 @@ function setPendingEmailCredentials() {
 function testHandleFederatedLinking() {
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
+  assertFederatedLinkingPage(federatedAccount.getEmail());
+  submitForm();
+  testAuth.assertSignInWithRedirect([expectedProvider]);
+  return testAuth.process();
+}
+
+
+function testHandleFederatedLinking_noLoginHint() {
+  // Add additional scopes to test they are properly passed to the sign-in
+  // method.
+  // As this is not google.com, no customParameters will be set.
+  var expectedProvider =
+      getExpectedProviderWithCustomParameters('github.com');
+  setPendingEmailCredentials();
+  firebaseui.auth.widget.handler.handleFederatedLinking(
+      app, container, federatedAccount.getEmail(), 'github.com');
   assertFederatedLinkingPage(federatedAccount.getEmail());
   submitForm();
   testAuth.assertSignInWithRedirect([expectedProvider]);
@@ -72,7 +90,9 @@ function testHandleFederatedLinking_popup_success() {
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -124,7 +144,9 @@ function testHandleFederatedLinking_popup_success_multipleClicks() {
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -216,7 +238,9 @@ function testHandleFederatedLinking_noPendingCredential_popup() {
 function testHandleFederatedLinking_error() {
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -237,7 +261,9 @@ function testHandleFederatedLinking_popup_recoverableError() {
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -268,7 +294,9 @@ function testHandleFederatedLinking_popup_userCancelled() {
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -299,7 +327,9 @@ function testHandleFederatedLinking_popup_unrecoverableError() {
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -326,7 +356,9 @@ function testHandleFederatedLinking_popup_popupBlockedError() {
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -357,7 +389,9 @@ function testHandleFederatedLinking_popup_popupBlockedError_redirectError() {
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -392,7 +426,9 @@ function testHandleFederatedLinking_inProcessing() {
   // Add additional scopes to test they are properly passed to the sign-in
   // method.
   app.updateConfig('signInOptions', signInOptionsWithScopes);
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');
@@ -421,7 +457,9 @@ function testHandleFederatedLinking_inProcessing() {
 function testHandleFederatedLinking_popup_cancelled() {
   // Test sign in with popup flow when the popup is cancelled.
   app.updateConfig('signInFlow', 'popup');
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': federatedAccount.getEmail()
+  });
   setPendingEmailCredentials();
   firebaseui.auth.widget.handler.handleFederatedLinking(
       app, container, federatedAccount.getEmail(), 'google.com');

--- a/javascript/widgets/handler/federatedsignin.js
+++ b/javascript/widgets/handler/federatedsignin.js
@@ -45,8 +45,10 @@ firebaseui.auth.widget.handler.handleFederatedSignIn = function(
       providerId,
       // On submit.
       function() {
+        // Pass the email since some OAuth providers support OAuth flow
+        // with a specified email.
         firebaseui.auth.widget.handler.common.federatedSignIn(app, component,
-            providerId);
+            providerId, email);
       });
 
   component.render(container);

--- a/javascript/widgets/handler/federatedsignin_test.js
+++ b/javascript/widgets/handler/federatedsignin_test.js
@@ -35,9 +35,26 @@ goog.require('firebaseui.auth.widget.handler.testHelper');
 
 function testHandleFederatedSignIn() {
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
+  assertFederatedLinkingPage();
+  submitForm();
+  testAuth.assertSignInWithRedirect(
+      [expectedProvider]);
+  return testAuth.process();
+}
+
+
+function testHandleFederatedSignIn_noLoginHint() {
+  // Add additional scopes to test they are properly passed to sign-in method.
+  // As this is not google.com, no customParameters will be set.
+  var expectedProvider =
+      getExpectedProviderWithCustomParameters('facebook.com');
+  firebaseui.auth.widget.handler.handleFederatedSignIn(
+      app, container, 'user@gmail.com', 'facebook.com');
   assertFederatedLinkingPage();
   submitForm();
   testAuth.assertSignInWithRedirect(
@@ -50,7 +67,9 @@ function testHandleFederatedSignIn_popup_success() {
   // Successful federated sign in with popup.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -90,7 +109,9 @@ function testHandleFederatedSignIn_popup_success_multipleClicks() {
   // Test multiple clicks in sign in with popup.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -139,7 +160,9 @@ function testHandleFederatedSignIn_popup_cancelled() {
   // Test sign in with popup flow when the popup is cancelled.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -171,7 +194,9 @@ function testHandleFederatedSignIn_reset() {
 
 function testHandleFederatedSignIn_error() {
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -190,7 +215,9 @@ function testHandleFederatedSignIn_popup_recoverableError() {
   // Test federated sign in with popup when recoverable error thrown.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -215,7 +242,9 @@ function testHandleFederatedSignIn_popup_userCancelled() {
   // Test federated sign in with popup when user denies permissions.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -240,7 +269,9 @@ function testHandleFederatedSignIn_popup_popupBlockedError() {
   // Test federated sign in with popup when popup blocked.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -266,7 +297,9 @@ function testHandleFederatedSignIn_popup_popupBlockedError_redirectError() {
   // Test federated sign in with popup when popup is blocked and redirect fails.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -298,7 +331,9 @@ function testHandleFederatedSignIn_popup_unrecoverableError() {
   // Test federated sign in with popup when unrecoverable error returned.
   app.updateConfig('signInFlow', 'popup');
   // Add additional scopes to test they are properly passed to sign-in method.
-  var expectedProvider = getExpectedProviderWithScopes();
+  var expectedProvider = getExpectedProviderWithScopes({
+    'login_hint': 'user@gmail.com'
+  });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -317,6 +352,11 @@ function testHandleFederatedSignIn_popup_unrecoverableError() {
 
 
 function testHandleFederatedSignIn_inProcessing() {
+  var expectedProvider = getExpectedProviderWithCustomParameters(
+      'google.com',
+      {
+        'login_hint': 'user@gmail.com'
+      });
   firebaseui.auth.widget.handler.handleFederatedSignIn(
       app, container, 'user@gmail.com', 'google.com');
   assertFederatedLinkingPage();
@@ -325,7 +365,7 @@ function testHandleFederatedSignIn_inProcessing() {
   // Click submit again.
   submitForm();
   testAuth.assertSignInWithRedirect(
-      [firebaseui.auth.idp.getAuthProvider('google.com')], null, internalError);
+      [expectedProvider], null, internalError);
   return testAuth.process().then(function() {
     // On error, show a message on info bar.
     assertInfoBarMessage(
@@ -335,8 +375,7 @@ function testHandleFederatedSignIn_inProcessing() {
     // Submit again.
     submitForm();
 
-    testAuth.assertSignInWithRedirect(
-        [firebaseui.auth.idp.getAuthProvider('google.com')]);
+    testAuth.assertSignInWithRedirect([expectedProvider]);
     return testAuth.process();
   });
 }


### PR DESCRIPTION
Fixes firebaseui.auth.idp.getAuthCredential credential initializer which was breaking account linking flow.

Added login_hint to Google OAuth flow when the email is specified.
This is applied in the following 2 cases:
1. Account linking is triggered and the user needs to sign in to existing Google account.
To force the user to sign in to the expected Google account, we pass the login hint with the email.
2. If a user selects email login and the Google account already exists for that email,
when clicking continue to sign in with Google account, we pass the login_hint for that account.