### PR TITLE
update e2e browser test configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - '8'
 install: npm install
-script: npm test -- --saucelabs
+script: SAUCE_ENABLED=true npm test
 before_install:
   - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -1106,7 +1106,7 @@ Take note of the "Tunnel Identifier" value logged in the terminal,at the top. In
 the other terminal that has the exported variables, run the tests:
 
 ```bash
-npm test -- --saucelabs --tunnelIdentifier=<the tunnel identifier>
+SAUCE_ENABLED=true TUNNEL_IDENTIFIER=<the tunnel identifier> npm test
 ```
 
 ## Cordova Setup

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -48,21 +48,19 @@
 # Travis will run `npm test -- --saucelabs`.
 
 cd "$(dirname $(dirname "$0"))"
-BIN_PATH="./node_modules/.bin"
-PROTRACTOR_BIN_PATH="./node_modules/protractor/bin"
 
 function killServer () {
   if [ "$seleniumStarted" = true ]; then
     echo "Stopping Selenium..."
-    $PROTRACTOR_BIN_PATH/webdriver-manager shutdown
-    $PROTRACTOR_BIN_PATH/webdriver-manager clean
+    npx webdriver-manager shutdown
+    npx webdriver-manager clean
   fi
   echo "Killing HTTP Server..."
   kill $serverPid
 }
 
 # Start the local webserver.
-$BIN_PATH/gulp serve &
+npx gulp serve &
 serverPid=$!
 echo "Local HTTP Server started with PID $serverPid."
 
@@ -70,26 +68,25 @@ trap killServer EXIT
 
 # If --saucelabs option is passed, forward it to the protractor command adding
 # the second argument that is required for local SauceLabs test run.
-if [[ $1 = "--saucelabs" ]]; then
-  # Enable saucelabs tests only when running locally or when Travis enviroment vars are accessible. 
+if [[ "$SAUCE_ENABLED" = true ]]; then
+  # Enable saucelabs tests only when running locally or when Travis environment vars are accessible.
   if [[ ( "$TRAVIS" = true  &&  "$TRAVIS_SECURE_ENV_VARS" = true ) || ( -z "$TRAVIS" ) ]]; then
     seleniumStarted=false
     sleep 2
     echo "Using SauceLabs."
-    # $2 contains the tunnelIdentifier argument if specified, otherwise is empty.
-    $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
+    npx protractor protractor.conf.js
   fi
 else
   echo "Using Headless Chrome."
   # Updates Selenium Webdriver.
-  echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --gecko=false"
-  $PROTRACTOR_BIN_PATH/webdriver-manager update --gecko=false
+  echo "npx webdriver-manager update --gecko=false"
+  npx webdriver-manager update --gecko=false
   # Start Selenium Webdriver.
-  echo "$PROTRACTOR_BIN_PATH/webdriver-manager start &>/dev/null &"
-  $PROTRACTOR_BIN_PATH/webdriver-manager start &>/dev/null &
+  echo "npx webdriver-manager start &>/dev/null &"
+  npx webdriver-manager start &>/dev/null &
   seleniumStarted=true
   echo "Selenium Server started."
   # Wait for servers to come up.
   sleep 10
-  $PROTRACTOR_BIN_PATH/protractor protractor.conf.js
+  npx protractor protractor.conf.js
 fi

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -18,12 +18,12 @@
 #
 # Usage:
 #
-# ./buildtools/run_tests.sh [--saucelabs [--tunnelIdentifier=<tunnelId>]]
+# [SAUCE_ENABLED=true [TUNNEL_IDENTIFIER=<tunnelId> ]]./buildtools/run_tests.sh
 #
-# Can take up to two arguments:
-# --saucelabs: Use SauceLabs instead of phantomJS.
-# --tunnelIdentifier=<tunnelId>: when using SauceLabs, specify the tunnel
-#     identifier. Otherwise, uses the environment variable TRAVIS_JOB_NUMBER.
+# Environment variables:
+# SAUCE_ENABLED=true: Use SauceLabs instead of phantomJS.
+# TUNNEL_IDENTIFIER=<tunnelId>: when using SauceLabs, specify the tunnel
+#     identifier. Otherwise, fallbacks to TRAVIS_JOB_NUMBER.
 #
 # Prefer to use the `npm test` command as explained below.
 #
@@ -41,11 +41,11 @@
 # $ ./buildtools/sauce_connect.sh
 # Take note of the "Tunnel Identifier" value logged in the terminal.
 # Run the tests:
-# $ npm run -- --saucelabs --tunnelIdentifier=<the tunnel identifier>
+# $ SAUCE_ENABLED=true TUNNEL_IDENTIFIER=<the tunnel identifier> npm run test
 # This will start the HTTP Server locally, and connect through SauceConnect
 # to SauceLabs remote browsers instances.
 #
