### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,7 +1055,7 @@ if (ui.isPendingRedirect()) {
   ui.start('#firebaseui-auth-container', uiConfig);
 }
 // This can also be done via:
-if ((firebase.auth().isSignInWithEmailLink(window.location.href)) {
+if (firebase.auth().isSignInWithEmailLink(window.location.href)) {
   ui.start('#firebaseui-auth-container', uiConfig);
 }
 ```


### PR DESCRIPTION
Remove an extra `(` in example code in README that causes a syntax error