### PR TITLE
Release3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ Localized versions of the widget are available through the CDN. To use a localiz
 localized JS library instead of the default library:
 
 ```html
-<script src="https://www.gstatic.com/firebasejs/ui/3.4.0/firebase-ui-auth__{LANGUAGE_CODE}.js"></script>
-<link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/3.4.0/firebase-ui-auth.css" />
+<script src="https://www.gstatic.com/firebasejs/ui/3.4.1/firebase-ui-auth__{LANGUAGE_CODE}.js"></script>
+<link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/3.4.1/firebase-ui-auth.css" />
 ```
 
 where `{LANGUAGE_CODE}` is replaced by the code of the language you want. For example, the French
 version of the library is available at
-`https://www.gstatic.com/firebasejs/ui/3.4.0/firebase-ui-auth__fr.js`. The list of available
+`https://www.gstatic.com/firebasejs/ui/3.4.1/firebase-ui-auth__fr.js`. The list of available
 languages and their respective language codes can be found at [LANGUAGES.md](LANGUAGES.md).
 
 Right-to-left languages also require the right-to-left version of the stylesheet, available at
-`https://www.gstatic.com/firebasejs/ui/3.4.0/firebase-ui-auth-rtl.css`, instead of the default
+`https://www.gstatic.com/firebasejs/ui/3.4.1/firebase-ui-auth-rtl.css`, instead of the default
 stylesheet. The supported right-to-left languages are Arabic (ar), Farsi (fa), and Hebrew (iw).
 
 ### Option 2: npm Module

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,2 @@
+fixed - Hides cancel button in phone sign-in page if only phone provider is configured.
+fixed - Reverts FirebaseUI languageCode modification on external Auth instance before sign in completion to not trigger race conditions when signInSuccessWithAuthResult callback modifies the Auth languageCode.

--- a/javascript/ui/page/phonesigninstart.js
+++ b/javascript/ui/page/phonesigninstart.js
@@ -32,9 +32,9 @@ goog.require('goog.dom.selection');
  * UI component for the user to enter their phone number.
  * @param {function(?)} onSubmitClick Callback to invoke when enter key (or its
  *     equivalent) is detected on submission.
- * @param {function(?)} onCancelClick Callback to invoke when cancel button
- *     is clicked.
  * @param {boolean} enableVisibleRecaptcha Whether to enable visible reCAPTCHA.
+ * @param {?function(?)=} opt_onCancelClick Callback to invoke when cancel
+ *     button is clicked.
  * @param {?function()=} opt_tosCallback Callback to invoke when the ToS link
  *     is clicked.
  * @param {?function()=} opt_privacyPolicyCallback Callback to invoke when the
@@ -52,8 +52,8 @@ goog.require('goog.dom.selection');
  */
 firebaseui.auth.ui.page.PhoneSignInStart = function(
     onSubmitClick,
-    onCancelClick,
     enableVisibleRecaptcha,
+    opt_onCancelClick,
     opt_tosCallback,
     opt_privacyPolicyCallback,
     opt_displayFullTosPpMessage,
@@ -69,6 +69,7 @@ firebaseui.auth.ui.page.PhoneSignInStart = function(
       {
         enableVisibleRecaptcha: enableVisibleRecaptcha,
         nationalNumber: nationalNumber,
+        displayCancelButton: !!opt_onCancelClick,
         displayFullTosPpMessage: !!opt_displayFullTosPpMessage
       },
       opt_domHelper,
@@ -84,7 +85,7 @@ firebaseui.auth.ui.page.PhoneSignInStart = function(
   /** @private {?function(?)} On submit click callback. */
   this.onSubmitClick_ = onSubmitClick;
   /** @private {?function(?)} On cancel click callback. */
-  this.onCancelClick_ = onCancelClick;
+  this.onCancelClick_ = opt_onCancelClick || null;
   /**
    * @private {?firebaseui.auth.data.country.LookupTree} The country
    *     lookup prefix tree to search country code with.
@@ -101,7 +102,7 @@ firebaseui.auth.ui.page.PhoneSignInStart.prototype.enterDocument = function() {
   // Handle a click on the submit button or cancel button.
   this.initFormElement(
       /** @type {function(?)} */ (this.onSubmitClick_),
-      /** @type {function(?)} */ (this.onCancelClick_));
+      this.onCancelClick_ || undefined);
   this.setupFocus_();
   firebaseui.auth.ui.page.PhoneSignInStart.base(this, 'enterDocument');
 };

