### PR TITLE
disable saucelab test if travis enviorment vars are not available

### DIFF
--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -71,11 +71,14 @@ trap killServer EXIT
 # If --saucelabs option is passed, forward it to the protractor command adding
 # the second argument that is required for local SauceLabs test run.
 if [[ $1 = "--saucelabs" ]]; then
-  seleniumStarted=false
-  sleep 2
-  echo "Using SauceLabs."
-  # $2 contains the tunnelIdentifier argument if specified, otherwise is empty.
-  $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
+  # Enable saucelabs tests only when running locally or when Travis enviroment vars are accessible. 
+  if [[ ( "$TRAVIS" = true  &&  "$TRAVIS_SECURE_ENV_VARS" = true ) || ( -z "$TRAVIS" ) ]]; then
+    seleniumStarted=false
+    sleep 2
+    echo "Using SauceLabs."
+    # $2 contains the tunnelIdentifier argument if specified, otherwise is empty.
+    $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
+  fi
 else
   echo "Using Headless Chrome."
   # Updates Selenium Webdriver.


### PR DESCRIPTION
External developers can only create PR from their own fork, in which they don't have access travis environment variables. It cause saucelabs test to fail. Disabled the test if saucelabs tests are running from travis and those variables are not available.  