### PR TITLE
update webdrivermgr

### DIFF
--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -80,6 +80,11 @@ if [[ $1 = "--saucelabs" ]]; then
     $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
   fi
 else
+  # https://github.com/angular/webdriver-manager/issues/404
+  echo "Updating webdriver-manager dependency."
+  cd ./node_modules/protractor/
+  npm i webdriver-manager@latest
+  cd ../../
   echo "Using Headless Chrome."
   # Updates Selenium Webdriver.
   echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --gecko=false"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebaseui",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8522,7 +8522,7 @@
         "selenium-webdriver": "3.6.0",
         "source-map-support": "~0.4.0",
         "webdriver-js-extender": "2.1.0",
-        "webdriver-manager": "^12.0.6"
+        "webdriver-manager": "^12.1.7"
       },
       "dependencies": {
         "webdriver-manager": {


### PR DESCRIPTION
Manually update webdriver-manger as protractor depends on older version of webdriver-manger and it causes the test to fail with the current chrome browser.
More detail here: https://github.com/angular/webdriver-manager/issues/404
Will remove it once protractor update the dependency. 