--- a/javascript/ui/page/phonesigninstart_test.js
+++ b/javascript/ui/page/phonesigninstart_test.js
@@ -79,10 +79,10 @@ function createComponent(enableVisibleRecaptcha, opt_tosCallback,
       goog.bind(
           firebaseui.auth.ui.element.FormTestHelper.prototype.onSubmit,
           formTestHelper),
+      enableVisibleRecaptcha,
       goog.bind(
           firebaseui.auth.ui.element.FormTestHelper.prototype.onLinkClick,
           formTestHelper),
-      enableVisibleRecaptcha,
       opt_tosCallback,
       opt_privacyPolicyCallback,
       opt_displayFullTosPpMessage,
@@ -232,6 +232,26 @@ function testPhoneSignInStart_defaultCountryNotAvailable() {
 }
 
 
+function testPhoneSignInStart_noOnCancelClick() {
+  component.dispose();
+  // Initialize component with no onCancelClick callback.
+  component = new firebaseui.auth.ui.page.PhoneSignInStart(
+      goog.bind(
+          firebaseui.auth.ui.element.FormTestHelper.prototype.onSubmit,
+          formTestHelper),
+      true,
+      null);
+  component.render(root);
+  formTestHelper.setComponent(component);
+  // Reset previous state of form helper.
+  formTestHelper.resetState();
+  // Cancel button should be hidden.
+  assertNull(component.getSecondaryLinkElement());
+  // Submit button should be available.
+  assertNotNull(component.getSubmitElement());
+}
+
+
 function testPhoneSignInStart_footer() {
   component.dispose();
   component = createComponent(false, tosCallback, privacyPolicyCallback);
@@ -305,10 +325,10 @@ function testPhoneSignInStart_pageEvents() {
       goog.bind(
           firebaseui.auth.ui.element.FormTestHelper.prototype.onSubmit,
           formTestHelper),
+      true,
       goog.bind(
           firebaseui.auth.ui.element.FormTestHelper.prototype.onLinkClick,
-          formTestHelper),
-      true);
+          formTestHelper));
   // Run all page helper tests.
   pageTestHelper.runTests(component, root);
 }

--- a/javascript/widgets/authui_test.js
+++ b/javascript/widgets/authui_test.js
@@ -705,6 +705,32 @@ function testStart_overrideLanguageCode() {
   assertEquals('de', testAuth.languageCode);
 }
 
