### PR TITLE
Fixes failing CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: node_js
 node_js:
-  - '6'
+  - '8'
 install: npm install
 script: npm test -- --saucelabs
 before_install:
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
   - unset _JAVA_OPTIONS
 addons:
   sauce_connect: true

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -77,9 +77,11 @@ if [[ $1 = "--saucelabs" ]]; then
 else
   echo "Using PhantomJS."
   # Updates Selenium Webdriver.
-  ./node_modules/.bin/webdriver-manager update
+  #./node_modules/.bin/webdriver-manager update
+  webdriver-manager update
   # Start Selenium Webdriver.
-  ./node_modules/.bin/webdriver-manager start &>/dev/null &
+  #./node_modules/.bin/webdriver-manager start &>/dev/null &
+  webdriver-manager start &>/dev/null &
   seleniumStarted=true
   echo "Selenium Server started."
   # Wait for servers to come up.

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -77,9 +77,9 @@ if [[ $1 = "--saucelabs" ]]; then
 else
   echo "Using PhantomJS."
   # Updates Selenium Webdriver.
-  ./node_modules/protractor/node_modules/webdriver-manager/bin/webdriver-manager update
+  ./node_modules/protractor/bin/webdriver-manager update
   # Start Selenium Webdriver.
-  ./node_modules/protractor/node_modules/webdriver-manager/bin/webdriver-manager start &>/dev/null &
+  ./node_modules/protractor/bin/webdriver-manager start &>/dev/null &
   seleniumStarted=true
   echo "Selenium Server started."
   # Wait for servers to come up.

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -77,11 +77,9 @@ if [[ $1 = "--saucelabs" ]]; then
 else
   echo "Using PhantomJS."
   # Updates Selenium Webdriver.
-  #./node_modules/.bin/webdriver-manager update
-  webdriver-manager update
+  ./node_modules/protractor/node_modules/webdriver-manager/bin/webdriver-manager update
   # Start Selenium Webdriver.
-  #./node_modules/.bin/webdriver-manager start &>/dev/null &
-  webdriver-manager start &>/dev/null &
+  ./node_modules/protractor/node_modules/webdriver-manager/bin/webdriver-manager start &>/dev/null &
   seleniumStarted=true
   echo "Selenium Server started."
   # Wait for servers to come up.

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -48,7 +48,7 @@
 # Travis will run `npm test -- --saucelabs`.
 
 cd "$(dirname $(dirname "$0"))"
