### PR TITLE
use npm ci to replace npm install

### DIFF
--- a/buildtools/publish.sh
+++ b/buildtools/publish.sh
@@ -114,9 +114,9 @@ if [ ! -s CHANGELOG.md ]; then
 fi
 echo "Made sure there is a changelog."
 
-echo "Running npm install..."
-npm install
-echo "Ran npm install."
+echo "Running npm ci..."
+npm ci
+echo "Ran npm ci."
 
 CURRENT_VERSION=$(jq -r ".version" package.json)
 echo "Making a $VERSION version..."


### PR DESCRIPTION
In recent 2,3 releases. Npm install can't ensure package-lock.json to be unchanged during running publish scripts,
the error usually I get is: Step #11: npm notice created a lockfile as package-lock.json. You should commit this file.
However, this error in highly randomness and would delay the release for 1-2 commits each time, and greatly reduce success rate for releasing. 
In the most recent release run, npm install change a package version back by 0.01, however, a second npm install would change it back and that doesn't happen on my local repo. This minute randomness cause release failure.
Therefore, I recommend using npm ci for reliable builds on package-lock.json.
Meanwhile, check/update package version using npm install before commit to update package-lock.json in time.