-# Travis will run `npm test -- --saucelabs`.
+# Travis will run `SAUCE_ENABLED=true npm test`.
 
 cd "$(dirname $(dirname "$0"))"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,6 +265,12 @@
       "dev": true,
       "optional": true
     },
+    "@types/node": {
+      "version": "6.0.115",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.115.tgz",
+      "integrity": "sha512-PWA07jqflLli+PAk7VaJn0MVdTw96egk5B1FxwocV/tcc3RamNGbza1ZgS0OGUsTuAYCFCboL+IlG2bPazV2Nw==",
+      "dev": true
+    },
     "@types/q": {
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
@@ -272,9 +278,9 @@
       "dev": true
     },
     "@types/selenium-webdriver": {
-      "version": "2.53.43",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz",
-      "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.10.tgz",
+      "integrity": "sha512-ikB0JHv6vCR1KYUQAzTO4gi/lXLElT4Tx+6De2pc/OZwizE9LRNiTa+U8TBFKBD/nntPnr/MPSHSnOTybjhqNA==",
       "dev": true
     },
     "JSONStream": {
@@ -330,12 +336,13 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
       "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -1161,6 +1168,15 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      }
+    },
+    "browserstack": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.1.tgz",
+      "integrity": "sha512-O8VMT64P9NOLhuIoD4YngyxBURefaSdR4QdhG8l6HZ9VxtU7jc3m6jLufFwKA5gaf7fetfB2TnRJnMxyob+heg==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^2.2.1"
       }
     },
     "buffer": {
@@ -2859,9 +2875,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
     },
     "es6-promisify": {
@@ -4743,14 +4759,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4770,8 +4784,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4919,7 +4932,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6795,17 +6807,6 @@
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "i": {
@@ -8998,12 +8999,6 @@
         }
       }
     },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
-      "dev": true
-    },
     "optjs": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
@@ -9587,15 +9582,16 @@
       "optional": true
     },
     "protractor": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.3.2.tgz",
-      "integrity": "sha512-pw4uwwiy5lHZjIguxNpkEwJJa7hVz+bJsvaTI+IbXlfn2qXwzbF8eghW/RmrZwE2sGx82I8etb8lVjQ+JrjejA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.4.0.tgz",
+      "integrity": "sha512-6TSYqMhUUzxr4/wN0ttSISqPMKvcVRXF4k8jOEpGWD8OioLak4KLgfzHK9FJ49IrjzRrZ+Mx1q2Op8Rk0zEcnQ==",
       "dev": true,
       "requires": {
         "@types/node": "^6.0.46",
         "@types/q": "^0.0.32",
-        "@types/selenium-webdriver": "~2.53.39",
+        "@types/selenium-webdriver": "^3.0.0",
         "blocking-proxy": "^1.0.0",
+        "browserstack": "^1.5.1",
         "chalk": "^1.1.3",
         "glob": "^7.0.3",
         "jasmine": "2.8.0",
@@ -9605,30 +9601,58 @@
         "saucelabs": "^1.5.0",
         "selenium-webdriver": "3.6.0",
         "source-map-support": "~0.4.0",
-        "webdriver-js-extender": "^1.0.0",
+        "webdriver-js-extender": "2.0.0",
         "webdriver-manager": "^12.0.6"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.113",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.113.tgz",
-          "integrity": "sha512-f9XXUWFqryzjkZA1EqFvJHSFyqyasV17fq8zCDIzbRV4ctL7RrJGKvG+lcex86Rjbzd1GrER9h9VmF5sSjV0BQ==",
+        "adm-zip": {
+          "version": "0.4.11",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+          "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
           "dev": true
         },
-        "webdriver-manager": {
-          "version": "12.0.6",
-          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.0.6.tgz",
-          "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "dev": true,
           "requires": {
-            "adm-zip": "^0.4.7",
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "webdriver-manager": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.0.tgz",
+          "integrity": "sha512-oEc5fmkpz6Yh6udhwir5m0eN5mgRPq9P/NU5YWuT3Up5slt6Zz+znhLU7q4+8rwCZz/Qq3Fgpr/4oao7NPCm2A==",
+          "dev": true,
+          "requires": {
+            "adm-zip": "^0.4.9",
             "chalk": "^1.1.1",
             "del": "^2.2.0",
             "glob": "^7.0.3",
             "ini": "^1.3.4",
             "minimist": "^1.2.0",
             "q": "^1.4.1",
-            "request": "^2.78.0",
+            "request": "^2.87.0",
             "rimraf": "^2.5.2",
             "semver": "^5.3.0",
             "xml2js": "^0.4.17"
@@ -11737,12 +11761,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
-      "dev": true
-    },
     "umd": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
@@ -12381,56 +12399,13 @@
       }
     },
     "webdriver-js-extender": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-1.0.0.tgz",
-      "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-2.0.0.tgz",
+      "integrity": "sha512-fbyKiVu3azzIc5d4+26YfuPQcFTlgFQV5yQ/0OQj4Ybkl4g1YQuIPskf5v5wqwRJhHJnPHthB6tqCjWHOKLWag==",
       "dev": true,
       "requires": {
-        "@types/selenium-webdriver": "^2.53.35",
-        "selenium-webdriver": "^2.53.2"
-      },
-      "dependencies": {
-        "adm-zip": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-          "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
-          "dev": true
-        },
-        "sax": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
-          "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk=",
-          "dev": true
-        },
-        "selenium-webdriver": {
-          "version": "2.53.3",
-          "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
-          "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
-          "dev": true,
-          "requires": {
-            "adm-zip": "0.4.4",
-            "rimraf": "^2.2.8",
-            "tmp": "0.0.24",
-            "ws": "^1.0.1",
-            "xml2js": "0.4.4"
-          }
-        },
-        "tmp": {
-          "version": "0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
-          "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-          "dev": true
-        },
-        "xml2js": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
-          "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
-          "dev": true,
-          "requires": {
-            "sax": "0.6.x",
-            "xmlbuilder": ">=1.0.0"
-          }
-        }
+        "@types/selenium-webdriver": "^3.0.0",
+        "selenium-webdriver": "^3.0.1"
       }
     },
     "websocket-driver": {
@@ -12561,16 +12536,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-      "dev": true,
-      "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gulp-sass": "^2.3.2",
     "gulp-util": "^3.0.7",
     "material-design-lite": "^1.2.0",
-    "protractor": "^5.3.2",
+    "protractor": "^5.4.0",
     "streamqueue": "^1.1.1"
   },
   "dependencies": {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -52,27 +52,21 @@ config = {
   }
 };
 
