### PR TITLE
Update README.md to include CDN download of firebase-auth JS SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ for a more in-depth example, showcasing a Single Page Application mode.
     <title>Sample FirebaseUI App</title>
     <!-- *******************************************************************************************
        * TODO(DEVELOPER): Paste the initialization snippet from:
-       * Firebase Console > Overview > Add Firebase to your web app. *
+       * Firebase Console > Overview > Add Firebase to your web app.
+       * In addition, include the firebase-auth SDK:
+       * <script src="https://www.gstatic.com/firebasejs/[FIREBASE VERSION USED IN SNIPPET]/firebase-auth.js"></script> *
        ***************************************************************************************** -->
     <script src="https://www.gstatic.com/firebasejs/ui/4.8.0/firebase-ui-auth.js"></script>
     <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.8.0/firebase-ui-auth.css" />


### PR DESCRIPTION
I followed this great guide, but hit trouble when I inserted the initialization snippet because it doesn't include the firebase-auth SDK. After searching, I found the firebase-auth SDK CDN is shown here: https://firebase.google.com/docs/web/setup.