### PR TITLE
Use google-closure-deps instead of depswriter.py.

### DIFF
--- a/buildtools/generate_test_files.sh
+++ b/buildtools/generate_test_files.sh
@@ -25,16 +25,21 @@ cd "$(dirname $(dirname "$0"))"
 
 echo "Compiling templates..."
 npm run build build-soy
-cp -r ./out/soy ./generated
+mkdir -p ./generated
+cp -r ./out/soy/* ./generated
 npm run build clean
 
 echo "Generating dependency file..."
-CLOSURE_PATH="google-closure-templates/javascript"
-python node_modules/google-closure-library/closure/bin/build/depswriter.py \
-    --root_with_prefix="soy ../../../../soy" \
-    --root_with_prefix="generated ../../../../generated" \
-    --root_with_prefix="javascript ../../../../javascript" \
-    --root_with_prefix="node_modules/$CLOSURE_PATH ../../../$CLOSURE_PATH" \
+node $(npm bin)/closure-make-deps \
+    --closure-path="node_modules/google-closure-library/closure/goog" \
+    --file="node_modules/google-closure-library/closure/goog/deps.js" \
+    --root="soy" \
+    --root="generated" \
+    --root="javascript" \
+    --root="node_modules/google-closure-templates/javascript" \
+    --exclude="generated/all_tests.js" \
+    --exclude="generated/deps.js" \
+    --exclude="javascript/externs" \
     > generated/deps.js
 
 echo "Generating test HTML files..."

--- a/package-lock.json
+++ b/package-lock.json
@@ -3597,6 +3597,12 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
     "escape-goat": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
@@ -5221,6 +5227,91 @@
       "integrity": "sha512-b7xRDyFbTYnNu1u5SjvAvOs0ngKnMC9SMoSuXlpFrdTxizUJ4np97MAnP8KXKShbh7/1r0EzBq8NTUjgVFigQw==",
       "dev": true,
       "optional": true
+    },
+    "google-closure-deps": {
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-deps/-/google-closure-deps-20210406.0.0.tgz",
+      "integrity": "sha512-4mn6qZ8u4c/9fhebKccxyN882l5/0O4nuJ+ibuxDy0y7XMgolSLNF/Gmg1HEhEgX00CF/JBKrc/rw0WVjnlSfw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
+        }
+      }
     },
     "google-closure-library": {
       "version": "20190415.0.0",
@@ -9600,7 +9691,7 @@
         "selenium-webdriver": "3.6.0",
         "source-map-support": "~0.4.0",
         "webdriver-js-extender": "2.1.0",
-        "webdriver-manager": "^12.1.8",
+        "webdriver-manager": "^12.1.7",
         "yargs": "^15.3.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "firebase-tools": "^9.3.0",
     "fs-extra": "^3.0.1",
     "google-closure-compiler": "^20190415.0.0",
+    "google-closure-deps": "^20210406.0.0",
     "google-closure-library": "^20190415.0.0",
     "google-closure-templates": "^20150410.0.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
In [Closure Library](https://github.com/google/closure-library), we will be removing `depswriter.py` and other Python-based build scripts soon. `depswriter.py` is superceded by [`google-closure-deps`](https://www.npmjs.com/package/google-closure-deps), a similar tool we maintain that is implemented in Node.js.

Here, I've substituted the `depswriter.py` command with a corresponding command from `google-closure-deps`; the CLI flags are similar. The difference in output is minimal (see below).

Explanation of "extra" flags:
* `--closure-path="node_modules/google-closure-library/closure/goog"` Path to Closure (now required)
* `--file="node_modules/google-closure-library/closure/goog/deps.js"` Use the deps.js file bundled with Closure as part of deps calculation
* `--exclude=...` Not strictly necessary, but prevents these files from being written to `deps.js` as trivial, 0-dependency entries

For reference, the diff of the resulting `deps.js` from running `npm run generate-test-files` (with lines sorted and formatted for diff clarity) is [here](https://github.com/kjin/firebaseui-web/commit/9579775cdebb13f8c984875bf3f8cc2bdf6ccc6e).