### PR TITLE
Adds ability to customize IdP buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+* Extends the ability to customize the default IdP buttons (provider name, icon URL and background color) for providers like Google and Email.
+* Adds the ability to overwrite the entire button label via `fullLabel` for all buttons.

--- a/README.md
+++ b/README.md
@@ -641,6 +641,16 @@ parameters.
 </td>
 </tr>
 <tr>
+<td>fullLabel</td>
+<td>No</td>
+<td>
+  The full label of the button. Instead of "Sign in with $providerName", this
+  button label will be used.
+  <em>Default:</em>
+  <code>Sign in with $providerName</code>
+</td>
+</tr>
+<tr>
 <td>buttonColor</td>
 <td>No</td>
 <td>
@@ -694,6 +704,8 @@ ui.start('#firebaseui-auth-container', {
     {
       provider: 'microsoft.com',
       providerName: 'Microsoft',
+      // To override the full label of the button.
+      // fullLabel: 'Login with Microsoft',
       buttonColor: '#2F2F2F',
       iconUrl: '<icon-url-of-sign-in-button>',
       loginHintKey: 'login_hint',
@@ -740,6 +752,16 @@ OIDC providers' `signInOptions` support the following configuration parameters.
 </td>
 </tr>
 <tr>
+<td>fullLabel</td>
+<td>No</td>
+<td>
+  The full label of the button. Instead of "Sign in with $providerName", this
+  button label will be used.
+  <em>Default:</em>
+  <code>Sign in with $providerName</code>
+</td>
+</tr>
+<tr>
 <td>buttonColor</td>
 <td>Yes</td>
 <td>
@@ -770,8 +792,10 @@ OIDC providers' `signInOptions` support the following configuration parameters.
 ui.start('#firebaseui-auth-container', {
   signInOptions: [
     {
-      provider: 'oidc.myProvider`,
+      provider: 'oidc.myProvider',
       providerName: 'MyOIDCProvider',
+      // To override the full label of the button.
+      // fullLabel: 'Employee Login',
       buttonColor: '#2F2F2F',
       iconUrl: '<icon-url-of-sign-in-button>',
       customParameters: {
@@ -814,6 +838,16 @@ SAML providers' `signInOptions` support the following configuration parameters.
 </td>
 </tr>
 <tr>
+<td>fullLabel</td>
+<td>No</td>
+<td>
+  The full label of the button. Instead of "Sign in with $providerName", this
+  button label will be used.
+  <em>Default:</em>
+  <code>Sign in with $providerName</code>
+</td>
+</tr>
+<tr>
 <td>buttonColor</td>
 <td>Yes</td>
 <td>
@@ -839,6 +873,8 @@ ui.start('#firebaseui-auth-container', {
     {
       provider: 'saml.myProvider',
       providerName: 'MySAMLProvider',
+      // To override the full label of the button.
+      // fullLabel: 'Constractor Portal',
       buttonColor: '#2F2F2F',
       iconUrl: '<icon-url-of-sign-in-button>'
     }

--- a/externs/firebaseui-externs.js
+++ b/externs/firebaseui-externs.js
@@ -683,6 +683,38 @@ firebaseui.auth.Callbacks.prototype.uiShown = function() {};
 firebaseui.auth.SignInOption = function() {};
 
 /**
+ * The provider name displayed to end users
+ * (sign-in button label/linking prompt).
+ * Default: provider ID
+ *
+ * @type {string|undefined}
+ */
+firebaseui.auth.SignInOption.prototype.providerName;
+
+/**
+ * The full label of the button, instead of "Sign in with $providerName".
+ * Default: "Sign in with $providerName".
+ *
+ * @type {string|undefined}
+ */
+firebaseui.auth.SignInOption.prototype.fullLabel;
+
+/**
+ * The color of the sign-in button.
+ *
+ * @type {string|undefined}
+ */
+firebaseui.auth.SignInOption.prototype.buttonColor;
+
+/**
+ * The URL of the Identity Provider's icon. This will be displayed on the
+ * provider's sign-in button, etc.
+ *
+ * @type {string|undefined}
+ */
+firebaseui.auth.SignInOption.prototype.iconUrl;
+
+/**
  * The provider ID for the provided sign in option,
  * eg: `firebase.auth.GoogleAuthProvider.PROVIDER_ID`.
  *

--- a/firebaseuihandler/README.md
+++ b/firebaseuihandler/README.md
@@ -137,6 +137,8 @@ const configs = {
           {
             provider: 'saml.my-provider1',
             providerName: 'SAML provider',
+            // To customize the full label:
+            // fullLabel: 'ACME Portal',
             buttonColor: '#4666FF',
             iconUrl: 'https://www.example.com/photos/my_idp/saml.png'
           },
@@ -161,6 +163,8 @@ const configs = {
           {
             provider: 'oidc.my-provider1',
             providerName: 'OIDC provider',
+            // To customize the full label:
+            // fullLabel: 'Contractor Login',
             buttonColor: '#4666FF',
             iconUrl: 'https://www.example.com/photos/my_idp/oidc.png'
           },

--- a/javascript/widgets/config.js
+++ b/javascript/widgets/config.js
@@ -237,16 +237,30 @@ class Config {
           googArray.contains(
               UI_SUPPORTED_PROVIDERS,
               option['provider'])) {
-        // For built-in providers, provider display name, button color and
-        // icon URL are fixed. The login hint key is also automatically set for
-        // built-in providers that support it.
-        return {
+        // The login hint key is also automatically set for built-in providers
+        // that support it.
+        const providerConfig = {
           providerId: option['provider'],
+          // Since developers may be using G-Suite for Google sign in or
+          // want to label email/password as their own provider, we should
+          // allow customization of these attributes.
+          providerName: option['providerName'] || null,
+          fullLabel: option['fullLabel'] || null,
+          buttonColor: option['buttonColor'] || null,
+          iconUrl: option['iconUrl'] ?
+              util.sanitizeUrl(option['iconUrl']) : null,
         };
+        for (const key in providerConfig) {
+          if (providerConfig[key] === null) {
+            delete providerConfig[key];
+          }
+        }
+        return providerConfig;
       } else {
         return {
           providerId: option['provider'],
           providerName: option['providerName'] || null,
+          fullLabel: option['fullLabel'] || null,
           buttonColor: option['buttonColor'] || null,
           iconUrl: option['iconUrl'] ?
               util.sanitizeUrl(option['iconUrl']) : null,
@@ -914,11 +928,15 @@ Config.SignInFlow = {
  * The provider config object for generic providers.
  * providerId: The provider ID.
  * providerName: The display name of the provider.
+ * fullLabel: The full button label. If both providerName and fullLabel are
+ * provided, we will use fullLabel for long name and providerName for short
+ * name.
  * buttonColor: The color of the sign in button.
  * iconUrl: The URL of the icon on sign in button.
  * loginHintKey: The name to use for the optional login hint parameter.
  * @typedef {{
  *   providerId: string,
+ *   fullLabel: (?string|undefined),
  *   providerName: (?string|undefined),
  *   buttonColor: (?string|undefined),
  *   iconUrl: (?string|undefined),

--- a/javascript/widgets/config_test.js
+++ b/javascript/widgets/config_test.js
@@ -311,8 +311,8 @@ testSuite({
       {
         'provider': 'google.com',
         'scopes': ['foo', 'bar'],
-        // providerName, buttonColor and iconUrl should be override with null.
-        'providerName': 'Google',
+        'providerName': 'MyIdp',
+        'fullLabel': 'MyIdp Portal',
         'buttonColor': '#FFB6C1',
         'iconUrl': '<url-of-the-icon-of-the-sign-in-button>',
       },
@@ -320,6 +320,7 @@ testSuite({
       {
         'provider': 'microsoft.com',
         'providerName': 'Microsoft',
+        'fullLabel': 'Microsoft Login',
         'buttonColor': '#FFB6C1',
         'iconUrl': '<url-of-the-icon-of-the-sign-in-button>',
         'loginHintKey': 'login_hint',
@@ -333,6 +334,10 @@ testSuite({
     assertEquals(4, providerConfigs.length);
     assertObjectEquals({
       providerId: 'google.com',
+      providerName: 'MyIdp',
+      fullLabel: 'MyIdp Portal',
+      buttonColor: '#FFB6C1',
+      iconUrl: '<url-of-the-icon-of-the-sign-in-button>',
     }, providerConfigs[0]);
     assertObjectEquals({
       providerId: 'facebook.com',
@@ -340,6 +345,7 @@ testSuite({
     assertObjectEquals({
       providerId: 'microsoft.com',
       providerName: 'Microsoft',
+      fullLabel: 'Microsoft Login',
       buttonColor: '#FFB6C1',
       iconUrl: '<url-of-the-icon-of-the-sign-in-button>',
       loginHintKey: 'login_hint',
@@ -347,6 +353,7 @@ testSuite({
     assertObjectEquals({
       providerId: 'yahoo.com',
       providerName: null,
+      fullLabel: null,
       buttonColor: null,
       iconUrl: null,
       loginHintKey: null,
@@ -358,15 +365,17 @@ testSuite({
       {
         'provider': 'google.com',
         'scopes': ['foo', 'bar'],
-        // providerName, buttonColor and iconUrl should be override with null.
-        'providerName': 'Google',
+        'providerName': 'MyIdp',
+        'fullLabel': 'MyIdp Portal',
         'buttonColor': '#FFB6C1',
         'iconUrl': '<url-of-the-icon-of-the-sign-in-button>',
+        'loginHintKey': 'other',
       },
       'facebook.com',
       {
         'provider': 'microsoft.com',
         'providerName': 'Microsoft',
+        'fullLabel': 'Microsoft Login',
         'buttonColor': '#FFB6C1',
         'iconUrl': '<url-of-the-icon-of-the-sign-in-button>',
         'loginHintKey': 'login_hint',
@@ -381,6 +390,10 @@ testSuite({
     ]);
     assertObjectEquals({
       providerId: 'google.com',
+      providerName: 'MyIdp',
+      fullLabel: 'MyIdp Portal',
+      buttonColor: '#FFB6C1',
+      iconUrl: '<url-of-the-icon-of-the-sign-in-button>',
     }, config.getConfigForProvider('google.com'));
     assertObjectEquals({
       providerId: 'facebook.com',
@@ -388,6 +401,7 @@ testSuite({
     assertObjectEquals({
       providerId: 'microsoft.com',
       providerName: 'Microsoft',
+      fullLabel: 'Microsoft Login',
       buttonColor: '#FFB6C1',
       iconUrl: '<url-of-the-icon-of-the-sign-in-button>',
       loginHintKey: 'login_hint',
@@ -396,6 +410,7 @@ testSuite({
     assertObjectEquals({
       providerId: 'yahoo.com',
       providerName: 'Yahoo',
+      fullLabel: null,
       buttonColor: '#FFB6C1',
       iconUrl: 'about:invalid#zClosurez',
       loginHintKey: null,

--- a/javascript/widgets/uihandlerconfig_test.js
+++ b/javascript/widgets/uihandlerconfig_test.js
@@ -54,6 +54,7 @@ testSuite({
             {
               hd: 'sub-acme.com',
               provider: 'password',
+              fullLabel: 'Sign in as Employee',
               requireDisplayName: false,
             },
           ],
@@ -70,6 +71,7 @@ testSuite({
             {
               hd: 'ocp-supplier1.com',
               provider: 'saml.my-provider1',
+              fullLabel: 'Contractor Portal',
               providerName: 'SAML provider',
               buttonColor: '#4413AD',
               iconUrl: 'https://www.example.com/photos/my_idp/saml.png',

--- a/soy/elements.soy
+++ b/soy/elements.soy
@@ -140,6 +140,11 @@
       <span class="firebaseui-idp-text firebaseui-idp-text-long">
         {if $providerConfig.fullLabel}
           {$providerConfig.fullLabel}
+        {elseif $providerConfig.providerName}
+          {msg desc="Labels for sign-in buttons, long version"}
+            Sign in with{sp}
+            {call .idpName data="all" /}
+          {/msg}
         {else}
           {msg desc="Label for a button to sign in with an email account that requires a password.
               The long version"}
@@ -161,6 +166,11 @@
       <span class="firebaseui-idp-text firebaseui-idp-text-long">
         {if $providerConfig.fullLabel}
           {$providerConfig.fullLabel}
+        {elseif $providerConfig.providerName}
+          {msg desc="Labels for sign-in buttons, long version"}
+            Sign in with{sp}
+            {call .idpName data="all" /}
+          {/msg}
         {else}
           {msg desc="Label for a button to sign in with phone number.
               The long version"}
@@ -182,6 +192,11 @@
       <span class="firebaseui-idp-text firebaseui-idp-text-long">
         {if $providerConfig.fullLabel}
           {$providerConfig.fullLabel}
+        {elseif $providerConfig.providerName}
+          {msg desc="Labels for sign-in buttons, long version"}
+            Sign in with{sp}
+            {call .idpName data="all" /}
+          {/msg}
         {else}
           {msg desc="Label for a button to continue as a guest user.
               The long version"}

--- a/soy/elements.soy
+++ b/soy/elements.soy
@@ -123,7 +123,7 @@
  * Renders an identity provider button.
  */
 {template .idpButton}
-  {@param? providerConfig: [providerId:string, providerName:string|null,
+  {@param? providerConfig: [providerId:string, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   <button
       class="firebaseui-idp-button mdl-button mdl-js-button mdl-button--raised{sp}
@@ -138,52 +138,84 @@
     </span>
     {if $providerConfig.providerId == 'password'}
       <span class="firebaseui-idp-text firebaseui-idp-text-long">
-        {msg desc="Label for a button to sign in with an email account that requires a password.
-            The long version"}
-          Sign in with email
-        {/msg}
+        {if $providerConfig.fullLabel}
+          {$providerConfig.fullLabel}
+        {else}
+          {msg desc="Label for a button to sign in with an email account that requires a password.
+              The long version"}
+            Sign in with email
+          {/msg}
+        {/if}
       </span>
       <span class="firebaseui-idp-text firebaseui-idp-text-short">
-        {msg desc="Label for a button to sign in with an email account that requires a password.
-            The short version"}
-          Email
-        {/msg}
+        {if $providerConfig.providerName}
+          {$providerConfig.providerName}
+        {else}
+          {msg desc="Label for a button to sign in with an email account that requires a password.
+              The short version"}
+            Email
+          {/msg}
+        {/if}
       </span>
     {elseif $providerConfig.providerId == 'phone'}
       <span class="firebaseui-idp-text firebaseui-idp-text-long">
-        {msg desc="Label for a button to sign in with phone number.
-            The long version"}
-          Sign in with phone
-        {/msg}
+        {if $providerConfig.fullLabel}
+          {$providerConfig.fullLabel}
+        {else}
+          {msg desc="Label for a button to sign in with phone number.
+              The long version"}
+            Sign in with phone
+          {/msg}
+        {/if}
       </span>
       <span class="firebaseui-idp-text firebaseui-idp-text-short">
-        {msg desc="Label for a button to sign in with phone number.
-            The short version"}
-          Phone
-        {/msg}
+        {if $providerConfig.providerName}
+          {$providerConfig.providerName}
+        {else}
+          {msg desc="Label for a button to sign in with phone number.
+              The short version"}
+            Phone
+          {/msg}
+        {/if}
       </span>
     {elseif $providerConfig.providerId == 'anonymous'}
       <span class="firebaseui-idp-text firebaseui-idp-text-long">
-        {msg desc="Label for a button to continue as a guest user.
-            The long version"}
-          Continue as guest
-        {/msg}
+        {if $providerConfig.fullLabel}
+          {$providerConfig.fullLabel}
+        {else}
+          {msg desc="Label for a button to continue as a guest user.
+              The long version"}
+            Continue as guest
+          {/msg}
+        {/if}
       </span>
       <span class="firebaseui-idp-text firebaseui-idp-text-short">
-        {msg desc="Label for a button to continue as a guest user.
-            The short version"}
-          Guest
-        {/msg}
+        {if $providerConfig.providerName}
+          {$providerConfig.providerName}
+        {else}
+          {msg desc="Label for a button to continue as a guest user.
+              The short version"}
+            Guest
+          {/msg}
+        {/if}
       </span>
     {else}
       <span class="firebaseui-idp-text firebaseui-idp-text-long">
-        {msg desc="Labels for sign-in buttons, long version"}
-          Sign in with{sp}
-          {call .idpName data="all" /}
-        {/msg}
+        {if $providerConfig.fullLabel}
+          {$providerConfig.fullLabel}
+        {else}
+          {msg desc="Labels for sign-in buttons, long version"}
+            Sign in with{sp}
+            {call .idpName data="all" /}
+          {/msg}
+        {/if}
       </span>
       <span class="firebaseui-idp-text firebaseui-idp-text-short">
+        {if $providerConfig.providerName}
+          {$providerConfig.providerName}
+        {else}
           {call .idpName data="all" /}
+        {/if}
       </span>
     {/if}
   </button>
@@ -589,7 +621,7 @@
  * The list should match the supported provider IDs in Firebase Auth.
  */
 {template .idpName kind="text"}
-  {@param? providerConfig: [providerId:string|null, providerName:string|null,
+  {@param? providerConfig: [providerId:string|null, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   {if $providerConfig.providerName}
     {$providerConfig.providerName}
@@ -610,7 +642,7 @@
  * The list should match the supported provider IDs in Firebase Auth.
  */
 {template .idpClass_ kind="text"}
-  {@param? providerConfig: [providerId:string, providerName:string|null,
+  {@param? providerConfig: [providerId:string, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   {switch $providerConfig.providerId}
     {case 'google.com'}
@@ -639,7 +671,7 @@
  * icon.
  */
 {template .idpLogo_ kind="uri"}
-  {@param? providerConfig: [providerId:string, providerName:string|null,
+  {@param? providerConfig: [providerId:string, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   {if $providerConfig.iconUrl}
     {$providerConfig.iconUrl}
@@ -661,7 +693,7 @@
  * password icon.
  */
 {template .idpColor_ kind="text"}
-  {@param? providerConfig: [providerId:string, providerName:string|null,
+  {@param? providerConfig: [providerId:string, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   {if $providerConfig.buttonColor}
     {$providerConfig.buttonColor}

--- a/soy/elements_test.js
+++ b/soy/elements_test.js
@@ -229,7 +229,17 @@ function testIdpButton() {
       providerId: 'saml.provider',
     },
     {
+      providerId: 'saml.idp',
+      providerName: 'MySamlIdp',
+      fullLabel: 'Contractor Portal',
+    },
+    {
       providerId: 'oidc.provider',
+    },
+    {
+      providerId: 'oidc.idp',
+      providerName: 'MyOidcIdp',
+      fullLabel: 'Employee Login',
     }];
   var root = goog.dom.getElement('idp-button');
   for (var i = 0; i < idpConfigs.length; i++) {

--- a/soy/pages.soy
+++ b/soy/pages.soy
@@ -537,7 +537,7 @@
  */
 {template .emailLinkSignInLinking}
   {@param email: string}
-  {@param? providerConfig: [providerId:string|null, providerName:string|null,
+  {@param? providerConfig: [providerId:string|null, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   {let $idpDisplayName kind="text"}{call firebaseui.auth.soy2.element.idpName data="all" /}{/let}
   <div class="mdl-card mdl-shadow--2dp firebaseui-container
@@ -589,7 +589,7 @@
  * Renders an account linking page for an email link account.
  */
 {template .emailLinkSignInLinkingDifferentDevice}
-  {@param? providerConfig: [providerId:string|null, providerName:string|null,
+  {@param? providerConfig: [providerId:string|null, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   {let $idpDisplayName kind="text"}{call firebaseui.auth.soy2.element.idpName data="all" /}{/let}
   <div class="mdl-card mdl-shadow--2dp firebaseui-container
@@ -638,7 +638,7 @@
  */
 {template .federatedLinking}
   {@param email: string}
-  {@param? providerConfig: [providerId:string|null, providerName:string|null,
+  {@param? providerConfig: [providerId:string|null, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]} /** The IdP provider config. */
   {let $idpDisplayName kind="text"}{call firebaseui.auth.soy2.element.idpName data="all" /}{/let}
   <div class="mdl-card mdl-shadow--2dp firebaseui-container firebaseui-id-page-federated-linking">
@@ -1234,7 +1234,7 @@
  * Renders the list of supported sign-in providers.
  */
 {template .providerSignIn}
-  {@param providerConfigs: list<[providerId:string, providerName:string|null,
+  {@param providerConfigs: list<[providerId:string, providerName:string|null, fullLabel:string|null,
       buttonColor:string|null, iconUrl: string|null]>} /** List of supported IdP configs. */
   <div class="firebaseui-container firebaseui-page-provider-sign-in{sp}
       firebaseui-id-page-provider-sign-in firebaseui-use-spinner">

--- a/soy/pages_test.js
+++ b/soy/pages_test.js
@@ -644,6 +644,50 @@ function testProviderSignIn() {
 }
 
 
+function testProviderSignIn_buttonCustomization() {
+  var root = goog.dom.getElement('provider-sign-in-customization');
+  goog.soy.renderElement(
+      root, firebaseui.auth.soy2.page.providerSignIn, {
+        'providerConfigs': [
+          {
+            providerId: 'password',
+            fullName: 'Login with password',
+            providerName: 'Password',
+          },
+          {
+            providerId: 'phone',
+            fullName: 'Phone login',
+            providerName: 'Phone Number',
+          },
+          {
+            providerId: 'google.com',
+            fullName: 'ACME Login',
+            providerName: 'ACME',
+          },
+          {
+            providerId: 'anonymous',
+            fullName: 'Create account later',
+            providerName: 'Skip',
+          },
+          {
+            providerId: 'microsoft.com',
+            providerName: 'Microsoft',
+            buttonColor: '#FFB6C1',
+            iconUrl: 'icon-url',
+            loginHintKey: 'login_hint'
+          },
+          {
+            providerId: 'oidc.provider',
+            providerName: 'MyOidcIdp',
+            fullLabel: 'Employee Login',
+            buttonColor: '#ff00ff',
+            iconUrl: 'icon-url'
+          }]
+      },
+      IJ_DATA_);
+}
+
+
 function testProviderSignIn_busy() {
   var root = goog.dom.getElement('provider-sign-in-busy');
   goog.soy.renderElement(

--- a/soy/pages_test_dom.html
+++ b/soy/pages_test_dom.html
@@ -282,8 +282,11 @@ td {
 
   <!-- providerSignIn -->
   <tr>
-    <td rowspan="2">providerSignIn</td>
+    <td rowspan="3">providerSignIn</td>
     <td><div id="provider-sign-in"></div></td>
+  </tr>
+  <tr>
+    <td><div id="provider-sign-in-customization"></div></td>
   </tr>
   <tr>
     <td><div id="provider-sign-in-busy"></div></td>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,6 +30,10 @@ interface Callbacks {
 
 interface SignInOption {
   provider: string;
+  providerName?: string;
+  fullLabel?: string;
+  buttonColor?: string;
+  iconUrl?: string;
   hd?: string|RegExp;
 }
 


### PR DESCRIPTION
Allow customization of native providers.
In addition, allow ability to override the entire button label via "fullLabel".
This will be used instead of "Sign in with $providerName" for the long name.
However, for the short name, $providerName is still used.