### PR TITLE
npm install

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -20,7 +20,9 @@ Run:
 
 ```bash
 git clone https://github.com/firebase/firebaseui-web.git
-cd firebaseui-web/demo
+cd firebaseui-web
+npm install
+cd demo
 ```
 
 This will clone the repository in the current directory.


### PR DESCRIPTION
I might have missed something, but this seems to be missing.
Install dependencies with `npm install` before trying to run the demo.