### PR TITLE
Add config option to disable new account creation prompt

### DIFF
--- a/javascript/widgets/config.js
+++ b/javascript/widgets/config.js
@@ -47,6 +47,11 @@ class Config {
         'credentialHelper',
         Config.CredentialHelper.ACCOUNT_CHOOSER_COM);
     /**
+     * Defines if unrecognized email addresses should be prompted to create
+     * an account. If set to false, the full email/password prompt will be shown.
+     */
+    this.config_.define('allowNewAccountCreation', true);
+    /**
      * Determines whether to immediately redirect to the provider's site or
      * instead show the default 'Sign in with Provider' button when there
      * is only a single federated provider in signInOptions. In order for this
@@ -798,6 +803,14 @@ class Config {
   isAccountChooserEnabled() {
     return this.getCredentialHelper() ==
         Config.CredentialHelper.ACCOUNT_CHOOSER_COM;
+  }
+
+  /**
+   * @return {boolean} Whether new accounts should should be allowed to register through the ui
+   */
+  isNewAccountCreationAllowed() {
+    return /** @type {boolean} If new account creation is allwed */ (
+      this.config_.get('allowNewAccountCreation'));
   }
 
   /**

--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -1269,7 +1269,6 @@ firebaseui.auth.widget.handler.common.handleSignInStart = function(
     // If new account creation is disabled, just show the full username/password
     // prompt. No need for the intermediate check.
     if (app.getConfig().isNewAccountCreationAllowed() === false) {
-      console.log('In block that I added!')
       firebaseui.auth.widget.handler.handle(
         firebaseui.auth.widget.HandlerName.PASSWORD_SIGN_IN,
         app,

--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -1266,21 +1266,33 @@ firebaseui.auth.widget.handler.common.isPhoneProviderOnly = function(app) {
 firebaseui.auth.widget.handler.common.handleSignInStart = function(
     app, container, email = undefined, infoBarMessage = undefined) {
   if (firebaseui.auth.widget.handler.common.isPasswordProviderOnly(app)) {
-    // If info bar message is available, do not go to accountchooser.com since
-    // this is a result of some error in the flow and the error message must be
-    // displayed.
-    if (infoBarMessage) {
+    // If new account creation is disabled, just show the full username/password
+    // prompt. No need for the intermediate check.
+    if (app.getConfig().isNewAccountCreationAllowed() === false) {
+      console.log('In block that I added!')
       firebaseui.auth.widget.handler.handle(
-          firebaseui.auth.widget.HandlerName.SIGN_IN,
-          app,
-          container,
-          email,
-          infoBarMessage);
+        firebaseui.auth.widget.HandlerName.PASSWORD_SIGN_IN,
+        app,
+        container,
+        email,
+        infoBarMessage);
     } else {
-      // Email auth provider is the only option, trigger that flow immediately
-      // instead of just showing a single sign-in with email button.
-      firebaseui.auth.widget.handler.common.handleSignInWithEmail(
-          app, container, email);
+      // If info bar message is available, do not go to accountchooser.com since
+      // this is a result of some error in the flow and the error message must be
+      // displayed.
+      if (infoBarMessage) {
+        firebaseui.auth.widget.handler.handle(
+            firebaseui.auth.widget.HandlerName.SIGN_IN,
+            app,
+            container,
+            email,
+            infoBarMessage);
+      } else {
+        // Email auth provider is the only option, trigger that flow immediately
+        // instead of just showing a single sign-in with email button.
+        firebaseui.auth.widget.handler.common.handleSignInWithEmail(
+            app, container, email);
+      }
     }
   } else if (
       app && firebaseui.auth.widget.handler.common.isPhoneProviderOnly(app) &&


### PR DESCRIPTION
Potential way to fix #99 - Adds `allowNewAccountCreation` config param (Which defaults to `true`, keeping current behavior). If set to `false` this displays the full username and password prompt, and does not show the "sign up" screen if an unrecognized email address is entered.

As people in the feature request thread have mentioned, new account creation should also be disabled server-side, but this prevents a lot of confusion on the part of the end user.