### PR TITLE
Make Firebase a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "streamqueue": "^1.1.1"
   },
   "dependencies": {
-    "dialog-polyfill": "^0.4.7",
+    "dialog-polyfill": "^0.4.7"
+  },
+  "peerDependencies": {
     "firebase": "^4.8.0"
   }
 }


### PR DESCRIPTION
Currently for most projects using this library, Firebase is imported twice because this library exposes a pre-compiled version to npm.