+function testStart_revertLanguageCode() {
+  // Test with explicit call to revertLanguageCode.
+  // Set the language code of widget to zh-CN.
+  testStubs.replace(goog, 'LOCALE', 'zh-CN');
+  createAndInstallTestInstances();
+  testAuth.install();
+  app = new firebaseui.auth.AuthUI(testAuth, 'id0');
+  app.getAuth().assertSetPersistence(['session'], null);
+  // Set the language code of auth to de.
+  testAuth.languageCode = 'de';
+  app.start(container1, config1);
+  app.getExternalAuth().runAuthChangeHandler();
+  // External Auth should use UI languageCode.
+  assertEquals('zh-CN', app.getExternalAuth().languageCode);
+  assertEquals('zh-CN', testAuth.languageCode);
+  // Revert languageCode changes.
+  app.revertLanguageCode();
+  assertEquals('de', testAuth.languageCode);
+  // Change languageCode to French.
+  testAuth.languageCode = 'fr';
+  app.getAuth().assertSignOut([]);
+  app.reset();
+  // Reset should not modify the language after revertLanguageCode.
+  assertEquals('fr', app.getExternalAuth().languageCode);
+}
+
 
 function testStart_elementNotFound() {
   // Test widget start method with missing element.

--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -420,6 +420,9 @@ firebaseui.auth.widget.handler.common.selectFromAccountChooser = function(
  */
 firebaseui.auth.widget.handler.common.setLoggedIn =
     function(app, component, credential, opt_user, opt_alreadySignedIn) {
+  // Revert language code at this point to ensure languageCode changes are
+  // reverted before callbacks are triggered.
+  app.revertLanguageCode();
   if (!!opt_alreadySignedIn) {
     // Already signed in on external auth instance.
     firebaseui.auth.widget.handler.common.setUserLoggedInExternal_(
@@ -540,6 +543,9 @@ firebaseui.auth.widget.handler.common.setLoggedIn =
  */
 firebaseui.auth.widget.handler.common.setLoggedInWithAuthResult =
     function(app, component, authResult, opt_alreadySignedIn) {
+  // Revert language code at this point to ensure languageCode changes are
+  // reverted before callbacks are triggered.
+  app.revertLanguageCode();
   if (!!opt_alreadySignedIn) {
     firebaseui.auth.widget.handler.common
         .setUserLoggedInExternalWithAuthResult_(

--- a/javascript/widgets/handler/common_test.js
+++ b/javascript/widgets/handler/common_test.js
@@ -281,7 +281,10 @@ function testSetLoggedIn() {
   var cred = firebase.auth.EmailAuthProvider.credential(
       passwordUser['email'], 'password');
   testAuth.setUser(passwordUser);
+  // Confirm revertLanguageCode called on setLoggedIn.
+  assertNoRevertLanguageCode();
   firebaseui.auth.widget.handler.common.setLoggedIn(app, testComponent, cred);
+  assertRevertLanguageCode(app);
   // Sign out from internal instance and then sign in with passed credential to
   // external instance.
   return testAuth.process().then(function() {
@@ -1202,8 +1205,11 @@ function testSetLoggedInWithAuthResult() {
     'operationType': 'signIn',
     'additionalUserInfo':  {'providerId': 'password', 'isNewUser': true}
   };
+  // Confirm revertLanguageCode called on setLoggedInWithAuthResult.
+  assertNoRevertLanguageCode();
   firebaseui.auth.widget.handler.common.setLoggedInWithAuthResult(
       app, testComponent, internalAuthResult);
+  assertRevertLanguageCode(app);
   // Sign out from internal instance and then sign in with passed credential to
   // external instance.
   return testAuth.process().then(function() {

--- a/javascript/widgets/handler/phonesigninstart.js
+++ b/javascript/widgets/handler/phonesigninstart.js
@@ -94,15 +94,15 @@ firebaseui.auth.widget.handler.handlePhoneSignInStart = function(
             // Whether the submission was triggered by a key code.
             !!(e && e.keyCode));
       },
+      firebaseui.auth.widget.handler.enableVisibleRecaptcha_,
       // On cancel.
-      function(e) {
+      isPhoneProviderOnly ? null : function(e) {
         // Go back to start sign in handler.
         recaptchaVerifier.clear();
         component.dispose();
         firebaseui.auth.widget.handler.common.handleSignInStart(
             app, container);
       },
-      firebaseui.auth.widget.handler.enableVisibleRecaptcha_,
       app.getConfig().getTosUrl(),
       app.getConfig().getPrivacyPolicyUrl(),
       isPhoneProviderOnly,

--- a/javascript/widgets/handler/phonesigninstart_test.js
+++ b/javascript/widgets/handler/phonesigninstart_test.js
@@ -307,6 +307,8 @@ function testHandlePhoneSignInStart_anonymousUpgrade_credInUseError() {
   // Only phone provider is configured, phoneSignInStart is the first page, full
   // message should be displayed.
   assertPhoneFullMessage(tosCallback, 'http://localhost/privacy_policy');
+  // Only phone provider is configured, cancel button should be hidden.
+  assertNull(getCancelButton());
   // Confirm reCAPTCHA initialized with expected parameters.
   recaptchaVerifierInstance.assertInitializedWithParameters(
       getRecaptchaElement(),
@@ -399,6 +401,8 @@ function testHandlePhoneSignInStart_anonymousUpgrade_signInError() {
   // Confirm expected page rendered.
   assertPhoneSignInStartPage();
   assertPhoneFullMessage(null, null);
+  // Only phone provider is configured, cancel button should be hidden.
+  assertNull(getCancelButton());
   // Confirm reCAPTCHA initialized with expected parameters.
   recaptchaVerifierInstance.assertInitializedWithParameters(
       getRecaptchaElement(),

--- a/javascript/widgets/handler/signin.js
+++ b/javascript/widgets/handler/signin.js
@@ -61,7 +61,7 @@ firebaseui.auth.widget.handler.handleSignIn = function(
             app, container, opt_email);
       },
       opt_email,
-       app.getConfig().getTosUrl(),
+      app.getConfig().getTosUrl(),
       app.getConfig().getPrivacyPolicyUrl(),
       isPasswordProviderOnly);
   component.render(container);

--- a/javascript/widgets/handler/testhelper.js
+++ b/javascript/widgets/handler/testhelper.js
@@ -155,6 +155,8 @@ var firebase = {};
 var getApp;
 var testComponent;
 
+var lastRevertLanguageCodeCall;
+
 
 function setUp() {
   // Used to initialize internal auth instance.
@@ -322,6 +324,14 @@ function setUp() {
       firebaseui.auth.AuthUI.prototype,
       'cancelOneTapSignIn',
       goog.testing.recordFunction());
+  // Record calls to revertLanguageCode.
+  lastRevertLanguageCodeCall = null;
+  testStubs.replace(
+      firebaseui.auth.AuthUI.prototype,
+      'revertLanguageCode',
+      function() {
+        lastRevertLanguageCodeCall = this;
+      });
 }
 
 
@@ -1200,4 +1210,25 @@ function assertSignInFailure(expectedError) {
       expectedError, signInFailureCallback.getLastCall().getArgument(0));
   // Sign in success should not be called.
   assertUndefined(signInCallbackUser);
+}
+
+
+
+/**
+ * Asserts the last revertLanguageCode call was called on the specified
+ * AuthUI instance. After assertion, the internal state counter is reset.
+ * @param {!firebaseui.auth.AuthUI} app The AuthUI instance to check for
+ *     revertLanguageCode calls.
+ */
+function assertRevertLanguageCode(app) {
+  assertEquals(app, lastRevertLanguageCodeCall);
+  lastRevertLanguageCodeCall = null;
+}
+
+
+/**
+ * Asserts no revertLanguageCode call was called.
+ */
+function assertNoRevertLanguageCode() {
+  assertNull(lastRevertLanguageCodeCall);
 }

--- a/soy/pages.soy
+++ b/soy/pages.soy
@@ -666,6 +666,7 @@
 {template .phoneSignInStart}
   {@param? nationalNumber: string} /** The phone number to prefill. */
   {@param? enableVisibleRecaptcha: bool} /** Whether to enable the visible reCAPTCHA. */
+  {@param? displayCancelButton: bool} /** Whether to display the cancel button. */
   {@param? displayFullTosPpMessage: bool} /** Whether to display the full message of ToS and PP. */
   <div class="mdl-card mdl-shadow--2dp{sp}
       firebaseui-container firebaseui-id-page-phone-sign-in-start">
@@ -685,7 +686,9 @@
       </div>
       <div class="firebaseui-card-actions">
         <div class="firebaseui-form-actions">
-          {call firebaseui.auth.soy2.element.cancelButton /}
+          {if $displayCancelButton}
+            {call firebaseui.auth.soy2.element.cancelButton /}
+          {/if}
           {call firebaseui.auth.soy2.element.submitButton}
             {param label kind="text"}
               {msg desc="The button that initiates the verification of the phone number provided

--- a/soy/pages_test.js
+++ b/soy/pages_test.js
@@ -386,7 +386,7 @@ function testPhoneSignInStartInvisibleRecaptcha() {
   var root = goog.dom.getElement('phone-sign-in-start-invisible-recaptcha');
   goog.soy.renderElement(
       root, firebaseui.auth.soy2.page.phoneSignInStart,
-      {enableVisibleRecaptcha: false}, IJ_DATA_);
+      {enableVisibleRecaptcha: false, displayCancelButton: true}, IJ_DATA_);
 }
 
 
@@ -394,7 +394,7 @@ function testPhoneSignInStartVisibleRecaptcha() {
   var root = goog.dom.getElement('phone-sign-in-start-visible-recaptcha');
   goog.soy.renderElement(
       root, firebaseui.auth.soy2.page.phoneSignInStart,
-      {enableVisibleRecaptcha: true}, IJ_DATA_);
+      {enableVisibleRecaptcha: true, displayCancelButton: true}, IJ_DATA_);
   loadRecaptcha(root);
 }
 
@@ -405,8 +405,17 @@ function testPhoneSignInStart_fullMessage() {
       root, firebaseui.auth.soy2.page.phoneSignInStart,
       {
         enableVisibleRecaptcha: false,
+        displayCancelButton: true,
         displayFullTosPpMessage: true
       }, IJ_DATA_);
+}
+
+
+function testPhoneSignInStart_noCancelButton() {
+  var root = goog.dom.getElement('phone-sign-in-start-no-cancel-button');
+  goog.soy.renderElement(
+      root, firebaseui.auth.soy2.page.phoneSignInStart,
+      {enableVisibleRecaptcha: false, displayCancelButton: false}, IJ_DATA_);
 }
 
 

--- a/soy/pages_test_dom.html
+++ b/soy/pages_test_dom.html
@@ -180,7 +180,7 @@ td {
 
   <!-- phoneSignInStart -->
   <tr>
-    <td rowspan="3">phoneSignInStart</td>
+    <td rowspan="4">phoneSignInStart</td>
     <td><div id="phone-sign-in-start-invisible-recaptcha"></div></td>
   </tr>
   <tr>
@@ -188,6 +188,9 @@ td {
   </tr>
   <tr>
     <td><div id="phone-sign-in-start-full-message"></div></td>
+  </tr>
+  <tr>
+    <td><div id="phone-sign-in-start-no-cancel-button"></div></td>
   </tr>
 
   <!-- phoneSignInFinish-->

--- a/translations/da.xtb
+++ b/translations/da.xtb
@@ -230,7 +230,7 @@
 <translation id="5611074838440670731">Dette telefonnummer er blevet brugt for mange gange</translation>
 <translation id="5630396263271753991">Eritrea</translation>
 <translation id="5636713964613741614">Mauritius</translation>
-<translation id="5642254620426025006">Der opstod en fejl. Prøv igen.</translation>
+<translation id="5642254620426025006">Noget gik galt. Prøv igen.</translation>
 <translation id="5649486931917149784">Adgangskode</translation>
 <translation id="5664080586064341046">St. Kitts</translation>
 <translation id="5699028034244995851">Angiv din mailadresse for at fortsætte</translation>

--- a/translations/es.xtb
+++ b/translations/es.xtb
@@ -365,7 +365,7 @@
 <ph name="P_START" />El equipo de <ph name="APP_NAME" /><ph name="P_END" /></translation>
 <translation id="8130982192244529100">Para enviar los códigos de verificación, indica el número de teléfono del destinatario.</translation>
 <translation id="8138904368098176683">Sudán</translation>
-<translation id="815425460105074455">Las Bahamas</translation>
+<translation id="815425460105074455">Bahamas</translation>
 <translation id="8177114080110296189">Costa de Marfil</translation>
 <translation id="8192724270853215748">Palaos</translation>
 <translation id="8210009914905612114">Mongolia</translation>

--- a/translations/pl.xtb
+++ b/translations/pl.xtb
@@ -193,7 +193,7 @@
 <translation id="4775051289386800916">Nikaragua</translation>
 <translation id="4783400389150493171">Burkina Faso</translation>
 <translation id="4852256440857413490">Nieprawidłowy kod. Spróbuj jeszcze raz.</translation>
-<translation id="4871106926303956169">Wyspy Turks i Caicos</translation>
+<translation id="4871106926303956169">Turks i Caicos</translation>
 <translation id="4877597386645466815">Kod można wysłać ponownie za: <ph name="TIME_REMAINING" /></translation>
 <translation id="4915406999072654369">Sprawdź pocztę</translation>
 <translation id="4955175001894453989">Dodaj hasło</translation>


### PR DESCRIPTION
Release V3.4.1: 
- Hides cancel button in phone sign-in page if only phone provider is configured.
- Reverts FirebaseUI languageCode modification on external Auth instance before sign in completion to not trigger race conditions when signInSuccessWithAuthResult callback modifies the Auth languageCode.