### PR TITLE
Fixes issue when email link user is locked out

### DIFF
--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -1417,19 +1417,29 @@ firebaseui.auth.widget.handler.common.handleSignInFetchSignInMethodsForEmail =
         opt_displayFullTosPpMessage);
   } else if ((signInMethods.length == 1) && (signInMethods[0] ===
       firebase.auth.EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD)) {
-    // Existing email link account.
-    firebaseui.auth.widget.handler.handle(
-        firebaseui.auth.widget.HandlerName.SEND_EMAIL_LINK_FOR_SIGN_IN,
-        app,
-        container,
-        email,
-        function() {
-          // Clicking back button goes back to sign in page.
-          firebaseui.auth.widget.handler.handle(
-              firebaseui.auth.widget.HandlerName.SIGN_IN,
-              app,
-              container);
-        });
+    if (app.getConfig().isEmailLinkSignInAllowed()) {
+      // Existing email link account.
+      firebaseui.auth.widget.handler.handle(
+          firebaseui.auth.widget.HandlerName.SEND_EMAIL_LINK_FOR_SIGN_IN,
+          app,
+          container,
+          email,
+          function() {
+            // Clicking back button goes back to sign in page.
+            firebaseui.auth.widget.handler.handle(
+                firebaseui.auth.widget.HandlerName.SIGN_IN,
+                app,
+                container);
+          });
+    } else {
+      // Email link sign-in is the only option for this user but it is not
+      // supported in the current app configuration.
+      firebaseui.auth.widget.handler.handle(
+          firebaseui.auth.widget.HandlerName.UNSUPPORTED_PROVIDER,
+          app,
+          container,
+          email);
+    }
   } else {
     // Federated Account.
     // The account exists, and is a federated identity account.

--- a/javascript/widgets/handler/common_test.js
+++ b/javascript/widgets/handler/common_test.js
@@ -1925,6 +1925,22 @@ function testHandleSignInWithEmail_prefillEmail() {
 }
 
 
+function testHandleSignInFetchSignInMethodsForEmail_unsupportedProvider() {
+  // When user has previously signed in with email link but only email/password
+  // auth is supported in the app's configuration.
+  var signInMethods = ['emailLink'];
+  var email = 'user@example.com';
+  app.updateConfig('signInOptions',  [{'provider': 'password'}]);
+  firebaseui.auth.widget.handler.common.handleSignInFetchSignInMethodsForEmail(
+      app, container, signInMethods, email);
+  // It should not store pending email.
+  assertFalse(firebaseui.auth.storage.hasPendingEmailCredential(
+        app.getAppId()));
+  // Unsupported provider page should show.
+  assertUnsupportedProviderPage(email);
+}
+
+
 function testLoadAccountchooserJs_externallyLoaded() {
   // Test accountchooser.com client loading when already loaded.
   // Reset loadAccountchooserJs stubs.


### PR DESCRIPTION
Fixes issue when email link user tries to sign in with FirebaseUI when only email/password sign in method is provided.

In this case, we should just fallback to unsupported provider screen.

Fixes https://github.com/firebase/firebaseui-web/issues/708