### PR TITLE
Use 'var' instead of 'const' to fix old Safari error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,7 @@ const CJS_DEPS = [
 const ESM_IMPORT = ESM_DEPS.join(';') + ';';
 
 // Export firebaseui.auth module.
-const ESM_EXPORT = 'const auth = firebaseui.auth;' +
+const ESM_EXPORT = 'var auth = firebaseui.auth;' +
     'export { auth } ;';
 
 // Adds the cjs module requirement and exports firebaseui.


### PR DESCRIPTION
Fixes #715

This fixes an error on Safari 9 (iOS 9.3) which causes a syntax error. Full error: `SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.`

I've traced the error to a line coming from firebase-ui. Looking into it, I believe this code in the gulpfile simply shouldn't use `const` because it never runs through a transpiler. A couple lines down I see `var` being used.

Let me know if there's anything I can do to help get this released. Thanks!