-// Read arguments to the protractor command.
-// The first 3 arguments are something similar to:
-// [ '.../bin/node',
-//  '.../node_modules/.bin/protractor',
-//  'protractor.conf.js' ]
-var arguments = process.argv.slice(3);
-
-// Default options: run tests locally (saucelabs false) and use the env variable
+// Default options: run tests locally (SAUCE_ENABLED=false) and use the env variable
 // TRAVIS_JOB_NUMBER to get the tunnel identifier, when using saucelabs.
 var options = {
   saucelabs: false,
   tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
 };
 
-for (var i = 0; i < arguments.length; i++) {
-  var arg = arguments[i];
-  if (arg == '--saucelabs') {
-    options.saucelabs = true;
-  } else if (arg.indexOf('--tunnelIdentifier') == 0) {
-    options.tunnelIdentifier = arg.split('=')[1];
-  }
+function isEmpty(object) {
+  return (!object || 0 === object.length);
+}
+
+if (/^t(?:rue)?$/i.test(process.env.SAUCE_ENABLED)) {
+  options.saucelabs = true;
+} else if (!isEmpty(process.env.TUNNEL_IDENTIFIER)) {
+  options.tunnelIdentifier = process.env.TUNNEL_IDENTIFIER;
 }
 
 if (options.saucelabs) {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -32,11 +32,11 @@
  * $ ./buildtools/sauce_connect.sh
  * Take note of the "Tunnel Identifier" value logged in the terminal.
  * Run the tests:
- * $ npm test -- --saucelabs --tunnelIdentifier=<the tunnel identifier>
+ * $ SAUCE_ENABLED=true TUNNEL_IDENTIFIER=<the tunnel identifier> npm test
  * This will start the HTTP Server locally, and connect through SauceConnect
  * to SauceLabs remote browsers instances.
  *
- * Travis will run `npm test -- --saucelabs`.
+ * Travis will run `SAUCE_ENABLED=true npm test`.
  */
 
 // Common configuration.


### PR DESCRIPTION
I'm digging into the failing e2e test on Saucelabs. Guess I am the one who causes it.  
Everything seems to work as expected except Microsoft Edge.  
  
I am guessing it is related to the webdriver.
I also see  
```
(node:8716) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```
which is the same dependency path as the webdriver.  
So I update the webdriver.  
At least the change addressed the deprecation warning.  
  
Nearby I see another deprecation warning
```
Ignoring unknown extra flags: saucelabs. This will be an error in future versions, please use --disableChecks flag to disable the  Protractor CLI flag checks.
```
This can be solved by either add `--disableChecks` to protractor execution command or use another way for variables passing to the `protractor.conf.js`.  
I choose the latter so the protractor can still keep checking for the unknown arguments.  
  
In the end, do I really solve the Saucelabs issue?  
Maybe, but I guess not. I'll leave it to the maintainers or someone reading this.  
  
I just made this Pull Request to record my journey.  
I don't even have a way to test this pull request properly I just test it to some extent.