### PR TITLE
Restrict firebase imports in Node distro

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,8 +40,8 @@ const OUTPUT_WRAPPER = OPTIMIZATION_LEVEL === 'WHITESPACE_ONLY' ?
 
 // Adds the firebase module requirement and exports firebaseui.
 const NPM_MODULE_WRAPPER = OPTIMIZATION_LEVEL === 'WHITESPACE_ONLY' ?
-    'var firebase=require(\'firebase\');%output%module.exports=firebaseui;' :
-    '(function() { var firebase=require(\'firebase\');%output% })();' +
+    'var firebase=require(\'firebase/app\');require(\'firebase/auth\');%output%module.exports=firebaseui;' :
+    '(function() { var firebase=require(\'firebase/app\');require(\'firebase/auth\');%output% })();' +
     'module.exports=firebaseui;';
 
 // The path to Closure Compiler.


### PR DESCRIPTION
At the moment only `require('firebase/app');` and `require('firebase/auth')` is needed but the Node distro imports the whole Firebase SDK with `require('firebase');`.

This makes it hard to only load parts of the Firebase SDK or use dynamic imports when using Node to build for the client (using Webpack for instance).

In this PR I'm replacing the `firebase` import with importing `firebase/app` and `firebase/auth`.

This would fix https://github.com/firebase/firebaseui-web/issues/163