### PR TITLE
Remove "yet" tease for non-browser environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ FirebaseUI Auth clients are also available for
 [Android](https://github.com/firebase/firebaseui-android).
 
 FirebaseUI fully supports all recent browsers. Signing in with federated
-providers (Google, Facebook, Twitter, Github) is not yet supported in
+providers (Google, Facebook, Twitter, Github) is not supported in
 non-browser environments (Cordova, React Native, Ionic...) nor Chrome
 extensions.
 


### PR DESCRIPTION
Unless you have a timeframe, or some other information to share, the "yet" only serves to get hopes up.