-BIN_PATH="./node_modules/.bin"
+BIN_PATH="./node_modules/protractor/bin"
 
 function killServer () {
   if [ "$seleniumStarted" = true ]; then
@@ -78,8 +78,8 @@ if [[ $1 = "--saucelabs" ]]; then
 else
   echo "Using Headless Chrome."
   # Updates Selenium Webdriver.
-  echo "$BIN_PATH/webdriver-manager update"
-  $BIN_PATH/webdriver-manager update
+  echo "$BIN_PATH/webdriver-manager update --gecko=false"
+  $BIN_PATH/webdriver-manager update --gecko=false
   # Start Selenium Webdriver.
   echo "$BIN_PATH/webdriver-manager start &>/dev/null &"
   $BIN_PATH/webdriver-manager start &>/dev/null &

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -77,9 +77,9 @@ if [[ $1 = "--saucelabs" ]]; then
 else
   echo "Using PhantomJS."
   # Updates Selenium Webdriver.
-  ./node_modules/protractor/bin/webdriver-manager update
+  ./node_modules/.bin/webdriver-manager update
   # Start Selenium Webdriver.
-  ./node_modules/protractor/bin/webdriver-manager start &>/dev/null &
+  ./node_modules/.bin/webdriver-manager start &>/dev/null &
   seleniumStarted=true
   echo "Selenium Server started."
   # Wait for servers to come up.

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -48,19 +48,20 @@
 # Travis will run `npm test -- --saucelabs`.
 
 cd "$(dirname $(dirname "$0"))"
+BIN_PATH="./node_modules/.bin"
 
 function killServer () {
   if [ "$seleniumStarted" = true ]; then
     echo "Stopping Selenium..."
-    ./node_modules/.bin/webdriver-manager shutdown
-    ./node_modules/.bin/webdriver-manager clean
+    $BIN_PATH/webdriver-manager shutdown
+    $BIN_PATH/webdriver-manager clean
   fi
   echo "Killing HTTP Server..."
   kill $serverPid
 }
 
 # Start the local webserver.
-./node_modules/.bin/gulp serve &
+$BIN_PATH/gulp serve &
 serverPid=$!
 echo "Local HTTP Server started with PID $serverPid."
 
@@ -73,16 +74,18 @@ if [[ $1 = "--saucelabs" ]]; then
   sleep 2
   echo "Using SauceLabs."
   # $2 contains the tunnelIdentifier argument if specified, otherwise is empty.
-  ./node_modules/.bin/protractor protractor.conf.js --saucelabs $2
+  $BIN_PATH/protractor protractor.conf.js --saucelabs $2
 else
-  echo "Using PhantomJS."
+  echo "Using Headless Chrome."
   # Updates Selenium Webdriver.
-  ./node_modules/.bin/webdriver-manager update
+  echo "$BIN_PATH/webdriver-manager update"
+  $BIN_PATH/webdriver-manager update
   # Start Selenium Webdriver.
-  ./node_modules/.bin/webdriver-manager start &>/dev/null &
+  echo "$BIN_PATH/webdriver-manager start &>/dev/null &"
+  $BIN_PATH/webdriver-manager start &>/dev/null &
   seleniumStarted=true
   echo "Selenium Server started."
   # Wait for servers to come up.
   sleep 10
-  ./node_modules/.bin/protractor protractor.conf.js
+  $BIN_PATH/protractor protractor.conf.js
 fi

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -48,13 +48,14 @@
 # Travis will run `npm test -- --saucelabs`.
 
 cd "$(dirname $(dirname "$0"))"
-BIN_PATH="./node_modules/protractor/bin"
+BIN_PATH="./node_modules/.bin"
+PROTRACTOR_BIN_PATH="./node_modules/protractor/bin"
 
 function killServer () {
   if [ "$seleniumStarted" = true ]; then
     echo "Stopping Selenium..."
-    $BIN_PATH/webdriver-manager shutdown
-    $BIN_PATH/webdriver-manager clean
+    $PROTRACTOR_BIN_PATH/webdriver-manager shutdown
+    $PROTRACTOR_BIN_PATH/webdriver-manager clean
   fi
   echo "Killing HTTP Server..."
   kill $serverPid
@@ -74,18 +75,18 @@ if [[ $1 = "--saucelabs" ]]; then
   sleep 2
   echo "Using SauceLabs."
   # $2 contains the tunnelIdentifier argument if specified, otherwise is empty.
-  $BIN_PATH/protractor protractor.conf.js --saucelabs $2
+  $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
 else
   echo "Using Headless Chrome."
   # Updates Selenium Webdriver.
-  echo "$BIN_PATH/webdriver-manager update --gecko=false"
-  $BIN_PATH/webdriver-manager update --gecko=false
+  echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --gecko=false"
+  $PROTRACTOR_BIN_PATH/webdriver-manager update --gecko=false
   # Start Selenium Webdriver.
-  echo "$BIN_PATH/webdriver-manager start &>/dev/null &"
-  $BIN_PATH/webdriver-manager start &>/dev/null &
+  echo "$PROTRACTOR_BIN_PATH/webdriver-manager start &>/dev/null &"
+  $PROTRACTOR_BIN_PATH/webdriver-manager start &>/dev/null &
   seleniumStarted=true
   echo "Selenium Server started."
   # Wait for servers to come up.
   sleep 10
-  $BIN_PATH/protractor protractor.conf.js
+  $PROTRACTOR_BIN_PATH/protractor protractor.conf.js
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -292,12 +292,6 @@
       "dev": true,
       "optional": true
     },
-    "@types/jasmine": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.2.tgz",
-      "integrity": "sha512-RabEJPjYMpjWqW1qYj4k0rlgP5uzyguoc0yxedJdq7t5h19MYvqhjCR1evM3raZ/peHRxp1Qfl24iawvkibSug==",
-      "dev": true
-    },
     "@types/long": {
       "version": "3.0.32",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
@@ -319,9 +313,9 @@
       "dev": true
     },
     "@types/selenium-webdriver": {
-      "version": "2.53.37",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.37.tgz",
-      "integrity": "sha1-NPdDwg5TrnEA7ekIcP3lVN8kR/g=",
+      "version": "2.53.43",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz",
+      "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
       "dev": true
     },
     "JSONStream": {
@@ -363,21 +357,12 @@
       "dev": true
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -747,6 +732,15 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
+      }
+    },
+    "blocking-proxy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/blocking-proxy/-/blocking-proxy-1.0.1.tgz",
+      "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0"
       }
     },
     "bn.js": {
@@ -2160,7 +2154,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -2438,6 +2432,15 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
       "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
       "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.1.1"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
@@ -2752,55 +2755,6 @@
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
-        }
-      }
-    },
-    "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.0",
-        "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "yauzl": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-          "dev": true,
-          "requires": {
-            "fd-slicer": "1.0.1"
-          }
         }
       }
     },
@@ -6657,16 +6611,6 @@
         "minimalistic-assert": "1.0.0"
       }
     },
-    "hasha": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true,
-      "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -6770,14 +6714,24 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "i": {
@@ -6797,6 +6751,12 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "import-regex": {
@@ -7048,18 +7008,18 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -7223,54 +7183,26 @@
       }
     },
     "jasmine": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
-      "integrity": "sha1-kBbdpFMhPSesbUPcTqlzFaGJCF4=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "3.2.11",
-        "jasmine-core": "2.4.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
-          }
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        }
+        "glob": "7.1.2",
+        "jasmine-core": "2.8.0"
       }
     },
     "jasmine-core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
