### PR TITLE
Remove deprecated npm bin command

### DIFF
--- a/buildtools/generate_test_files.sh
+++ b/buildtools/generate_test_files.sh
@@ -29,7 +29,7 @@ mkdir -p ./generated
 cp -r ./out/soy/* ./generated
 
 echo "Generating dependency file..."
-node $(npm bin)/closure-make-deps \
+node node_modules/.bin/closure-make-deps \
     --closure-path="node_modules/google-closure-library/closure/goog" \
     --file="node_modules/google-closure-library/closure/goog/deps.js" \
     --root="soy" \


### PR DESCRIPTION
This command was removed in npm 9, causing dependency file generation to fail in `generate_test_files.sh`