### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Here is how you would track the Auth state across all your pages:
       };
 
       window.addEventListener('load', function() {
-        initApp()
+        initApp();
       });
     </script>
   </head>


### PR DESCRIPTION
Added a semicolon to match the style of the previous example. This way if a beginner uses the drop-in code and attempts to immediately add a new line to the function they will not have any issues.