-      "integrity": "sha1-b4OrOg8WlRcizgfSBsdz1XzIOL4=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
       "dev": true
     },
     "jasminewd2": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.10.tgz",
-      "integrity": "sha1-lPSK4ryUbK1kMDVGe0u36pwQde8=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-2.2.0.tgz",
+      "integrity": "sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=",
       "dev": true
     },
     "jju": {
@@ -7411,6 +7343,53 @@
         "verror": "1.10.0"
       }
     },
+    "jszip": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+          "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+          "dev": true
+        },
+        "es6-promise": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "jwa": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
@@ -7433,12 +7412,6 @@
         "jwa": "1.1.5",
         "safe-buffer": "5.1.1"
       }
-    },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
@@ -7517,6 +7490,15 @@
       "dev": true,
       "requires": {
         "astw": "2.2.0"
+      }
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "dev": true,
+      "requires": {
+        "immediate": "3.0.6"
       }
     },
     "liftoff": {
@@ -9098,51 +9080,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "phantomjs-prebuilt": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
-      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "4.1.1",
-        "extract-zip": "1.6.6",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.83.0",
-        "request-progress": "2.0.1",
-        "which": "1.3.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
-        }
-      }
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -9317,38 +9254,38 @@
       "optional": true
     },
     "protractor": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.14.tgz",
-      "integrity": "sha1-78Sod/rDoYKp3e0mzVhp9HYv0XI=",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.3.2.tgz",
+      "integrity": "sha512-pw4uwwiy5lHZjIguxNpkEwJJa7hVz+bJsvaTI+IbXlfn2qXwzbF8eghW/RmrZwE2sGx82I8etb8lVjQ+JrjejA==",
       "dev": true,
       "requires": {
-        "@types/jasmine": "2.8.2",
-        "@types/node": "6.0.92",
+        "@types/node": "6.0.113",
         "@types/q": "0.0.32",
-        "@types/selenium-webdriver": "2.53.37",
-        "adm-zip": "0.4.7",
+        "@types/selenium-webdriver": "2.53.43",
+        "blocking-proxy": "1.0.1",
         "chalk": "1.1.3",
         "glob": "7.1.2",
-        "jasmine": "2.4.1",
-        "jasminewd2": "0.0.10",
+        "jasmine": "2.8.0",
+        "jasminewd2": "2.2.0",
         "optimist": "0.6.1",
         "q": "1.4.1",
-        "saucelabs": "1.3.0",
-        "selenium-webdriver": "2.53.3",
+        "saucelabs": "1.5.0",
+        "selenium-webdriver": "3.6.0",
         "source-map-support": "0.4.18",
-        "webdriver-manager": "10.3.0"
+        "webdriver-js-extender": "1.0.0",
+        "webdriver-manager": "12.0.6"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.92",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-          "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+          "version": "6.0.113",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.113.tgz",
+          "integrity": "sha512-f9XXUWFqryzjkZA1EqFvJHSFyqyasV17fq8zCDIzbRV4ctL7RrJGKvG+lcex86Rjbzd1GrER9h9VmF5sSjV0BQ==",
           "dev": true
         },
         "webdriver-manager": {
-          "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.3.0.tgz",
-          "integrity": "sha1-mTFFiKCx2+aIxEHXQojGyxh1+os=",
+          "version": "12.0.6",
+          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.0.6.tgz",
+          "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
           "dev": true,
           "requires": {
             "adm-zip": "0.4.7",
@@ -9360,7 +9297,8 @@
             "q": "1.4.1",
             "request": "2.83.0",
             "rimraf": "2.6.2",
-            "semver": "5.4.1"
+            "semver": "5.4.1",
+            "xml2js": "0.4.19"
           }
         }
       }
@@ -9757,15 +9695,6 @@
         "uuid": "3.1.0"
       }
     },
-    "request-progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true,
-      "requires": {
-        "throttleit": "1.0.0"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10078,18 +10007,18 @@
       }
     },
     "saucelabs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
-      "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.5.0.tgz",
+      "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
+        "https-proxy-agent": "2.2.1"
       }
     },
     "sax": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
-      "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "scss-tokenizer": {
@@ -10123,29 +10052,25 @@
       }
     },
     "selenium-webdriver": {
-      "version": "2.53.3",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
-      "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
+      "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
-        "adm-zip": "0.4.4",
+        "jszip": "3.1.5",
         "rimraf": "2.6.2",
-        "tmp": "0.0.24",
-        "ws": "1.1.5",
-        "xml2js": "0.4.4"
+        "tmp": "0.0.30",
+        "xml2js": "0.4.19"
       },
       "dependencies": {
-        "adm-zip": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-          "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
-          "dev": true
-        },
         "tmp": {
-          "version": "0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
-          "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-          "dev": true
+          "version": "0.0.30",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
+          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
         }
       }
     },
@@ -10990,12 +10915,6 @@
         }
       }
     },
-    "throttleit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -11683,6 +11602,59 @@
         "indexof": "0.0.1"
       }
     },
