### PR TITLE
Updates closure-builder version to ^2.2.34.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,23 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@browserify/acorn5-object-spread": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@browserify/acorn5-object-spread/-/acorn5-object-spread-5.0.1.tgz",
+      "integrity": "sha512-sFCUPzgeEjdq3rinwy4TFXtak2YZdhqpj6MdNusxkdTFr9TXAUEYK4YQSamR8Joqt/yii1drgl5hk8q/AtJDKA==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+          "dev": true
+        }
+      }
+    },
     "@firebase/app": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.1.2.tgz",
@@ -849,61 +866,6 @@
         }
       }
     },
-    "browserify": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
-      "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
-      "dev": true,
-      "requires": {
-        "assert": "1.4.1",
-        "browser-pack": "6.0.2",
-        "browser-resolve": "1.11.2",
-        "browserify-zlib": "0.2.0",
-        "buffer": "5.0.8",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "defined": "1.0.0",
-        "deps-sort": "2.0.0",
-        "domain-browser": "1.1.7",
-        "duplexer2": "0.1.4",
-        "events": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "htmlescape": "1.1.1",
-        "https-browserify": "1.0.0",
-        "inherits": "2.0.3",
-        "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
-        "labeled-stream-splicer": "2.0.0",
-        "module-deps": "4.1.1",
-        "os-browserify": "0.3.0",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.3",
-        "resolve": "1.5.0",
-        "shasum": "1.0.2",
-        "shell-quote": "1.6.1",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "1.0.3",
-        "subarg": "1.0.0",
-        "syntax-error": "1.3.0",
-        "through2": "2.0.3",
-        "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4",
-        "xtend": "4.0.1"
-      }
-    },
     "browserify-aes": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
@@ -1236,39 +1198,182 @@
       }
     },
     "closure-builder": {
-      "version": "2.2.29",
-      "resolved": "https://registry.npmjs.org/closure-builder/-/closure-builder-2.2.29.tgz",
-      "integrity": "sha1-yTtafCTiZY1Ak2Fvvqk6qlKmhVc=",
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/closure-builder/-/closure-builder-2.2.34.tgz",
+      "integrity": "sha512-8nQ2Ysr1LU2PhXHny0SUazjOIfPZm6kiY+tIqXMIO5q11tCzGVwEaKaTcbhEZ4HykVHC1qCMU1oTU1GZqhrCJQ==",
       "dev": true,
       "requires": {
-        "browserify": "14.5.0",
+        "browserify": "15.1.0",
         "clean-css": "4.1.9",
         "decompress": "4.2.0",
-        "eslint-config-google": "0.9.1",
-        "follow-redirects": "1.2.5",
-        "fs-extra": "4.0.2",
+        "follow-redirects": "1.3.0",
+        "fs-extra": "5.0.0",
         "glob": "7.1.2",
         "loglevel": "1.6.0",
-        "marked": "0.3.6",
+        "marked": "0.3.12",
         "mkdirp": "0.5.1",
         "path-parse": "1.0.5",
         "progress": "2.0.0",
         "rimraf": "2.6.2",
-        "rollup": "0.50.1",
+        "rollup": "0.53.4",
         "touch": "3.1.0",
-        "validator": "9.1.1"
+        "validator": "9.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+          "dev": true
+        },
+        "browserify": {
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-15.1.0.tgz",
+          "integrity": "sha512-CulQKBiROFN+EssphwJEY4wWBACqWR1Iv+wxgO0GvOiweLb1Rwja4J/XbTCxx1ixTDK6llgUB3iG8fFxLBbJDA==",
+          "dev": true,
+          "requires": {
+            "assert": "1.4.1",
+            "browser-pack": "6.0.2",
+            "browser-resolve": "1.11.2",
+            "browserify-zlib": "0.2.0",
+            "buffer": "5.0.8",
+            "cached-path-relative": "1.0.1",
+            "concat-stream": "1.5.2",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.12.0",
+            "defined": "1.0.0",
+            "deps-sort": "2.0.0",
+            "domain-browser": "1.1.7",
+            "duplexer2": "0.1.4",
+            "events": "1.1.1",
+            "glob": "7.1.2",
+            "has": "1.0.1",
+            "htmlescape": "1.1.1",
+            "https-browserify": "1.0.0",
+            "inherits": "2.0.3",
+            "insert-module-globals": "7.0.1",
+            "JSONStream": "1.3.1",
+            "labeled-stream-splicer": "2.0.0",
+            "module-deps": "5.0.1",
+            "os-browserify": "0.3.0",
+            "parents": "1.0.1",
+            "path-browserify": "0.0.0",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "read-only-stream": "2.0.0",
+            "readable-stream": "2.3.3",
+            "resolve": "1.5.0",
+            "shasum": "1.0.2",
+            "shell-quote": "1.6.1",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.7.2",
+            "string_decoder": "1.0.3",
+            "subarg": "1.0.0",
+            "syntax-error": "1.3.0",
+            "through2": "2.0.3",
+            "timers-browserify": "1.4.2",
+            "tty-browserify": "0.0.0",
+            "url": "0.11.0",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4",
+            "xtend": "4.0.1"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "detective": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-5.0.2.tgz",
+          "integrity": "sha512-NUsLoezj4wb9o7vpxS9F3L5vcO87ceyRBcl48op06YFNwkyIEY997JpSCA5lDlDuDc6JxOtaL5qfK3muoWxpMA==",
+          "dev": true,
+          "requires": {
+            "@browserify/acorn5-object-spread": "5.0.1",
+            "acorn": "5.3.0",
+            "defined": "1.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.3.0.tgz",
+          "integrity": "sha1-9oSHH8EW0uMp/aVe9naH9Pq8kFw=",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0"
+          }
+        },
         "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "4.0.0",
             "universalify": "0.1.1"
           }
+        },
+        "marked": {
+          "version": "0.3.12",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+          "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+          "dev": true
+        },
+        "module-deps": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-5.0.1.tgz",
+          "integrity": "sha512-sigq/hm/L+Z5IGi1DDl0x2ptkw7S86aFh213QhPLD8v9Opv90IHzKIuWJrRa5bJ77DVKHco2CfIEuThcT/vDJA==",
+          "dev": true,
+          "requires": {
+            "browser-resolve": "1.11.2",
+            "cached-path-relative": "1.0.1",
+            "concat-stream": "1.6.0",
+            "defined": "1.0.0",
+            "detective": "5.0.2",
+            "duplexer2": "0.1.4",
+            "inherits": "2.0.3",
+            "JSONStream": "1.3.1",
+            "parents": "1.0.1",
+            "readable-stream": "2.3.3",
+            "resolve": "1.5.0",
+            "stream-combiner2": "1.1.1",
+            "subarg": "1.0.0",
+            "through2": "2.0.3",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
+              }
+            }
+          }
+        },
+        "rollup": {
+          "version": "0.53.4",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.53.4.tgz",
+          "integrity": "sha512-ErW5cFw5KY/qiyUlPDJ7iBhw51Iro/oyvxETupO85bMg5T7MLlFj3lEDzwjLTOxJAyzWQanUYj/LZHm6aLLm5w==",
+          "dev": true
+        },
+        "validator": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-9.2.0.tgz",
+          "integrity": "sha512-6Ij4Eo0KM4LkR0d0IegOwluG5453uqT5QyF5SV5Ezvm8/zmkKI/L4eoraafZGlZPC9guLkwKzgypcw8VGWWnGA==",
+          "dev": true
         }
       }
     },
