### PR TITLE
prevent double testing

### DIFF
--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -70,15 +70,15 @@ trap killServer EXIT
 
 # If --saucelabs option is passed, forward it to the protractor command adding
 # the second argument that is required for local SauceLabs test run.
-if [[ $1 = "--saucelabs" ]]; then
-  # Enable saucelabs tests only when running locally or when Travis enviroment vars are accessible. 
-  if [[ ( "$TRAVIS" = true  &&  "$TRAVIS_SECURE_ENV_VARS" = true ) || ( -z "$TRAVIS" ) ]]; then
-    seleniumStarted=false
-    sleep 2
-    echo "Using SauceLabs."
-    # $2 contains the tunnelIdentifier argument if specified, otherwise is empty.
-    $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
-  fi
+# Enable saucelabs tests only when running locally or when Travis enviroment vars are accessible.
+if [[ $1 = "--saucelabs" ]] && \
+   [[ ( "$TRAVIS" = true  &&  "$TRAVIS_SECURE_ENV_VARS" = true ) || ( -z "$TRAVIS" ) ]]
+then
+  seleniumStarted=false
+  sleep 2
+  echo "Using SauceLabs."
+  # $2 contains the tunnelIdentifier argument if specified, otherwise is empty.
+  $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
 else
   echo "Using Headless Chrome."
   # Updates Selenium Webdriver.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "npm run build && npm run generate-test-files && ./buildtools/run_tests.sh",
     "serve": "npm run build && npm run generate-test-files && gulp serve",
     "generate-test-files": "./buildtools/generate_test_files.sh",
-    "prepublish": "npm run test && cp -r dist demo/public"
+    "prepublishOnly": "npm run test && cp -r dist demo/public"
   },
   "test": "npm run test",
   "author": "Google",


### PR DESCRIPTION
look closely  
https://api.travis-ci.org/v3/job/410969924/log.txt  
The CI run the test twice this whole time.  
  
This is because `prepublish` also run after `npm install` for preparing stuffs before consumption.  
  
We should not test the library at the `prepublish` hook considering its lifecycle.  
For now it's `prepublishOnly`.