+    "webdriver-js-extender": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-1.0.0.tgz",
+      "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
+      "dev": true,
+      "requires": {
+        "@types/selenium-webdriver": "2.53.43",
+        "selenium-webdriver": "2.53.3"
+      },
+      "dependencies": {
+        "adm-zip": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+          "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
+          "dev": true
+        },
+        "sax": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+          "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk=",
+          "dev": true
+        },
+        "selenium-webdriver": {
+          "version": "2.53.3",
+          "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
+          "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
+          "dev": true,
+          "requires": {
+            "adm-zip": "0.4.4",
+            "rimraf": "2.6.2",
+            "tmp": "0.0.24",
+            "ws": "1.1.5",
+            "xml2js": "0.4.4"
+          }
+        },
+        "tmp": {
+          "version": "0.0.24",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+          "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
+          "dev": true
+        },
+        "xml2js": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
+          "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
+          "dev": true,
+          "requires": {
+            "sax": "0.6.1",
+            "xmlbuilder": "9.0.7"
+          }
+        }
+      }
+    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -11830,19 +11802,19 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
-      "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": "0.6.1",
-        "xmlbuilder": "9.0.4"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
     "xmlhttprequest": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "gulp-sass": "^2.3.2",
     "gulp-util": "^3.0.7",
     "material-design-lite": "^1.2.0",
