### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/javascript/testing/mockhelper.js
+++ b/javascript/testing/mockhelper.js
@@ -221,7 +221,7 @@ class MockHelper extends Disposable {
    * @private
    */
   static capitalize_(str) {
-    return str.charAt(0).toUpperCase() + str.substr(1);
+    return str.charAt(0).toUpperCase() + str.slice(1);
   }
 }
 

--- a/javascript/ui/element/phonenumber.js
+++ b/javascript/ui/element/phonenumber.js
@@ -298,7 +298,7 @@ element.phoneNumber.selectCountry = function(id, lookupTree,
     if (countries.length && countries[0].e164_cc != country.e164_cc) {
       // Update national number with newly selected code.
       nationalNumber = '+' + country.e164_cc +
-          nationalNumber.substr(countries[0].e164_cc.length + 1);
+          nationalNumber.slice(countries[0].e164_cc.length + 1);
       // Re-populate the number in the form.
       goog.dom.forms.setValue(
           element.phoneNumber.getPhoneNumberElement.call(this), nationalNumber);
@@ -365,7 +365,7 @@ element.phoneNumber.getPhoneNumberValue = function(opt_lookupTree) {
   }
   // Remove country code prefix from national number.
   if (countries.length) {
-    nationalNumber = nationalNumber.substr(countries[0].e164_cc.length + 1);
+    nationalNumber = nationalNumber.slice(countries[0].e164_cc.length + 1);
   }
   // If only country code provided, consider the phone number missing.
   if (!nationalNumber) {

--- a/javascript/utils/phonenumber.js
+++ b/javascript/utils/phonenumber.js
@@ -62,7 +62,7 @@ firebaseui.auth.PhoneNumber = class {
       }
       // Get the national number. Add the + char to the e164_cc string.
       var nationalNumber =
-          trimmedPhoneNumber.substr(countries[0].e164_cc.length + 1);
+          trimmedPhoneNumber.slice(countries[0].e164_cc.length + 1);
       // Return the phone number object.
       return new firebaseui.auth.PhoneNumber(
           countryId, goog.string.trim(nationalNumber));


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.