### PR TITLE
Remove dependencies from ES module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebaseui",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7370,10 +7370,9 @@
       }
     },
     "material-design-lite": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.3.0.tgz",
-      "integrity": "sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.2.0.tgz",
+      "integrity": "sha1-zuJb8kclxq9RceSwXDf92eq5jwU="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "gulp-css-inline-images": "^0.1.1",
     "gulp-sass": "^2.3.2",
     "gulp-util": "^3.0.7",
-    "material-design-lite": "^1.2.0",
     "protractor": "^5.3.2",
     "streamqueue": "^1.1.1"
   },
   "dependencies": {
-    "dialog-polyfill": "^0.4.7"
+    "dialog-polyfill": "^0.4.7",
+    "material-design-lite": "^1.2.0"
   },
   "peerDependencies": {
     "firebase": ">=6.0.1"


### PR DESCRIPTION
Fixes #618 

Instead of bundling the dependencies for the ES module, let's import them. This fixes the issue of `dialog-polyfill` also defining an export and bundlers getting confused.

I tried to run the tests, but ran into issues with PhantomJS, so if anyone from the team could run the tests, that would be nice.