-    "phantomjs-prebuilt": "^2.1.13",
-    "protractor": "^4.0.9",
+    "protractor": "^5.3.2",
     "streamqueue": "^1.1.1"
   },
   "dependencies": {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -103,7 +103,7 @@ if (options.saucelabs) {
 } else {
   // Configuration for headless chrome.
   config.directConnect = true;
-  //config.seleniumAddress = 'http://localhost:4444/wd/hub';
+  config.seleniumAddress = 'http://localhost:4444/wd/hub';
   config.multiCapabilities = [{
     browserName: 'chrome',
     chromeOptions: {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -104,7 +104,8 @@ if (options.saucelabs) {
   config.multiCapabilities = [{
     browserName: 'chrome',
     chromeOptions: {
-      args: [ "--headless", "--disable-gpu", "--window-size=800,600" ]
+      args: [ "--headless", "--disable-gpu", "--window-size=800,600",
+              "--no-sandbox", "--disable-dev-shm-usage" ]
     }
   }];
 }

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -95,6 +95,9 @@ if (options.saucelabs) {
   // Configuration for SauceLabs browsers.
   config.multiCapabilities = sauceBrowsers.map(function(browser) {
     browser['tunnel-identifier'] = options.tunnelIdentifier;
+    browser.maxDuration = 2000;
+    browser.commandTimeout = 600;
+    browser.idleTimeout = 120;
     return browser;
   });
 } else {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -89,7 +89,6 @@ if (options.saucelabs) {
   }
   // Avoid going over the SauceLabs concurrency limit (5).
   config.maxSessions = 5;
-  config.maxDuration = 1800;
   // List of browsers configurations tested.
   var sauceBrowsers = require('./sauce_browsers.json');
   // Configuration for SauceLabs browsers.

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -98,13 +98,15 @@ if (options.saucelabs) {
     return browser;
   });
 } else {
-  // Configuration for phantomJS.
+  // Configuration for headless chrome.
+  config.directConnect = true;
   config.seleniumAddress = 'http://localhost:4444/wd/hub';
-  config.capabilities = {
-    'browserName': 'phantomjs',
-    'phantomjs.binary.path': require('phantomjs-prebuilt').path,
-    'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG']
-  };
+  config.multiCapabilities = [{
+    browserName: 'chrome',
+    chromeOptions: {
+      args: [ "--headless", "--disable-gpu", "--window-size=800,600" ]
+    }
+  }];
 }
 
 exports.config = config;

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -48,7 +48,7 @@ config = {
   // Jasmine options. Increase the timeout to 5min instead of the default 30s.
   jasmineNodeOpts: {
     // Default time to wait in ms before a test fails.
-    defaultTimeoutInterval: 5 * 60 * 1000
+    defaultTimeoutInterval: 2 * 5 * 60 * 1000
   }
 };
 
@@ -89,6 +89,7 @@ if (options.saucelabs) {
   }
   // Avoid going over the SauceLabs concurrency limit (5).
   config.maxSessions = 5;
+  config.allScriptsTimeout = 5 * 60 * 1000;
   // List of browsers configurations tested.
   var sauceBrowsers = require('./sauce_browsers.json');
   // Configuration for SauceLabs browsers.

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -89,6 +89,7 @@ if (options.saucelabs) {
   }
   // Avoid going over the SauceLabs concurrency limit (5).
   config.maxSessions = 5;
+  config.maxDuration = 1800;
   // List of browsers configurations tested.
   var sauceBrowsers = require('./sauce_browsers.json');
   // Configuration for SauceLabs browsers.

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -103,7 +103,6 @@ if (options.saucelabs) {
 } else {
   // Configuration for headless chrome.
   config.directConnect = true;
-  config.seleniumAddress = 'http://localhost:4444/wd/hub';
   config.multiCapabilities = [{
     browserName: 'chrome',
     chromeOptions: {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -48,7 +48,7 @@ config = {
   // Jasmine options. Increase the timeout to 5min instead of the default 30s.
   jasmineNodeOpts: {
     // Default time to wait in ms before a test fails.
-    defaultTimeoutInterval: 2 * 5 * 60 * 1000
+    defaultTimeoutInterval: 20 * 60 * 1000
   }
 };
 
@@ -89,7 +89,7 @@ if (options.saucelabs) {
   }
   // Avoid going over the SauceLabs concurrency limit (5).
   config.maxSessions = 5;
-  config.allScriptsTimeout = 5 * 60 * 1000;
+  config.allScriptsTimeout = 10 * 60 * 1000;
   // List of browsers configurations tested.
   var sauceBrowsers = require('./sauce_browsers.json');
   // Configuration for SauceLabs browsers.

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -100,7 +100,7 @@ if (options.saucelabs) {
 } else {
   // Configuration for headless chrome.
   config.directConnect = true;
-  config.seleniumAddress = 'http://localhost:4444/wd/hub';
+  //config.seleniumAddress = 'http://localhost:4444/wd/hub';
   config.multiCapabilities = [{
     browserName: 'chrome',
     chromeOptions: {

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -54,8 +54,8 @@ describe('Run all Closure unit tests', function() {
         setTimeout(waitForTest.bind(undefined, done, fail, tries - 1), 300);
       } else if (status && status.isFinished) {
         done(status);
-      } else if (new Date().getTime() - startTime > 2000) {
-        fail(new Error('ETIMEDOUT'));
+      //} else if (new Date().getTime() - startTime > 2000) {
+      //  fail(new Error('ETIMEDOUT'));
       } else {
         // Try again in a few ms.
         setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);
@@ -108,7 +108,7 @@ describe('Run all Closure unit tests', function() {
       };
       // Run test routine. Set timeout retrial to 2 times, eg. test will try
       // 2 more times before giving up.
-      runRoutine(3, done);
+      runRoutine(2, done);
     });
   };
 

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -54,13 +54,11 @@ describe('Run all Closure unit tests', function() {
         setTimeout(waitForTest.bind(undefined, done, fail, tries - 1), 300);
       } else if (status && status.isFinished) {
         done(status);
+      } else if (new Date().getTime() - startTime > 3000) {
+        fail(new Error('ETIMEDOUT'));
       } else {
-        if (new Date().getTime() - startTime > 5000) {
-          fail(new Error('ETIMEDOUT'));
-        } else {
-          // Try again in a few ms.
-          setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);
-        }
+        // Try again in a few ms.
+        setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);
       }
     }, function(err) {
       // This can happen if the webdriver had an issue executing the script.
@@ -90,8 +88,7 @@ describe('Run all Closure unit tests', function() {
               }, function(err) {
                 // If browser test execution times out try up to trial times.
                 if (err.message &&
-                    (err.message.indexOf('ETIMEDOUT') != -1 ||
-                     err.message.indexOf('WebDriverError') != -1) &&
+                    err.message.indexOf('ETIMEDOUT') != -1 &&
                     tries > 0) {
                   runRoutine(tries - 1, done);
                 } else {
@@ -101,8 +98,7 @@ describe('Run all Closure unit tests', function() {
             }, function(err) {
               // If browser test execution times out try up to trial times.
               if (err.message &&
-                  (err.message.indexOf('ETIMEDOUT') != -1 ||
-                   err.message.indexOf('WebDriverError') != -1) &&
+                  err.message.indexOf('ETIMEDOUT') != -1 &&
                   tries > 0) {
                 runRoutine(tries - 1, done);
               } else {

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -55,7 +55,7 @@ describe('Run all Closure unit tests', function() {
       } else if (status && status.isFinished) {
         done(status);
       } else {
-        if (new Date().getTime() - startTime > 10000) {
+        if (new Date().getTime() - startTime > 5000) {
           fail(new Error('ETIMEDOUT'));
         } else {
           // Try again in a few ms.

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -54,8 +54,8 @@ describe('Run all Closure unit tests', function() {
         setTimeout(waitForTest.bind(undefined, done, fail, tries - 1), 300);
       } else if (status && status.isFinished) {
         done(status);
-      } else if (new Date().getTime() - startTime > 1000) {
-        fail(new Error('ETIMEDOUT'));
+      //} else if (new Date().getTime() - startTime > 1000) {
+      //  fail(new Error('ETIMEDOUT'));
       } else {
         // Try again in a few ms.
         setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -88,7 +88,7 @@ describe('Run all Closure unit tests', function() {
               }, function(err) {
                 // If browser test execution times out try up to trial times.
                 if (err.message &&
-                    err.message.indexOf('ETIMEDOUT') != -1 &&
+                    err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error)/) &&
                     tries > 0) {
                   runRoutine(tries - 1, done);
                 } else {
@@ -98,7 +98,7 @@ describe('Run all Closure unit tests', function() {
             }, function(err) {
               // If browser test execution times out try up to trial times.
               if (err.message &&
-                  err.message.indexOf('ETIMEDOUT') != -1 &&
+                  err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error)/) &&
                   tries > 0) {
                 runRoutine(tries - 1, done);
               } else {

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -54,7 +54,7 @@ describe('Run all Closure unit tests', function() {
         setTimeout(waitForTest.bind(undefined, done, fail, tries - 1), 300);
       } else if (status && status.isFinished) {
         done(status);
-      } else if (new Date().getTime() - startTime > 3000) {
+      } else if (new Date().getTime() - startTime > 2000) {
         fail(new Error('ETIMEDOUT'));
       } else {
         // Try again in a few ms.
@@ -108,7 +108,7 @@ describe('Run all Closure unit tests', function() {
       };
       // Run test routine. Set timeout retrial to 2 times, eg. test will try
       // 2 more times before giving up.
-      runRoutine(5, done);
+      runRoutine(3, done);
     });
   };
 

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -54,8 +54,8 @@ describe('Run all Closure unit tests', function() {
         setTimeout(waitForTest.bind(undefined, done, fail, tries - 1), 300);
       } else if (status && status.isFinished) {
         done(status);
-      //} else if (new Date().getTime() - startTime > 2000) {
-      //  fail(new Error('ETIMEDOUT'));
+      } else if (new Date().getTime() - startTime > 1000) {
+        fail(new Error('ETIMEDOUT'));
       } else {
         // Try again in a few ms.
         setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -88,7 +88,7 @@ describe('Run all Closure unit tests', function() {
               }, function(err) {
                 // If browser test execution times out try up to trial times.
                 if (err.message &&
-                    err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error)/) &&
+                    err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error|504)/) &&
                     tries > 0) {
                   runRoutine(tries - 1, done);
                 } else {
@@ -98,7 +98,7 @@ describe('Run all Closure unit tests', function() {
             }, function(err) {
               // If browser test execution times out try up to trial times.
               if (err.message &&
-                  err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error)/) &&
+                  err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error|504)/) &&
                   tries > 0) {
                 runRoutine(tries - 1, done);
               } else {

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -90,7 +90,8 @@ describe('Run all Closure unit tests', function() {
               }, function(err) {
                 // If browser test execution times out try up to trial times.
                 if (err.message &&
-                    err.message.indexOf('ETIMEDOUT') != -1 &&
+                    (err.message.indexOf('ETIMEDOUT') != -1 ||
+                     err.message.indexOf('Gateway Time-out') != -1) &&
                     tries > 0) {
                   runRoutine(tries - 1, done);
                 } else {
@@ -100,7 +101,8 @@ describe('Run all Closure unit tests', function() {
             }, function(err) {
               // If browser test execution times out try up to trial times.
               if (err.message &&
-                  err.message.indexOf('ETIMEOUT') != -1 &&
+                  (err.message.indexOf('ETIMEOUT') != -1 ||
+                   err.message.indexOf('Gateway Time-out') != -1) &&
                   trial > 0) {
                 runRoutine(tries - 1, done);
               } else {

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -32,6 +32,7 @@ describe('Run all Closure unit tests', function() {
     if (typeof tries === 'undefined') {
       tries = FLAKY_TEST_RETRIAL;
     }
+    var startTime = new Date().getTime();
     // executeScript runs the passed method in the "window" context of
     // the current test. JSUnit exposes hooks into the test's status through
     // the "G_testRunner" global object.
@@ -54,8 +55,12 @@ describe('Run all Closure unit tests', function() {
       } else if (status && status.isFinished) {
         done(status);
       } else {
-        // Try again in a few ms.
-        setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);
+        if (new Date().getTime() - startTime > 10000) {
+          fail(new Error('ETIMEDOUT ETIMEOUT'));
+        } else {
+          // Try again in a few ms.
+          setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);
+        }
       }
     }, function(err) {
       // This can happen if the webdriver had an issue executing the script.
@@ -105,7 +110,7 @@ describe('Run all Closure unit tests', function() {
       };
       // Run test routine. Set timeout retrial to 2 times, eg. test will try
       // 2 more times before giving up.
-      runRoutine(2, done);
+      runRoutine(5, done);
     });
   };
 

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -18,6 +18,8 @@ var TEST_SERVER = 'http://localhost:4000';
 
 var FLAKY_TEST_RETRIAL = 3;
 
+var RETRY_MESSAGE_REGEX = /(ETIMEDOUT|WebDriverError|Internal Server Error|504)/;
+
 describe('Run all Closure unit tests', function() {
   /**
    * Waits for current tests to be executed.
@@ -32,7 +34,6 @@ describe('Run all Closure unit tests', function() {
     if (typeof tries === 'undefined') {
       tries = FLAKY_TEST_RETRIAL;
     }
-    var startTime = new Date().getTime();
     // executeScript runs the passed method in the "window" context of
     // the current test. JSUnit exposes hooks into the test's status through
     // the "G_testRunner" global object.
@@ -54,8 +55,6 @@ describe('Run all Closure unit tests', function() {
         setTimeout(waitForTest.bind(undefined, done, fail, tries - 1), 300);
       } else if (status && status.isFinished) {
         done(status);
-      //} else if (new Date().getTime() - startTime > 1000) {
-      //  fail(new Error('ETIMEDOUT'));
       } else {
         // Try again in a few ms.
         setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);
@@ -88,7 +87,7 @@ describe('Run all Closure unit tests', function() {
               }, function(err) {
                 // If browser test execution times out try up to trial times.
                 if (err.message &&
-                    err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error|504)/) &&
+                    err.message.match(RETRY_MESSAGE_REGEX) &&
                     tries > 0) {
                   runRoutine(tries - 1, done);
                 } else {
@@ -98,7 +97,7 @@ describe('Run all Closure unit tests', function() {
             }, function(err) {
               // If browser test execution times out try up to trial times.
               if (err.message &&
-                  err.message.match(/(ETIMEDOUT|WebDriverError|Internal Server Error|504)/) &&
+                  err.message.match(RETRY_MESSAGE_REGEX) &&
                   tries > 0) {
                 runRoutine(tries - 1, done);
               } else {

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -56,7 +56,7 @@ describe('Run all Closure unit tests', function() {
         done(status);
       } else {
         if (new Date().getTime() - startTime > 10000) {
-          fail(new Error('ETIMEDOUT ETIMEOUT'));
+          fail(new Error('ETIMEDOUT'));
         } else {
           // Try again in a few ms.
           setTimeout(waitForTest.bind(undefined, done, fail, tries), 300);
@@ -91,7 +91,7 @@ describe('Run all Closure unit tests', function() {
                 // If browser test execution times out try up to trial times.
                 if (err.message &&
                     (err.message.indexOf('ETIMEDOUT') != -1 ||
-                     err.message.indexOf('Gateway Time-out') != -1) &&
+                     err.message.indexOf('WebDriverError') != -1) &&
                     tries > 0) {
                   runRoutine(tries - 1, done);
                 } else {
@@ -101,9 +101,9 @@ describe('Run all Closure unit tests', function() {
             }, function(err) {
               // If browser test execution times out try up to trial times.
               if (err.message &&
-                  (err.message.indexOf('ETIMEOUT') != -1 ||
-                   err.message.indexOf('Gateway Time-out') != -1) &&
-                  trial > 0) {
+                  (err.message.indexOf('ETIMEDOUT') != -1 ||
+                   err.message.indexOf('WebDriverError') != -1) &&
+                  tries > 0) {
                 runRoutine(tries - 1, done);
               } else {
                 done.fail(err);

--- a/sauce_browsers.json
+++ b/sauce_browsers.json
@@ -1,22 +1,71 @@
 [
   {
+    "browserName" : "firefox",
+    "platform" : "OS X 10.11",
+    "version": "59.0",
+    "name": "firefox-latest-mac"
+  },
+  {
+    "browserName" : "chrome",
+    "platform" : "OS X 10.11",
+    "timeZone": "Pacific",
+    "version" : "65.0",
+    "name": "chrome-latest-mac"
+  },
+  {
     "browserName" : "internet explorer",
     "version" : "11.0",
     "platform" : "Windows 7",
     "timeZone": "Pacific",
-    "name": "ie-11-windows",
-    "maxDuration": 2000,
-    "commandTimeout": 600,
-    "idleTimeout": 120
+    "name": "ie-11-windows"
+  },
+  {
+    "browserName" : "internet explorer",
+    "version" : "10.0",
+    "timeZone": "Pacific",
+    "platform" : "Windows 7",
+    "name": "ie-10-windows"
   },
   {
     "browserName" : "MicrosoftEdge",
     "platform" : "Windows 10",
     "timeZone": "Pacific",
     "version" : "16.16299",
-    "name": "edge-16-windows",
-    "maxDuration": 2000,
-    "commandTimeout": 600,
-    "idleTimeout": 120
+    "name": "edge-16-windows"
+  },
+  {
+    "browserName" : "safari",
+    "version" : "8.0",
+    "platform" : "OS X 10.10",
+    "timeZone": "Pacific",
+    "name": "safari-8-mac"
+  },
+  {
+    "browserName" : "safari",
+    "version" : "10.0",
+    "platform" : "OS X 10.11",
+    "timeZone": "Pacific",
+    "name": "safari-10-mac"
+  },
+  {
+    "deviceName": "iPhone 6 Simulator",
+    "platformName": "iOS",
+    "platformVersion": "11.2",
+    "browserName": "Safari",
+    "name": "ios-11-sim"
+  },
+  {
+    "deviceName": "iPhone 6 Simulator",
+    "platformName": "iOS",
+    "platformVersion": "9.3",
+    "browserName": "Safari",
+    "name": "ios-93-sim"
+  },
+  {
+    "deviceName": "Android Emulator",
+    "platformName": "Android",
+    "platformVersion": "5.1",
+    "browserName": "Browser",
+    "name": "android-51-sim"
   }
 ]

--- a/sauce_browsers.json
+++ b/sauce_browsers.json
@@ -5,7 +5,9 @@
     "platform" : "Windows 7",
     "timeZone": "Pacific",
     "name": "ie-11-windows",
-    "maxDuration": 2000
+    "maxDuration": 2000,
+    "commandTimeout": 600,
+    "idleTimeout": 60
   },
   {
     "browserName" : "MicrosoftEdge",
@@ -13,6 +15,8 @@
     "timeZone": "Pacific",
     "version" : "16.16299",
     "name": "edge-16-windows",
-    "maxDuration": 2000
+    "maxDuration": 2000,
+    "commandTimeout": 600,
+    "idleTimeout": 60
   }
 ]

--- a/sauce_browsers.json
+++ b/sauce_browsers.json
@@ -5,7 +5,7 @@
     "platform" : "Windows 7",
     "timeZone": "Pacific",
     "name": "ie-11-windows",
-    "maxDuration": 1800
+    "maxDuration": 2000
   },
   {
     "browserName" : "MicrosoftEdge",
@@ -13,6 +13,6 @@
     "timeZone": "Pacific",
     "version" : "16.16299",
     "name": "edge-16-windows",
-    "maxDuration": 1800
+    "maxDuration": 2000
   }
 ]

--- a/sauce_browsers.json
+++ b/sauce_browsers.json
@@ -7,7 +7,7 @@
     "name": "ie-11-windows",
     "maxDuration": 2000,
     "commandTimeout": 600,
-    "idleTimeout": 60
+    "idleTimeout": 120
   },
   {
     "browserName" : "MicrosoftEdge",
@@ -17,6 +17,6 @@
     "name": "edge-16-windows",
     "maxDuration": 2000,
     "commandTimeout": 600,
-    "idleTimeout": 60
+    "idleTimeout": 120
   }
 ]

--- a/sauce_browsers.json
+++ b/sauce_browsers.json
@@ -1,18 +1,5 @@
 [
   {
-    "browserName" : "firefox",
-    "platform" : "OS X 10.11",
-    "version": "59.0",
-    "name": "firefox-latest-mac"
-  },
-  {
-    "browserName" : "chrome",
-    "platform" : "OS X 10.11",
-    "timeZone": "Pacific",
-    "version" : "65.0",
-    "name": "chrome-latest-mac"
-  },
-  {
     "browserName" : "internet explorer",
     "version" : "11.0",
     "platform" : "Windows 7",
@@ -32,40 +19,5 @@
     "timeZone": "Pacific",
     "version" : "16.16299",
     "name": "edge-16-windows"
-  },
-  {
-    "browserName" : "safari",
-    "version" : "8.0",
-    "platform" : "OS X 10.10",
-    "timeZone": "Pacific",
-    "name": "safari-8-mac"
-  },
-  {
-    "browserName" : "safari",
-    "version" : "10.0",
-    "platform" : "OS X 10.11",
-    "timeZone": "Pacific",
-    "name": "safari-10-mac"
-  },
-  {
-    "deviceName": "iPhone 6 Simulator",
-    "platformName": "iOS",
-    "platformVersion": "11.2",
-    "browserName": "Safari",
-    "name": "ios-11-sim"
-  },
-  {
-    "deviceName": "iPhone 6 Simulator",
-    "platformName": "iOS",
-    "platformVersion": "9.3",
-    "browserName": "Safari",
-    "name": "ios-93-sim"
-  },
-  {
-    "deviceName": "Android Emulator",
-    "platformName": "Android",
-    "platformVersion": "5.1",
-    "browserName": "Browser",
-    "name": "android-51-sim"
   }
 ]

--- a/sauce_browsers.json
+++ b/sauce_browsers.json
@@ -4,13 +4,15 @@
     "version" : "11.0",
     "platform" : "Windows 7",
     "timeZone": "Pacific",
-    "name": "ie-11-windows"
+    "name": "ie-11-windows",
+    "maxDuration": 1800
   },
   {
     "browserName" : "MicrosoftEdge",
     "platform" : "Windows 10",
     "timeZone": "Pacific",
     "version" : "16.16299",
-    "name": "edge-16-windows"
+    "name": "edge-16-windows",
+    "maxDuration": 1800
   }
 ]

--- a/sauce_browsers.json
+++ b/sauce_browsers.json
@@ -7,13 +7,6 @@
     "name": "ie-11-windows"
   },
   {
-    "browserName" : "internet explorer",
-    "version" : "10.0",
-    "timeZone": "Pacific",
-    "platform" : "Windows 7",
-    "name": "ie-10-windows"
-  },
-  {
     "browserName" : "MicrosoftEdge",
     "platform" : "Windows 10",
     "timeZone": "Pacific",


### PR DESCRIPTION
Upgrades tests to Node 8.
Upgrades protractor to the latest version.
Switches from phantomjs to headless chrome.
Adds various new timeouts to decrease likelihood of failure.
Adds new criteria for test retry, though this needs more confirmation.