### PR TITLE
Porting over some Github Actions fixes from the v9 PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Test
 on:
   push:
     branches:
-      - "**"
+      - master
   pull_request:
-    branches: 
+    branches:
       - "**"
 
 env:
@@ -33,8 +33,11 @@ jobs:
             ${{ runner.os }}-14-node_modules-
       - name: NPM install
         if: steps.node_modules_cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Build & run tests
+        # Start sauce connect here, so it's ready to go by the time we need it
         run: |
+          npm ci
           ./buildtools/sauce_connect.sh &
-          npm test -- --saucelabs
+      - name: Build & run tests
+        run: npm run test
+      - name: Run tests in Saucelabs
+        run: ./buildtools/run_tests.sh --saucelabs

--- a/buildtools/generate_test_files.sh
+++ b/buildtools/generate_test_files.sh
@@ -24,10 +24,9 @@
 cd "$(dirname $(dirname "$0"))"
 
 echo "Compiling templates..."
-npm run build build-soy
+npm run build-soy
 mkdir -p ./generated
 cp -r ./out/soy/* ./generated
-npm run build clean
 
 echo "Generating dependency file..."
 node $(npm bin)/closure-make-deps \

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -80,15 +80,11 @@ if [[ $1 = "--saucelabs" ]]; then
     $PROTRACTOR_BIN_PATH/protractor protractor.conf.js --saucelabs $2
   fi
 else
-  # https://github.com/angular/webdriver-manager/issues/404
-  echo "Updating webdriver-manager dependency."
-  cd ./node_modules/protractor/
-  npm i webdriver-manager@latest
-  cd ../../
   echo "Using Headless Chrome."
   # Updates Selenium Webdriver.
-  echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --gecko=false"
-  $PROTRACTOR_BIN_PATH/webdriver-manager update --gecko=false
+  GOOGLE_CHROME_VERSION=$(google-chrome --product-version || echo 'latest')
+  echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome $GOOGLE_CHROME_VERSION --gecko=false"
+  $PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome $GOOGLE_CHROME_VERSION --gecko=false
   # Start Selenium Webdriver.
   echo "$PROTRACTOR_BIN_PATH/webdriver-manager start &>/dev/null &"
   $PROTRACTOR_BIN_PATH/webdriver-manager start &>/dev/null &


### PR DESCRIPTION
* Only build on push on the main branch, this prevent duplicate runs from triggering on PRs
* `webdriver-manager` defaults to the latest version of chrome, which isn't on github actions yet; use the available version
* our build script could recurse...