### PR TITLE
fix: fixes signInFailure return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+* Fixes `signInFailure` return type to also include void to match external documentation. Fixes
+  https://github.com/firebase/firebaseui-web/issues/770

--- a/externs/firebaseui-externs.js
+++ b/externs/firebaseui-externs.js
@@ -674,8 +674,8 @@ firebaseui.auth.Callbacks.prototype.signInSuccessWithAuthResult =
  *
  * @param {!firebaseui.auth.AuthUIError} error The FirebaseUI error identifying
  *     the reason behind the failure.
- * @return {!Promise<void>} A promise that resolves when the merge conflict
- *     is completed.
+ * @return {!Promise<void>|void} Either void or a promise that resolves when the
+ *     merge conflict is completed.
  */
 firebaseui.auth.Callbacks.prototype.signInFailure = function(error) {};
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,7 +24,7 @@ interface Callbacks {
     authResult: any,
     redirectUrl?: string
   ): boolean;
-  signInFailure?(error: firebaseui.auth.AuthUIError): Promise<void>;
+  signInFailure?(error: firebaseui.auth.AuthUIError): Promise<void>|void;
   uiShown?(): void;
 }
 


### PR DESCRIPTION
Updates signInFailure's return type to also include void to match external documentation.

Fixes https://github.com/firebase/firebaseui-web/issues/770