@@ -2145,16 +2250,6 @@
         "fs-exists-sync": "0.1.0"
       }
     },
-    "detective": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13",
-        "defined": "1.0.0"
-      }
-    },
     "dialog-polyfill": {
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.4.9.tgz",
@@ -2373,12 +2468,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "eslint-config-google": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.9.1.tgz",
-      "integrity": "sha512-5A83D+lH0PA81QMESKbLJd/a3ic8tPZtwUmqNrxMRo54nfFaUvtt89q/+icQ+fd66c2xQHn0KyFkzJDoAUfpZA==",
       "dev": true
     },
     "etag": {
@@ -3095,15 +3184,6 @@
           "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
           "dev": true
         }
-      }
-    },
-    "follow-redirects": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
-      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9"
       }
     },
     "for-in": {
@@ -6926,12 +7006,6 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
-    "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
-      "dev": true
-    },
     "material-design-lite": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.3.0.tgz",
@@ -7185,29 +7259,6 @@
       "integrity": "sha1-O0tCACOmbKfjK9uhbnEJN+FNGws=",
       "dev": true,
       "optional": true
-    },
-    "module-deps": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
-      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
-      "dev": true,
-      "requires": {
-        "browser-resolve": "1.11.2",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "defined": "1.0.0",
-        "detective": "4.5.0",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.3",
-        "resolve": "1.5.0",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
-      }
     },
     "moment": {
       "version": "2.19.2",
@@ -8940,12 +8991,6 @@
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=",
       "dev": true
     },
-    "rollup": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.1.tgz",
-      "integrity": "sha512-XwrnqjSTk+yR8GbP6hiJuVe83MVmBw/gm4P3qP34A10fRXvv6ppl0ZUg1+Pj1tIZSR/aw5ZaILLEiVxwXIAdAw==",
-      "dev": true
-    },
     "router": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/router/-/router-1.3.2.tgz",
@@ -10605,12 +10650,6 @@
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
-    },
-    "validator": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-9.1.1.tgz",
-      "integrity": "sha512-1TGGX1GKilfmcEa9rm+9nI9AqIUQK8oj4jZI0DmTGLTPM5jmowBBhyBIHCks73+P1QPZk2i6oOYUq583uOetHQ==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "closure-builder": "^2.0.17",
+    "closure-builder": "^2.2.34",
     "firebase-tools": "^3.0.8",
     "fs-extra": "^3.0.1",
     "google-closure-compiler": "^20171112.0.0",


### PR DESCRIPTION
This version uses npm marked package >= 0.3.9 which has a security vulnerability in version 0.3.6.

I'm sorry I never posted this comment, can you please explain what this comment is doing here?