### PR TITLE
Update password reset handler to handle password policy error

### DIFF
--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -90,7 +90,8 @@ else
   # TODO(jhuleatt) this is failing when `google-chrome --product-version` returns Chrome 115.0.5790.110
   # so for now, hard code latest
   # GOOGLE_CHROME_VERSION=$(google-chrome --product-version || echo 'latest')
-  GOOGLE_CHROME_VERSION=$(echo 'latest')
+  # GOOGLE_CHROME_VERSION=$(echo 'latest')
+  GOOGLE_CHROME_VERSION=$(echo '114.0.5735.90')
   echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=$GOOGLE_CHROME_VERSION --gecko=false"
   $PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=$GOOGLE_CHROME_VERSION --gecko=false
   # Start Selenium Webdriver.

--- a/buildtools/run_tests.sh
+++ b/buildtools/run_tests.sh
@@ -90,8 +90,7 @@ else
   # TODO(jhuleatt) this is failing when `google-chrome --product-version` returns Chrome 115.0.5790.110
   # so for now, hard code latest
   # GOOGLE_CHROME_VERSION=$(google-chrome --product-version || echo 'latest')
-  # GOOGLE_CHROME_VERSION=$(echo 'latest')
-  GOOGLE_CHROME_VERSION=$(echo '114.0.5735.90')
+  GOOGLE_CHROME_VERSION=$(echo 'latest')
   echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=$GOOGLE_CHROME_VERSION --gecko=false"
   $PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=$GOOGLE_CHROME_VERSION --gecko=false
   # Start Selenium Webdriver.

--- a/javascript/widgets/handler/actioncode.js
+++ b/javascript/widgets/handler/actioncode.js
@@ -129,27 +129,36 @@ firebaseui.auth.widget.handler.resetPassword_ = function(
  */
 firebaseui.auth.widget.handler.handlePasswordResetFailure_ = function(
     app, container, opt_component, opt_error) {
-  var errorCode = opt_error && opt_error['code'];
-  if (errorCode == 'auth/weak-password') {
+  const errorCode = opt_error && opt_error['code'];
+  if (errorCode === 'auth/weak-password') {
     // Handles this error differently as it just requires to display a message
     // to the user to use a longer password.
-    var errorMessage =
+    const errorMessage =
         firebaseui.auth.widget.handler.common.getErrorMessage(opt_error);
     firebaseui.auth.ui.element.setValid(
         opt_component.getNewPasswordElement(), false);
     firebaseui.auth.ui.element.show(
         opt_component.getNewPasswordErrorElement(), errorMessage);
     opt_component.getNewPasswordElement().focus();
-    return;
+  } else if (errorCode === 'auth/password-does-not-meet-requirements') {
+    // Pass the error message from the backend which contains all the password
+    // requirements to be met.
+    const errorMessage =
+        firebaseui.auth.widget.handler.common.getErrorMessage(opt_error);
+    firebaseui.auth.ui.element.setValid(
+        opt_component.getNewPasswordElement(), false);
+    firebaseui.auth.ui.element.show(
+        opt_component.getNewPasswordErrorElement(), errorMessage);
+    opt_component.getNewPasswordElement().focus();
+  } else {
+    if (opt_component) {
+      opt_component.dispose();
+    }
+    var component = new firebaseui.auth.ui.page.PasswordResetFailure();
+    component.render(container);
+    // Set current UI component.
+    app.setCurrentComponent(component);
   }
-
-  if (opt_component) {
-    opt_component.dispose();
-  }
-  var component = new firebaseui.auth.ui.page.PasswordResetFailure();
-  component.render(container);
-  // Set current UI component.
-  app.setCurrentComponent(component);
 };
 
 

--- a/javascript/widgets/handler/actioncode_test.js
+++ b/javascript/widgets/handler/actioncode_test.js
@@ -201,6 +201,79 @@ function testHandlePasswordReset_weakPasswordError() {
 }
 
 
+function testHandlePasswordReset_nonCompliantPasswordError() {
+  const errorMessage = 'Missing password requirements: [Password may contain at most 16 characters, Password must contain a lower case character, Password must contain an upper case character, Password must contain a numeric character, Password must contain a non-alphanumeric character]';
+  const error = {
+    'code': 'auth/password-does-not-meet-requirements',
+    'message': errorMessage
+  };
+  asyncTestCase.waitForSignals(1);
+  firebaseui.auth.widget.handler.handlePasswordReset(
+      app, container, 'PASSWORD_RESET_ACTION_CODE');
+  // Successful action code verification.
+  app.getAuth().assertVerifyPasswordResetCode(
+      ['PASSWORD_RESET_ACTION_CODE'], 'user@example.com');
+  app.getAuth()
+      .process()
+      .then(function() {
+        // Password reset page should show.
+        assertPasswordResetPage();
+
+        goog.dom.forms.setValue(getNewPasswordElement(), '123');
+        // Submit password reset form.
+        submitForm();
+        // Simulates password doesn't meet requirements.
+        app.getAuth().assertConfirmPasswordReset(
+            ['PASSWORD_RESET_ACTION_CODE', '123'], null, error);
+        return app.getAuth().process();
+      })
+      .then(function() {
+        // Error message should be shown on the same page.
+        assertPasswordResetPage();
+        assertEquals(
+            firebaseui.auth.widget.handler.common.getErrorMessage(error),
+            getNewPasswordErrorMessage());
+        asyncTestCase.signal();
+      });
+}
+
+
+function testHandlePasswordReset_nonCompliantPassword_emptyError() {
+  const error = {
+    'code': 'auth/password-does-not-meet-requirements',
+    'message': ''
+  };
+  asyncTestCase.waitForSignals(1);
+  firebaseui.auth.widget.handler.handlePasswordReset(
+      app, container, 'PASSWORD_RESET_ACTION_CODE');
+  // Successful action code verification.
+  app.getAuth().assertVerifyPasswordResetCode(
+      ['PASSWORD_RESET_ACTION_CODE'], 'user@example.com');
+  app.getAuth()
+      .process()
+      .then(function() {
+        // Password reset page should show.
+        assertPasswordResetPage();
+
+        goog.dom.forms.setValue(getNewPasswordElement(), '123');
+        // Submit password reset form.
+        submitForm();
+        // Simulates password doesn't meet requirements.
+        app.getAuth().assertConfirmPasswordReset(
+            ['PASSWORD_RESET_ACTION_CODE', '123'], null, error);
+        return app.getAuth().process();
+      })
+      .then(function() {
+        // Error message should be shown on the same page.
+        assertPasswordResetPage();
+        assertEquals(
+            firebaseui.auth.widget.handler.common.getErrorMessage(error),
+            getNewPasswordErrorMessage());
+        asyncTestCase.signal();
+      });
+}
+
+
 function testHandlePasswordReset_failToResetPassword() {
   asyncTestCase.waitForSignals(1);
   firebaseui.auth.widget.handler.handlePasswordReset(

--- a/javascript/widgets/handler/common.js
+++ b/javascript/widgets/handler/common.js
@@ -383,6 +383,69 @@ firebaseui.auth.widget.handler.common.getSignedInRedirectUrl_ =
  * @package
  */
 firebaseui.auth.widget.handler.common.getErrorMessage = function(error) {
+  // Password policy error message varies depending on the policy violations.
+  // Hence, we construct an error message from the strings file based on the
+  // error message from the backend.
+  if (error['code'] &&
+      error['code'] == 'auth/password-does-not-meet-requirements') {
+    const originalError = error['message'];
+    let minPasswordLength = '';
+    let maxPasswordLength = '';
+    let passwordNotMeetMinLength = false;
+    let passwordNotMeetMaxLength = false;
+    let passwordNotContainLowercaseLetter = false;
+    let passwordNotContainUppercaseLetter = false;
+    let passwordNotContainNumericCharacter = false;
+    let passwordNotContainNonAlphanumericCharacter = false;
+
+    const minLengthErrorMatch =
+        originalError.match(/Password must contain at least (\d+)/);
+    if (minLengthErrorMatch) {
+      passwordNotMeetMinLength = true;
+      minPasswordLength = minLengthErrorMatch[1];
+    }
+    const maxLengthErrorMatch =
+        originalError.match(/Password may contain at most (\d+)/);
+    if (maxLengthErrorMatch) {
+      passwordNotMeetMaxLength = true;
+      maxPasswordLength = maxLengthErrorMatch[1];
+    }
+    // This needs to be hardcoded. Checking against
+    // "firebaseui.auth.soy2.strings.errorPasswordNotContainLowercaseLetter().toString()"
+    // will return a translated string, while originalError is always in
+    // English.
+    if (originalError.includes(
+      'Password must contain a lower case character')) {
+      passwordNotContainLowercaseLetter = true;
+    }
+    if (originalError.includes(
+      'Password must contain an upper case character')) {
+      passwordNotContainUppercaseLetter = true;
+    }
+    if (originalError.includes('Password must contain a numeric character')) {
+      passwordNotContainNumericCharacter = true;
+    }
+    if (originalError.includes(
+      'Password must contain a non-alphanumeric character')) {
+      passwordNotContainNonAlphanumericCharacter = true;
+    }
+
+    return firebaseui.auth.soy2.strings
+        .errorMissingPasswordRequirements({
+          passwordNotMeetMinLength: passwordNotMeetMinLength,
+          minPasswordLength: minPasswordLength,
+          passwordNotMeetMaxLength: passwordNotMeetMaxLength,
+          maxPasswordLength: maxPasswordLength,
+          passwordNotContainLowercaseLetter: passwordNotContainLowercaseLetter,
+          passwordNotContainUppercaseLetter: passwordNotContainUppercaseLetter,
+          passwordNotContainNumericCharacter:
+              passwordNotContainNumericCharacter,
+          passwordNotContainNonAlphanumericCharacter:
+              passwordNotContainNonAlphanumericCharacter
+        })
+        .toString();
+  }
+
   // Try to get an error message from the strings file, or fall back to the
   // error message from the Firebase SDK if none is found.
   var message =

--- a/javascript/widgets/handler/common_test.js
+++ b/javascript/widgets/handler/common_test.js
@@ -1336,6 +1336,19 @@ function testGetErrorMessage_unknownError_jsonMessage() {
 }
 
 
+function testGetErrorMessage_passwordPolicyError_message() {
+  const error = {
+    code: 'auth/password-does-not-meet-requirements',
+    message:
+        'Missing password requirements: [Password must contain at least 8 characters, Password may contain at most 16 characters, Password must contain a lower case character, Password must contain an upper case character, Password must contain a numeric character, Password must contain a non-alphanumeric character]'
+  };
+  const message = firebaseui.auth.widget.handler.common.getErrorMessage(error);
+  assertEquals(
+      'Missing password requirements: [ Password must contain at least 8 characters. Password may contain at most 16 characters. Password must contain a lower case character. Password must contain an upper case character. Password must contain a numeric character. Password must contain a non-alphanumeric character. ]',
+      message);
+}
+
+
 function testIsPasswordProviderOnly_multipleMixedProviders() {
   // Set a password and federated providers in the FirebaseUI instance
   // configuration.

--- a/soy/strings.soy
+++ b/soy/strings.soy
@@ -210,6 +210,111 @@
 {/template}
 
 
+
+/** Error message for when the user tries to sign in, sign up, or reset password with a
+          password that is not compliant with the policy.. */
+{template .errorMissingPasswordRequirements kind="text"}
+  {@param passwordNotMeetMinLength: bool}                      /** Whether to display the
+                                                                   passwordNotMeetMinLength
+                                                                   error. */
+  {@param minPasswordLength: string}                           /** The minimum password length. */
+  {@param passwordNotMeetMaxLength: bool}                      /** Whether to display the
+                                                                   passwordNotMeetMaxLength
+                                                                   error. */
+  {@param maxPasswordLength: string}                           /** The maximum password length. */
+  {@param passwordNotContainLowercaseLetter: bool}             /** Whether to display the
+                                                                   passwordNotContainLowercaseLetter
+                                                                   error. */
+  {@param passwordNotContainUppercaseLetter: bool}             /** Whether to display the
+                                                                   passwordNotContainUppercaseLetter
+                                                                   error. */
+  {@param passwordNotContainNumericCharacter: bool}            /** Whether to display the
+                                                                   passwordNotContainNumericCharacter
+                                                                   error. */
+  {@param passwordNotContainNonAlphanumericCharacter: bool}    /** Whether to display the
+                                                                   passwordNotContainNonAlphanumericCharacter
+                                                                   error. */
+
+  {call .error}
+    {param code: 'auth/password-does-not-meet-requirements' /}
+  {/call}{sp}
+  [{sp}
+  {if $passwordNotMeetMinLength and $minPasswordLength != null}
+    {call .errorPasswordNotMeetMinLength}
+      {param minPasswordLength: $minPasswordLength /}
+    {/call}.{sp}
+  {/if}
+  {if $passwordNotMeetMaxLength and $maxPasswordLength != null}
+    {call .errorPasswordNotMeetMaxLength}
+      {param maxPasswordLength: $maxPasswordLength /}
+    {/call}.{sp}
+  {/if}
+  {if $passwordNotContainLowercaseLetter}{call .errorPasswordNotContainLowercaseLetter /}.{sp}{/if}
+  {if $passwordNotContainUppercaseLetter}{call .errorPasswordNotContainUppercaseLetter /}.{sp}{/if}
+  {if $passwordNotContainNumericCharacter}{call .errorPasswordNotContainNumericCharacter /}.{sp}{/if}
+  {if $passwordNotContainNonAlphanumericCharacter}
+    {call .errorPasswordNotContainNonAlphanumericCharacter /}.{sp}
+  {/if}
+  ]
+{/template}
+
+
+/** Error message for a password that is shorter than the minimum password length. */
+{template .errorPasswordNotMeetMinLength kind="text"}
+  {@param minPasswordLength: string}    /** The minimum password length. */
+  {msg desc="Error message when the user enters a password that is shorter than the minimum password
+      length."}
+    Password must contain at least {$minPasswordLength} characters
+  {/msg}
+{/template}
+
+
+/** Error message for a password that is longer than the maximum password length. */
+{template .errorPasswordNotMeetMaxLength kind="text"}
+  {@param maxPasswordLength: string}    /** The maximum password length. */
+  {msg desc="Error message when the user enters a password that is longer than the maximum password
+      length."}
+    Password may contain at most {$maxPasswordLength} characters
+  {/msg}
+{/template}
+
+
+/** Error message for a password that does not contain a lower case character. */
+{template .errorPasswordNotContainLowercaseLetter kind="text"}
+  {msg desc="Error message when the user enters a password that does not contain a lower case
+      character."}
+    Password must contain a lower case character
+  {/msg}
+{/template}
+
+
+/** Error message for a password that does not contain an upper case character. */
+{template .errorPasswordNotContainUppercaseLetter kind="text"}
+  {msg desc="Error message when the user enters a password that does not contain an upper case
+      character."}
+    Password must contain an upper case character
+  {/msg}
+{/template}
+
+
+/** Error message for a password that does not contain a numeric character. */
+{template .errorPasswordNotContainNumericCharacter kind="text"}
+  {msg desc="Error message when the user enters a password that does not contain a numeric
+      character."}
+    Password must contain a numeric character
+  {/msg}
+{/template}
+
+
+/** Error message for a password that does not contain a non-alphanumeric character. */
+{template .errorPasswordNotContainNonAlphanumericCharacter kind="text"}
+  {msg desc="Error message when the user enters a password that does not contain a non-alphanumeric
+      character."}
+    Password must contain a non-alphanumeric character
+  {/msg}
+{/template}
+
+
 /** Translates an error code from Firebase Auth to a user-displayable string. */
 {template .error kind="text"}
   {@param? code: string} /** The error code. */
@@ -241,7 +346,7 @@
     {case 'auth/weak-password'}
       {msg desc="Error message for when the user tries to sign in or sign up with a password that is
           too short."}
-        Strong passwords have at least 6 characters and a mix of letters and numbers
+        The password must be at least 6 characters long
       {/msg}
     {case 'auth/wrong-password'}
       {msg desc="Error message for incorrect password."}
@@ -271,6 +376,11 @@
           etc. is invalid."}
         The action code is invalid. This can happen if the code is malformed, expired, or has
         already been used.
+      {/msg}
+    {case 'auth/password-does-not-meet-requirements'}
+      {msg desc="Error message for when the user tries to sign in, sign up, or reset password with a
+          password that is not compliant with the policy."}
+        Missing password requirements:
       {/msg}
     {default}
   {/switch}

--- a/translations/ar-XB.xtb
+++ b/translations/ar-XB.xtb
@@ -30,7 +30,9 @@
 <translation id="1451880131543823984"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> ‏‮is‬‏ ‏‮not‬‏ ‏‮authorized‬‏ ‏‮to‬‏ ‏‮view‬‏ ‏‮the‬‏ ‏‮requested‬‏ ‏‮page‬‏.</translation>
 <translation id="1479035434297790822">‏‮Too‬‏ ‏‮many‬‏ ‏‮account‬‏ ‏‮requests‬‏ ‏‮are‬‏ ‏‮coming‬‏ ‏‮from‬‏ ‏‮your‬‏ ‏‮IP‬‏ ‏‮address‬‏. ‏‮Try‬‏ ‏‮again‬‏ ‏‮in‬‏ ‏‮a‬‏ ‏‮few‬‏ ‏‮minutes‬‏.</translation>
 <translation id="1483249363694224399">‏‮Sri‬‏ ‏‮Lanka‬‏</translation>
+<translation id="1501741971280143794">‏‮Enter‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮phone‬‏ ‏‮number‬‏.</translation>
 <translation id="1507995441600689506">‏‮You‬‏ ‏‮can‬‏ ‏‮now‬‏ ‏‮sign‬‏ ‏‮in‬‏ ‏‮with‬‏ ‏‮your‬‏ ‏‮new‬‏ ‏‮account‬‏</translation>
+<translation id="1535200361681091160">‏‮Enter‬‏ ‏‮your‬‏ ‏‮email‬‏</translation>
 <translation id="1544981664986460902">‏‮Client‬‏ ‏‮specified‬‏ ‏‮an‬‏ ‏‮invalid‬‏ ‏‮argument‬‏.</translation>
 <translation id="1575848116712334589">‏‮Chad‬‏</translation>
 <translation id="1630237004390596779">‏‮Resend‬‏ ‏‮code‬‏ ‏‮in‬‏ <ph name="STRING" /></translation>
@@ -45,16 +47,16 @@
 <translation id="1799407952500261728">‏‮Cook‬‏ ‏‮Islands‬‏</translation>
 <translation id="1870056762032541323">‏‮Wrong‬‏ ‏‮code‬‏. ‏‮Try‬‏ ‏‮again‬‏.</translation>
 <translation id="1898579907513173256">‏‮Macau‬‏</translation>
-<translation id="1929332760123475919"><ph name="P_START" />‏‮Hello‬‏ <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">‏‮Delete‬‏ ‏‮account‬‏</translation>
+<translation id="1912929493041975510">‏‮The‬‏ ‏‮password‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮at‬‏ ‏‮least‬‏ 6 ‏‮characters‬‏ ‏‮long‬‏</translation>
+<translation id="1933044638365301516">‏‮Sign‬‏ ‏‮in‬‏ ‏‮with‬‏ <ph name="STRING" /></translation>
 <translation id="1987722456379605552">‏‮Enter‬‏ ‏‮the‬‏ 6-‏‮digit‬‏ ‏‮code‬‏ ‏‮we‬‏ ‏‮sent‬‏ ‏‮to‬‏ <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">‏‮Follow‬‏ ‏‮the‬‏ ‏‮instructions‬‏ ‏‮sent‬‏ ‏‮to‬‏ <ph name="PH_1" /> ‏‮to‬‏ ‏‮recover‬‏ ‏‮your‬‏ ‏‮password‬‏.</translation>
+<translation id="1999379687946415948"><ph name="IDV_CODE_PLACE_HOLDER" /> ‏‮is‬‏ ‏‮your‬‏ ‏‮code‬‏ ‏‮for‬‏ <ph name="APP_NAME" />.</translation>
+<translation id="2033662766890821456">‏‮Resend‬‏ ‏‮code‬‏</translation>
 <translation id="2035855087334775326">‏‮Hungary‬‏</translation>
 <translation id="2040904406955887821">‏‮Suriname‬‏</translation>
 <translation id="2046207054419739276">‏‮United‬‏ ‏‮States‬‏</translation>
 <translation id="2049229571938383319">‏‮Saint‬‏ ‏‮Barth‬‏é‏‮lemy‬‏</translation>
 <translation id="2058731785647385204">‏‮Montserrat‬‏</translation>
-<translation id="2070709910567585968">‏‮Strong‬‏ ‏‮passwords‬‏ ‏‮have‬‏ ‏‮at‬‏ ‏‮least‬‏ 6 ‏‮characters‬‏ ‏‮and‬‏ ‏‮a‬‏ ‏‮mix‬‏ ‏‮of‬‏ ‏‮letters‬‏ ‏‮and‬‏ ‏‮numbers‬‏</translation>
 <translation id="2074008538308369451">‏‮Terms‬‏ ‏‮of‬‏ ‏‮Service‬‏</translation>
 <translation id="2089802663554186342">‏‮Session‬‏ ‏‮ended‬‏</translation>
 <translation id="2108717231438756650">‏‮United‬‏ ‏‮Kingdom‬‏</translation>
@@ -74,6 +76,7 @@
 <translation id="2285049245646335550">‏‮Cape‬‏ ‏‮Verde‬‏</translation>
 <translation id="2301396996587599046">‏‮Macedonia‬‏</translation>
 <translation id="2310948428656960769">‏‮Signed‬‏ ‏‮in‬‏!</translation>
+<translation id="2321152797538991921">‏‮Password‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮a‬‏ ‏‮non‬‏-‏‮alphanumeric‬‏ ‏‮character‬‏</translation>
 <translation id="2324942959480650701">‏‮Guest‬‏</translation>
 <translation id="2331781584136059536">‏‮Ghana‬‏</translation>
 <translation id="2338909515537249568">‏‮The‬‏ ‏‮browser‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮using‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮support‬‏ ‏‮Web‬‏ ‏‮Storage‬‏. ‏‮Please‬‏ ‏‮try‬‏ ‏‮again‬‏ ‏‮in‬‏ ‏‮a‬‏ ‏‮different‬‏ ‏‮browser‬‏.</translation>
@@ -139,6 +142,7 @@
 <translation id="3215050409577090361">‏‮An‬‏ ‏‮issue‬‏ ‏‮was‬‏ ‏‮encountered‬‏ ‏‮when‬‏ ‏‮authenticating‬‏ ‏‮your‬‏ ‏‮request‬‏. ‏‮Please‬‏ ‏‮visit‬‏ ‏‮the‬‏ ‏‮URL‬‏ ‏‮that‬‏ ‏‮redirected‬‏ ‏‮you‬‏ ‏‮to‬‏ ‏‮this‬‏ ‏‮page‬‏ ‏‮again‬‏ ‏‮to‬‏ ‏‮restart‬‏ ‏‮the‬‏ ‏‮authentication‬‏ ‏‮process‬‏.</translation>
 <translation id="3216149523061905579">‏‮Dominica‬‏</translation>
 <translation id="3223688630903046698">‏‮New‬‏ ‏‮password‬‏</translation>
+<translation id="3245143966477136343">‏‮Password‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮a‬‏ ‏‮lower‬‏ ‏‮case‬‏ ‏‮character‬‏</translation>
 <translation id="3250864391349648273">‏‮Gabon‬‏</translation>
 <translation id="3259479674319858599">‏‮You‬‏’‏‮ve‬‏ ‏‮already‬‏ ‏‮used‬‏ <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. ‏‮Sign‬‏ ‏‮in‬‏ ‏‮with‬‏ <ph name="IDP_DISPLAY_NAME" /> ‏‮to‬‏ ‏‮continue‬‏.</translation>
 <translation id="3275852444431525182">‏‮New‬‏ ‏‮Zealand‬‏</translation>
@@ -216,6 +220,7 @@
 <translation id="4571870355114729513">‏‮Follow‬‏ ‏‮the‬‏ ‏‮instructions‬‏ ‏‮sent‬‏ ‏‮to‬‏ <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> ‏‮to‬‏ ‏‮recover‬‏ ‏‮your‬‏ ‏‮password‬‏</translation>
 <translation id="4588392627302012849">‏‮Sign‬‏ ‏‮in‬‏ ‏‮with‬‏ ‏‮email‬‏</translation>
 <translation id="4595119411041064617">‏‮By‬‏ ‏‮tapping‬‏ “<ph name="PH_1" />”, ‏‮an‬‏ ‏‮SMS‬‏ ‏‮may‬‏ ‏‮be‬‏ ‏‮sent‬‏. ‏‮Message‬‏ &amp; ‏‮data‬‏ ‏‮rates‬‏ ‏‮may‬‏ ‏‮apply‬‏.</translation>
+<translation id="4603232692404395592">‏‮Password‬‏ ‏‮may‬‏ ‏‮contain‬‏ ‏‮at‬‏ ‏‮most‬‏ <ph name="MAX_PASSWORD_LENGTH" /> ‏‮characters‬‏</translation>
 <translation id="4632709875751031323">‏‮Russia‬‏</translation>
 <translation id="4644169548516814280">‏‮The‬‏ ‏‮email‬‏ ‏‮address‬‏ ‏‮is‬‏ ‏‮already‬‏ ‏‮used‬‏ ‏‮by‬‏ ‏‮another‬‏ ‏‮account‬‏</translation>
 <translation id="4692014002063276828">‏‮Poland‬‏</translation>
@@ -311,16 +316,19 @@
 <translation id="6132202686885223981">‏‮Check‬‏ ‏‮that‬‏ ‏‮your‬‏ ‏‮inbox‬‏ ‏‮space‬‏ ‏‮is‬‏ ‏‮not‬‏ ‏‮running‬‏ ‏‮out‬‏ ‏‮or‬‏ ‏‮other‬‏ ‏‮inbox‬‏ ‏‮settings‬‏ ‏‮related‬‏ ‏‮issues‬‏.</translation>
 <translation id="6135589730599211649">‏‮Client‬‏ ‏‮specified‬‏ ‏‮an‬‏ ‏‮invalid‬‏ ‏‮range‬‏.</translation>
 <translation id="6143147250106939258">‏‮The‬‏ ‏‮quota‬‏ ‏‮for‬‏ ‏‮this‬‏ ‏‮operation‬‏ ‏‮has‬‏ ‏‮been‬‏ ‏‮exceeded‬‏. ‏‮Try‬‏ ‏‮again‬‏ ‏‮later‬‏.</translation>
+<translation id="615787395595800956">‏‮Missing‬‏ ‏‮password‬‏ ‏‮requirements‬‏:</translation>
 <translation id="6189573836664806798">‏‮Paraguay‬‏</translation>
 <translation id="6192657410634245771">‏‮Algeria‬‏</translation>
 <translation id="6213969168046789596">‏‮You‬‏ ‏‮have‬‏ ‏‮entered‬‏ ‏‮an‬‏ ‏‮incorrect‬‏ ‏‮password‬‏ ‏‮too‬‏ ‏‮many‬‏ ‏‮times‬‏. ‏‮Please‬‏ ‏‮try‬‏ ‏‮again‬‏ ‏‮in‬‏ ‏‮a‬‏ ‏‮few‬‏ ‏‮minutes‬‏.</translation>
 <translation id="6216759405419177713">‏‮Norfolk‬‏ ‏‮Island‬‏</translation>
-<translation id="6245066275978703471">‏‮Phone‬‏ ‏‮number‬‏ ‏‮automatically‬‏ ‏‮verified‬‏</translation>
-<translation id="6269083314054226194">‏‮Network‬‏ ‏‮error‬‏, ‏‮check‬‏ ‏‮your‬‏ ‏‮internet‬‏ ‏‮connection‬‏.</translation>
-<translation id="6295157125625453859">‏‮Verified‬‏!</translation>
+<translation id="6238170540438416559">‏‮By‬‏ ‏‮tapping‬‏ “<ph name="PH_1" />”, ‏‮you‬‏ ‏‮are‬‏ ‏‮indicating‬‏ ‏‮that‬‏ ‏‮you‬‏ ‏‮accept‬‏ ‏‮our‬‏ <ph name="PP" />. ‏‮An‬‏ ‏‮SMS‬‏ ‏‮may‬‏ ‏‮be‬‏ ‏‮sent‬‏. ‏‮Message‬‏ &amp; ‏‮data‬‏ ‏‮rates‬‏ ‏‮may‬‏ ‏‮apply‬‏.</translation>
+<translation id="6265373887273416711">‏‮Verify‬‏ ‏‮your‬‏ ‏‮phone‬‏ ‏‮number‬‏</translation>
+<translation id="6283536862756552051">‏‮In‬‏ ‏‮order‬‏ ‏‮to‬‏ ‏‮change‬‏ ‏‮your‬‏ ‏‮password‬‏, ‏‮you‬‏ ‏‮first‬‏ ‏‮need‬‏ ‏‮to‬‏ ‏‮enter‬‏ ‏‮your‬‏ ‏‮current‬‏ ‏‮password‬‏.</translation>
+<translation id="6299890279889400823">‏‮Back‬‏</translation>
 <translation id="6316446940976157217">‏‮India‬‏</translation>
 <translation id="6327723482938582895">‏‮Benin‬‏</translation>
 <translation id="6338643731889005578">‏‮Continue‬‏</translation>
+<translation id="6355621963154078138">‏‮Password‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮a‬‏ ‏‮numeric‬‏ ‏‮character‬‏</translation>
 <translation id="6359400968059656782">‏‮You‬‏ ‏‮can‬‏ ‏‮now‬‏ ‏‮sign‬‏ ‏‮in‬‏ ‏‮with‬‏ ‏‮your‬‏ ‏‮new‬‏ ‏‮password‬‏</translation>
 <translation id="6363241121027868570">‏‮Aruba‬‏</translation>
 <translation id="6377222208046638522">‏‮Luxembourg‬‏</translation>
@@ -420,6 +428,7 @@
 <translation id="7790301903034097323">‏‮Choose‬‏ ‏‮password‬‏</translation>
 <translation id="7796914496604415892">‏‮New‬‏ ‏‮device‬‏ ‏‮or‬‏ ‏‮browser‬‏ ‏‮detected‬‏</translation>
 <translation id="786166109137986817">‏‮Sign‬‏ ‏‮in‬‏ ‏‮to‬‏ <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">‏‮Password‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮an‬‏ ‏‮upper‬‏ ‏‮case‬‏ ‏‮character‬‏</translation>
 <translation id="7868540442111212282">‏‮Czech‬‏ ‏‮Republic‬‏</translation>
 <translation id="7874584525604421364">‏‮Tuvalu‬‏</translation>
 <translation id="7926046652648626866">‏‮Sign‬‏ ‏‮in‬‏ ‏‮with‬‏ ‏‮GitHub‬‏</translation>
@@ -493,13 +502,15 @@
 <translation id="8916080112145514151">‏‮If‬‏ ‏‮you‬‏ ‏‮still‬‏ ‏‮want‬‏ ‏‮to‬‏ ‏‮connect‬‏ ‏‮your‬‏ <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> ‏‮account‬‏, ‏‮open‬‏ ‏‮the‬‏ ‏‮link‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮same‬‏ ‏‮device‬‏ ‏‮where‬‏ ‏‮you‬‏ ‏‮started‬‏ ‏‮sign‬‏-‏‮in‬‏. ‏‮Otherwise‬‏, ‏‮tap‬‏ ‏‮Continue‬‏ ‏‮to‬‏ ‏‮sign‬‏-‏‮in‬‏ ‏‮on‬‏ ‏‮this‬‏ ‏‮device‬‏.</translation>
 <translation id="8920674952994839257">‏‮Retry‬‏</translation>
 <translation id="8939353296336237380">‏‮You‬‏ ‏‮originally‬‏ ‏‮intended‬‏ ‏‮to‬‏ ‏‮connect‬‏ <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> ‏‮to‬‏ ‏‮your‬‏ ‏‮email‬‏ ‏‮account‬‏ ‏‮but‬‏ ‏‮have‬‏ ‏‮opened‬‏ ‏‮the‬‏ ‏‮link‬‏ ‏‮on‬‏ ‏‮a‬‏ ‏‮different‬‏ ‏‮device‬‏ ‏‮where‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮signed‬‏ ‏‮in‬‏.</translation>
-<translation id="8971555482255213064">‏‮Resend‬‏ ‏‮code‬‏ ‏‮in‬‏ 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">‏‮By‬‏ ‏‮tapping‬‏ <ph name="BTN" /> ‏‮you‬‏ ‏‮are‬‏ ‏‮indicating‬‏ ‏‮that‬‏ ‏‮you‬‏ ‏‮agree‬‏ ‏‮to‬‏ ‏‮the‬‏ <ph name="PP" />.</translation>
+<translation id="8980953965669178372">‏‮Done‬‏</translation>
 <translation id="8984161590699631096">‏‮Morocco‬‏</translation>
 <translation id="8994098794339484800">‏‮If‬‏ ‏‮you‬‏ ‏‮don‬‏'‏‮t‬‏ ‏‮recognize‬‏ ‏‮this‬‏ ‏‮device‬‏, ‏‮someone‬‏ ‏‮might‬‏ ‏‮be‬‏ ‏‮trying‬‏ ‏‮to‬‏ ‏‮access‬‏ ‏‮your‬‏ ‏‮account‬‏. ‏‮Consider‬‏ <ph name="START_LINK" />‏‮changing‬‏ ‏‮your‬‏ ‏‮password‬‏ ‏‮right‬‏ ‏‮away‬‏<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">‏‮Bangladesh‬‏</translation>
 <translation id="9022632332691561239">‏‮Phone‬‏</translation>
 <translation id="9028063588419847334">‏‮Finland‬‏</translation>
 <translation id="9078135685219203661">‏‮United‬‏ ‏‮Arab‬‏ ‏‮Emirates‬‏</translation>
+<translation id="9085311482535098646">‏‮Password‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮at‬‏ ‏‮least‬‏ <ph name="MIN_PASSWORD_LENGTH" /> ‏‮characters‬‏</translation>
 <translation id="9121203582272050974">‏‮Your‬‏ ‏‮email‬‏ ‏‮has‬‏ ‏‮been‬‏ ‏‮verified‬‏ ‏‮and‬‏ ‏‮changed‬‏</translation>
 <translation id="9156150178611681179">‏‮Password‬‏</translation>
 <translation id="9168877696443530714">‏‮Central‬‏ ‏‮African‬‏ ‏‮Republic‬‏</translation>

--- a/translations/ar.xtb
+++ b/translations/ar.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">جزر كوك</translation>
 <translation id="1870056762032541323">الرمز غير صحيح. يُرجى المحاولة مجددًا.</translation>
 <translation id="1898579907513173256">ماكاو</translation>
-<translation id="1929332760123475919"><ph name="P_START" />مرحبًا <ph name="DISPLAY_NAME" />،<ph name="P_END" /></translation>
-<translation id="1966996824429980990">حذف الحساب</translation>
+<translation id="1912929493041975510">يجب أن تتألف كلمة المرور من 6 أحرف على الأقل.</translation>
+<translation id="1933044638365301516">تسجيل الدخول عبر <ph name="STRING" /></translation>
 <translation id="1987722456379605552">أدخل الرمز المكوّن من 6 أرقام الذي ارسلناه إلى <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">اتبع التعليمات التي تم إرسالها إلى <ph name="PH_1" /> لاسترداد كلمة المرور.</translation>
 <translation id="2035855087334775326">المجر</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">الولايات المتحدة</translation>
 <translation id="2049229571938383319">سان بارتليمي</translation>
 <translation id="2058731785647385204">مونتسيرات</translation>
-<translation id="2070709910567585968">تتضمن كلمات المرور القوية 6 أرقام على الأقل ومزيجًا من الأحرف والأرقام</translation>
 <translation id="2074008538308369451">بنود الخدمة</translation>
 <translation id="2089802663554186342">انتهت الجلسة</translation>
 <translation id="2108717231438756650">المملكة المتحدة</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">الجزائر</translation>
 <translation id="6213969168046789596">لقد أدخلت كلمة مرور غير صحيحة لمرات كثيرة جدًا. يُرجى إعادة المحاولة بعد بضع دقائق.</translation>
 <translation id="6216759405419177713">جزيرة نورفولك</translation>
-<translation id="6245066275978703471">تمّ التحقّق تلقائيًا من رقم الهاتف.</translation>
-<translation id="6269083314054226194">حدث خطأ في الشبكة، يُرجى التحقّق من اتصال الإنترنت.</translation>
-<translation id="6295157125625453859">اكتملت عملية إثبات الملكية!</translation>
+<translation id="6238170540438416559">يشير النقر على "<ph name="PH_1" />" إلى موافقتك على <ph name="PP" />. وقد يتمّ إرسال رسالة قصيرة كما قد تنطبق رسوم الرسائل والبيانات.</translation>
+<translation id="6265373887273416711">إثبات ملكية رقم هاتفك</translation>
+<translation id="6283536862756552051">لتغيير كلمة المرور، يجب أولاً إدخال كلمة المرور الحالية.</translation>
+<translation id="6299890279889400823">رجوع</translation>
 <translation id="6316446940976157217">الهند</translation>
 <translation id="6327723482938582895">بنين</translation>
 <translation id="6338643731889005578">متابعة</translation>

--- a/translations/bg.xtb
+++ b/translations/bg.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Кук, о-ви</translation>
 <translation id="1870056762032541323">Неправилен код. Опитайте отново.</translation>
 <translation id="1898579907513173256">Макао</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Здравейте, <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Изтриване на профила</translation>
+<translation id="1912929493041975510">Паролата трябва да съдържа поне 6 знака</translation>
+<translation id="1933044638365301516">Вход с <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Въведете 6-цифрения код, който изпратихме до <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">За да възстановите паролата си, изпълнете инструкциите, изпратени до <ph name="PH_1" />.</translation>
 <translation id="2035855087334775326">Унгария</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Съединени щати</translation>
 <translation id="2049229571938383319">Сен Бартелеми</translation>
 <translation id="2058731785647385204">Монтсерат</translation>
-<translation id="2070709910567585968">Надеждните пароли съдържат поне 6 знака и комбинация от букви и цифри</translation>
 <translation id="2074008538308369451">Общи условия</translation>
 <translation id="2089802663554186342">Сесията приключи</translation>
 <translation id="2108717231438756650">Обединено кралство</translation>
@@ -132,7 +131,7 @@
 <translation id="3141549453511344986">Вход с телефон</translation>
 <translation id="3147551458884186429">Индонезия</translation>
 <translation id="3154748063569624719">Първоначално искахте да влезете с/ъс <ph name="PENDING_EMAIL" /></translation>
-<translation id="3164676761565983157">Венецуела</translation>
+<translation id="3164676761565983157">Венесуела</translation>
 <translation id="3170526549630869494">Имате проблем при влизането?</translation>
 <translation id="3204914819635733576">Потвърждаване на самоличността ви</translation>
 <translation id="3215050409577090361">При удостоверяване на заявката ви възникна проблем. Моля, отворете URL адреса, който ви пренасочи към тази страница, за да стартирате отново процеса на удостоверяване.</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Алжир</translation>
 <translation id="6213969168046789596">Въведохте неправилна парола твърде много пъти. Моля, опитайте отново след няколко минути.</translation>
 <translation id="6216759405419177713">Норфолк, о-в</translation>
-<translation id="6245066275978703471">Телефонният номер е потвърден автоматично</translation>
-<translation id="6269083314054226194">Грешка в мрежата – проверете връзката с интернет.</translation>
-<translation id="6295157125625453859">Потвърдено!</translation>
+<translation id="6238170540438416559">Докосвайки „<ph name="PH_1" />“, приемате нашата <ph name="PP" />. Възможно е да получите SMS съобщение. То може да се таксува по тарифите за данни и SMS.</translation>
+<translation id="6265373887273416711">Потвърждаване на телефонния ви номер</translation>
+<translation id="6283536862756552051">За да промените паролата си, първо трябва да въведете текущата.</translation>
+<translation id="6299890279889400823">Назад</translation>
 <translation id="6316446940976157217">Индия</translation>
 <translation id="6327723482938582895">Бенин</translation>
 <translation id="6338643731889005578">Напред</translation>

--- a/translations/ca.xtb
+++ b/translations/ca.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Illes Cook</translation>
 <translation id="1870056762032541323">El codi no és correcte. Torna-ho a provar.</translation>
 <translation id="1898579907513173256">Macau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hola, <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Suprimeix el compte</translation>
+<translation id="1912929493041975510">La contrasenya ha de tenir com a mínim 6 caràcters</translation>
+<translation id="1933044638365301516">Inicia la sessió amb <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Introdueix el codi de 6 dígits que s'ha enviat al número <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Per recuperar la contrasenya, segueix les instruccions que s'han enviat a <ph name="PH_1" />.</translation>
 <translation id="2035855087334775326">Hongria</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Estats Units</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Perquè una contrasenya sigui segura, ha de tenir com a mínim 6 caràcters i combinar lletres i números</translation>
 <translation id="2074008538308369451">Condicions del servei</translation>
 <translation id="2089802663554186342">Sessió finalitzada</translation>
 <translation id="2108717231438756650">Regne Unit</translation>
@@ -250,7 +249,7 @@
 <translation id="5255830932650472373">Contrasenya nova</translation>
 <translation id="5301108536112812420">La teva sol·licitud per verificar l'adreça electrònica ha caducat o l'enllaç ja s'ha utilitzat</translation>
 <translation id="5323041129469627535">Oman</translation>
-<translation id="5326139833547026317">Antilles Neerlandeses</translation>
+<translation id="5326139833547026317">Carib Neerlandès</translation>
 <translation id="5347459868860672391">S'ha modificat l'adreça electrònica</translation>
 <translation id="5397737236938796917">Has tancat la sessió correctament.</translation>
 <translation id="5406620662929585965">Inicia la sessió amb el telèfon</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Algèria</translation>
 <translation id="6213969168046789596">Has introduït una contrasenya incorrecta massa vegades. Torna-ho a provar d'aquí a uns quants minuts.</translation>
 <translation id="6216759405419177713">Norfolk</translation>
-<translation id="6245066275978703471">El número de telèfon s'ha verificat automàticament</translation>
-<translation id="6269083314054226194">Error de la xarxa; comprova la connexió a Internet.</translation>
-<translation id="6295157125625453859">S'ha verificat.</translation>
+<translation id="6238170540438416559">En tocar <ph name="PH_1" />, acceptes la nostra <ph name="PP" />. És possible que s'enviï un SMS. Es poden aplicar tarifes de dades i missatges.</translation>
+<translation id="6265373887273416711">Verifica el número de telèfon</translation>
+<translation id="6283536862756552051">Per canviar la contrasenya, primer has d'introduir la teva contrasenya actual.</translation>
+<translation id="6299890279889400823">Enrere</translation>
 <translation id="6316446940976157217">Índia</translation>
 <translation id="6327723482938582895">Benín</translation>
 <translation id="6338643731889005578">Continua</translation>
@@ -329,7 +329,7 @@
 <translation id="6470057025778734988">Ja no podràs iniciar la sessió amb el teu compte</translation>
 <translation id="6472297146424049005">Comprova la connexió a Internet.</translation>
 <translation id="6483116480230343278">T'estàs registrant…</translation>
-<translation id="6502083090260346644">En tocar <ph name="STRING" />, és possible que s'enviï un SMS. Es poden aplicar tarifes de dades i missatges.</translation>
+<translation id="6494734506607758748">Per canviar l'adreça electrònica associada al teu compte, has de tornar a iniciar la sessió.</translation>
 <translation id="6508909904815637928">Vanuatu</translation>
 <translation id="6520863029476703422">Samoa Nord-americana</translation>
 <translation id="6527597037551425211">Brasil</translation>

--- a/translations/cs.xtb
+++ b/translations/cs.xtb
@@ -2,7 +2,7 @@
 <translation id="1003362845472634045">Přihlašovací e-mail odeslán</translation>
 <translation id="10081113082271688">Nesprávný ověřovací kód</translation>
 <translation id="1024070574104100559">Svatý Vincenc</translation>
-<translation id="1080228854514607739">E-mailový odkaz je neplatný. K tomu může dojít, pokud platnost emailového odkazu vypršela nebo byl k přihlášení již použit. Přihlaste se znovu.</translation>
+<translation id="1080228854514607739">E-mailový odkaz je neplatný. K tomu může dojít, pokud platnost emailového odkazu vypršela nebo byl k přihlášení již použit. Přihlaste se znovu.</translation>
 <translation id="1088824719285122027">Toto telefonní číslo již bylo použito příliš mnohokrát</translation>
 <translation id="1111168792069656940">ui_flow</translation>
 <translation id="1130401182255828006">Lotyšsko</translation>
@@ -12,23 +12,23 @@
 <translation id="1163771673786684213">Filipíny</translation>
 <translation id="1170304454812139475">Rumunsko</translation>
 <translation id="1194565221977667376">Jižní Georgie a Jižní Sandwichovy ostrovy</translation>
-<translation id="1233977465587641672">Došlo ke ztrátě neobnovitelných dat nebo k poškození dat.</translation>
+<translation id="1233977465587641672">Došlo ke ztrátě neobnovitelných dat nebo k poškození dat.</translation>
 <translation id="1244846213930750436">Itálie</translation>
 <translation id="1268266284642694018">Libanon</translation>
 <translation id="1294742657282291237">Guayana</translation>
 <translation id="1297168472480293352">Guatemala</translation>
 <translation id="1307255433239736397"><ph name="START_PARAGRAPH" />Něco se pokazilo při odebírání druhého faktoru.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Zkuste ho odebrat znovu. Pokud tento postup nefunguje, kontaktujte podporu.<ph name="END_PARAGRAPH" /></translation>
 <translation id="1310034618729602982">Zkuste e-mail znovu aktualizovat</translation>
-<translation id="1312824004897469797">Došlo k chybě sítě. Zkuste to znovu později.</translation>
+<translation id="1312824004897469797">Došlo k chybě sítě. Zkuste to znovu později.</translation>
 <translation id="1315809131562953678">Zadejte platné telefonní číslo</translation>
-<translation id="1335716056288807013">Klepnutím na tlačítko Ověřit vyjadřujete svůj souhlas s našimi <ph name="START_LINK_1" />smluvními podmínkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />zásadami ochrany osobních údajů<ph name="END_LINK" />. Může být odeslána SMS a mohou být účtovány poplatky za zprávy a data.</translation>
+<translation id="1335716056288807013">Klepnutím na tlačítko Ověřit vyjadřujete svůj souhlas s našimi <ph name="START_LINK_1" />smluvními podmínkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />zásadami ochrany osobních údajů<ph name="END_LINK" />. Může být odeslána SMS a mohou být účtovány poplatky za zprávy a data.</translation>
 <translation id="137210131544215127">Zadejte své heslo</translation>
 <translation id="1393433815796487579">Hotovo</translation>
 <translation id="1412449974349991050">Haiti</translation>
-<translation id="144766329299583285">Pokud jste nežádali o změnu přihlašovacího e-mailu, je možné, že se někdo snaží získat přístup k vašemu účtu. <ph name="START_LINK" />Co nejdříve si proto změňte heslo<ph name="END_LINK" />.</translation>
+<translation id="144766329299583285">Pokud jste nežádali o změnu přihlašovacího e-mailu, je možné, že se někdo snaží získat přístup k vašemu účtu. <ph name="START_LINK" />Co nejdříve si proto změňte heslo<ph name="END_LINK" />.</translation>
 <translation id="1449981769524156676">Heardův ostrov a McDonaldovy ostrovy</translation>
 <translation id="1451880131543823984">Účet <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> nemá oprávnění zobrazit požadovanou stránku.</translation>
-<translation id="1479035434297790822">Z vaší adresy IP přichází příliš mnoho požadavků na účet. Zkuste to znovu za několik minut.</translation>
+<translation id="1479035434297790822">Z vaší adresy IP přichází příliš mnoho požadavků na účet. Zkuste to znovu za několik minut.</translation>
 <translation id="1483249363694224399">Srí Lanka</translation>
 <translation id="1507995441600689506">Nyní se můžete přihlásit prostřednictvím nového účtu</translation>
 <translation id="1544981664986460902">Klient uvedl neplatný argument.</translation>
@@ -36,7 +36,7 @@
 <translation id="1630237004390596779">Znovu odeslat kód za <ph name="STRING" /></translation>
 <translation id="1653501608290591291">Bělorusko</translation>
 <translation id="1667376103923043653">E-mailová adresa neodpovídá žádnému stávajícímu účtu.</translation>
-<translation id="173576986138855124">Po klepnutím na možnost „<ph name="PH_1" />“ může být odeslána SMS. Mohou být účtovány poplatky za zprávy a data.</translation>
+<translation id="173576986138855124">Po klepnutím na možnost „<ph name="PH_1" />“ může být odeslána SMS. Mohou být účtovány poplatky za zprávy a data.</translation>
 <translation id="1739056958326110545">Svatá Helena</translation>
 <translation id="1743026758446868773">Barbados</translation>
 <translation id="1772888465204630090">Klepnutím na Pokračovat potvrzujete, že souhlasíte se <ph name="START_LINK" />smluvními podmínkami<ph name="END_LINK" /></translation>
@@ -45,22 +45,21 @@
 <translation id="1799407952500261728">Cookovy ostrovy</translation>
 <translation id="1870056762032541323">Špatný kód. Zkuste to znovu.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Dobrý den,<ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Smazat účet</translation>
+<translation id="1912929493041975510">Heslo musí mít alespoň 6 znaků</translation>
+<translation id="1933044638365301516">Přihlásit se přes <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Zadejte šestimístný kód, který jsme zaslali na číslo <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Postupujte podle pokynů odeslaných na adresu <ph name="PH_1" /> a obnovte heslo.</translation>
+<translation id="2016421613709283485">Postupujte podle pokynů odeslaných na adresu <ph name="PH_1" /> a obnovte heslo.</translation>
 <translation id="2035855087334775326">Maďarsko</translation>
 <translation id="2040904406955887821">Surinam</translation>
 <translation id="2046207054419739276">Spojené státy americké</translation>
 <translation id="2049229571938383319">Svatý Bartoloměj</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Silné heslo má alespoň šest znaků a skládá se z kombinace písmen a číslic</translation>
 <translation id="2074008538308369451">Smluvní podmínky</translation>
 <translation id="2089802663554186342">Relace byla ukončena</translation>
-<translation id="2108717231438756650">Velká Británie</translation>
+<translation id="2108717231438756650">Spojené království</translation>
 <translation id="2120419640334291526">Kajmanské ostrovy</translation>
 <translation id="2124070231227334770">Moldavsko</translation>
-<translation id="2124843735553988177">Udělte prosím požadovaná oprávnění, která jsou nutná k přihlášení do aplikace</translation>
+<translation id="2124843735553988177">Udělte prosím požadovaná oprávnění, která jsou nutná k přihlášení do aplikace</translation>
 <translation id="2130553359919781209">Malawi</translation>
 <translation id="2187260952722791093">Ověřeno!</translation>
 <translation id="2192561962270021282">Zadání telefonního čísla</translation>
@@ -78,26 +77,26 @@
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">Váš prohlížeč nepodporuje webové úložiště. Zkuste použít jiný prohlížeč.</translation>
 <translation id="2342152898808240937">Požadavek byl zrušen klientem.</translation>
-<translation id="2356282732642724501"><ph name="START_PARAGRAPH" />Změnu e-mailové adresy na původní adresu se nepodařilo provést.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Pokud se obnovení adresy nezdaří ani při dalším pokusu, požádejte o pomoc svého správce.<ph name="END_PARAGRAPH" /></translation>
+<translation id="2356282732642724501"><ph name="START_PARAGRAPH" />Změnu e-mailové adresy na původní adresu se nepodařilo provést.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Pokud se obnovení adresy nezdaří ani při dalším pokusu, požádejte o pomoc svého správce.<ph name="END_PARAGRAPH" /></translation>
 <translation id="2375419764963116430">Bahrajn</translation>
 <translation id="2392247362473363900">Interní chyba serveru.</translation>
 <translation id="2405828009195143258">Írán</translation>
 <translation id="2422942582251341722">Zapomněli jste heslo?</translation>
-<translation id="2446078593003901807">V pořádku</translation>
+<translation id="2446078593003901807">V pořádku</translation>
 <translation id="2448487988481516351">Nová Kaledonie</translation>
 <translation id="2451742558284013472">Monako</translation>
 <translation id="2460064915291012298">Seychelly</translation>
 <translation id="2490672522100125425">Odebrána druhá fáze ověření: <ph name="START_STRONG" /><ph name="FACTOR_ID" /> <ph name="PHONE_NUMBER" /><ph name="END_STRONG" />.</translation>
-<translation id="2494962141967044042">Nepodařilo se upgradovat stávajícího anonymního uživatele. Identifikační údaje neanonymního uživatele jsou již přidruženy k účtu jiného uživatele.</translation>
-<translation id="2541179214468543429">Provedli jste příliš mnoho neplatných pokusů o zadání hesla. Opakujte akci za chvíli.</translation>
+<translation id="2494962141967044042">Nepodařilo se upgradovat stávajícího anonymního uživatele. Identifikační údaje neanonymního uživatele jsou již přidruženy k účtu jiného uživatele.</translation>
+<translation id="2541179214468543429">Provedli jste příliš mnoho neplatných pokusů o zadání hesla. Opakujte akci za chvíli.</translation>
 <translation id="2561560038714758184">Zabezpečení</translation>
-<translation id="2561835578785502516">Platnost vaší žádosti o obnovení hesla vypršela nebo byl odkaz již použit</translation>
+<translation id="2561835578785502516">Platnost vaší žádosti o obnovení hesla vypršela nebo byl odkaz již použit</translation>
 <translation id="2562498793334241360">Nyní se můžete přihlásit prostřednictvím nového účtu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="2581514546525533462">Zadaný kód země není podporován.</translation>
 <translation id="2600950452451016107">Zkontrolujte, zda jste adresu e-mailu napsali správně.</translation>
 <translation id="2610891451939662786">Twitter</translation>
 <translation id="2612036261782356367">Kambodža</translation>
-<translation id="2614081868476050089">Služba není k dispozici.</translation>
+<translation id="2614081868476050089">Služba není k dispozici.</translation>
 <translation id="2616650714309312732">Portugalsko</translation>
 <translation id="2619590123270932385">Francouzská Guyana</translation>
 <translation id="2621854044487969847">Britské Panenské ostrovy</translation>
@@ -114,10 +113,10 @@
 <translation id="2752984808025184019">Jihoafrická republika</translation>
 <translation id="2760636260031093254">Nejprve zadejte svou e-mailovou adresu</translation>
 <translation id="276938411216176478">Uživatelský účet byl deaktivován administrátorem.</translation>
-<translation id="2782685789517131804">Na adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> byl odeslán přihlašovací e-mail s dalšími pokyny. Dokončete přihlášení podle instrukcí v e-mailu.</translation>
+<translation id="2782685789517131804">Na adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> byl odeslán přihlašovací e-mail s dalšími pokyny. Dokončete přihlášení podle instrukcí v e-mailu.</translation>
 <translation id="2828509010894808185">Tvorba účtu</translation>
 <translation id="2834770837848769530">Afghánistán</translation>
-<translation id="2884525438023347369">Klepnutím na možnost <ph name="BTN" /> vyjadřujete svůj souhlas s dokumentem <ph name="TOS" />.</translation>
+<translation id="2884525438023347369">Klepnutím na možnost <ph name="BTN" /> vyjadřujete svůj souhlas s dokumentem <ph name="TOS" />.</translation>
 <translation id="2909392332969582158">Kanada</translation>
 <translation id="2911018261311455240">Dánsko</translation>
 <translation id="2949732021187449522">Překročen konečný termín požadavku.</translation>
@@ -127,19 +126,19 @@
 <translation id="3040586343252524572">Jemen</translation>
 <translation id="3045244039436637116">Guinea Bissau</translation>
 <translation id="3046745817056752783">Saúdská Arábie</translation>
-<translation id="3083819527012413063">V aplikaci <ph name="APP_NAME" /> byla přidána další fáze zabezpečení</translation>
+<translation id="3083819527012413063">V aplikaci <ph name="APP_NAME" /> byla přidána další fáze zabezpečení</translation>
 <translation id="3122584863645047144">Americké Panenské ostrovy</translation>
 <translation id="3141549453511344986">Přihlásit se pomocí telefonu</translation>
 <translation id="3147551458884186429">Indonésie</translation>
 <translation id="3154748063569624719">Původně jste se chtěli přihlásit prostřednictvím adresy <ph name="PENDING_EMAIL" /></translation>
 <translation id="3164676761565983157">Venezuela</translation>
-<translation id="3170526549630869494">Máte potíže s přihlášením?</translation>
-<translation id="3204914819635733576">Ověřte svou identitu</translation>
-<translation id="3215050409577090361">Během ověřování vaší žádosti došlo k chybě. Navštivte znovu adresu URL, která vás na tuto stránku přesměrovala, abyste proces ověřování restartovali.</translation>
+<translation id="3170526549630869494">Máte potíže s přihlášením?</translation>
+<translation id="3204914819635733576">Ověřte svou totožnost</translation>
+<translation id="3215050409577090361">Během ověřování vaší žádosti došlo k chybě. Navštivte znovu adresu URL, která vás na tuto stránku přesměrovala, abyste proces ověřování restartovali.</translation>
 <translation id="3216149523061905579">Dominika</translation>
 <translation id="3223688630903046698">Nové heslo</translation>
 <translation id="3250864391349648273">Gabun</translation>
-<translation id="3259479674319858599">K přihlášení jste již použili adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Chcete-li pokračovat, přihlaste se přes <ph name="IDP_DISPLAY_NAME" />.</translation>
+<translation id="3259479674319858599">K přihlášení jste již použili adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Chcete-li pokračovat, přihlaste se přes <ph name="IDP_DISPLAY_NAME" />.</translation>
 <translation id="3275852444431525182">Nový Zéland</translation>
 <translation id="3314478375063334511">Myanmar</translation>
 <translation id="3361878270020566601">Island</translation>
@@ -166,10 +165,10 @@
 <translation id="3605933028246642593">Nepál</translation>
 <translation id="3608140835232496799">Tokelau</translation>
 <translation id="3620185428620643248">Vybrané přihlašovací údaje pro daného poskytovatele služeb ověření nejsou podporovány.</translation>
-<translation id="3658306886462996856">Pro daný e-mail není k dispozici žádný poskytovatel přihlášení, zkuste jiný e-mail.</translation>
-<translation id="3695180913983403205">Zadejte jméno a příjmení</translation>
+<translation id="3658306886462996856">Pro daný e-mail není k dispozici žádný poskytovatel přihlášení, zkuste jiný e-mail.</translation>
+<translation id="3695180913983403205">Zadejte jméno a příjmení</translation>
 <translation id="3700097473356216716">Kolumbie</translation>
-<translation id="3703067902498234034">Klepnutím na tlačítko ULOŽIT potvrzujte svůj souhlas s dokumentem </translation>
+<translation id="3703067902498234034">Klepnutím na tlačítko ULOŽIT potvrzujte svůj souhlas s dokumentem </translation>
 <translation id="3736041829854387744">Burundi</translation>
 <translation id="3755663127769565780">Mauritánie</translation>
 <translation id="3813801701232240278">Twitter</translation>
@@ -191,7 +190,7 @@
 <translation id="4066104405592701692">Estonsko</translation>
 <translation id="4147949012570877154">Smazat</translation>
 <translation id="4163133799286985193">Argentina</translation>
-<translation id="4166504762096983411">Budete-li pokračovat, vyjadřujete svůj souhlas s našimi <ph name="START_LINK_1" />smluvními podmínkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />zásadami ochrany osobních údajů<ph name="END_LINK" />.</translation>
+<translation id="4166504762096983411">Budete-li pokračovat, vyjadřujete svůj souhlas s našimi <ph name="START_LINK_1" />smluvními podmínkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />zásadami ochrany osobních údajů<ph name="END_LINK" />.</translation>
 <translation id="420554669252656972">Zadejte novou e-mailovou adresu</translation>
 <translation id="4210333062216604630">Odpojit</translation>
 <translation id="4242716276491763916">Conakry, Guinea</translation>
@@ -214,41 +213,41 @@
 <translation id="4556476996891737119">Jordánsko</translation>
 <translation id="4571870355114729513">Obnovte heslo podle pokynů zaslaných na adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /></translation>
 <translation id="4588392627302012849">Přihlášení pomocí e-mailu</translation>
-<translation id="4595119411041064617">Po klepnutí na možnost <ph name="PH_1" /> může být odeslána SMS. Mohou být účtovány poplatky za zprávy a data.</translation>
+<translation id="4595119411041064617">Po klepnutí na možnost <ph name="PH_1" /> může být odeslána SMS. Mohou být účtovány poplatky za zprávy a data.</translation>
 <translation id="4632709875751031323">Rusko</translation>
 <translation id="4644169548516814280">Tuto e-mailovou adresu již používá jiný účet</translation>
 <translation id="4692014002063276828">Polsko</translation>
 <translation id="4723701728629289714">Izrael</translation>
-<translation id="4725154639671888461">Došlo k chybě</translation>
+<translation id="4725154639671888461">Došlo k chybě</translation>
 <translation id="4751937685196678080">Číslo</translation>
 <translation id="4769553102874508676">Klient nemá dostatečné oprávnění.</translation>
 <translation id="4773060157545352832">Potvrďte ověření reCAPTCHA.</translation>
 <translation id="4775051289386800916">Nikaragua</translation>
 <translation id="4783400389150493171">Burkina Faso</translation>
 <translation id="4852256440857413490">Špatný kód. Zkuste to znovu.</translation>
-<translation id="4866990546854875813">Relace přidružená k této žádosti o přihlášení buď vypršela, nebo byla vymazána.</translation>
+<translation id="4866990546854875813">Relace přidružená k této žádosti o přihlášení buď vypršela, nebo byla vymazána.</translation>
 <translation id="4871106926303956169">Turks a Caicos</translation>
 <translation id="4877597386645466815">Opakované odeslání kódu možné za <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
-<ph name="P_START" />K vašemu účtu v aplikaci <ph name="APP_NAME" /> bylo přidáno telefonní číslo <ph name="SECOND_FACTOR" /> pro dvoufázové ověření.<ph name="P_END" />
+<ph name="P_START" />K vašemu účtu v aplikaci <ph name="APP_NAME" /> bylo přidáno telefonní číslo <ph name="SECOND_FACTOR" /> pro dvoufázové ověření.<ph name="P_END" />
 <ph name="P_START" />Pokud jste toto telefonní číslo pro dvoufázové ověření nepřidali, kliknutím na odkaz níže ho odeberete.<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="4923375331439013137">Druhý faktor nelze odebrat</translation>
 <translation id="4955175001894453989">Přidat heslo</translation>
 <translation id="496366313824211679">Salvador</translation>
-<translation id="4982483807073820954">Chcete-li změnit heslo k účtu, musíte se znovu přihlásit.</translation>
+<translation id="4982483807073820954">Chcete-li změnit heslo k účtu, musíte se znovu přihlásit.</translation>
 <translation id="4991626049082973728">Srbsko</translation>
 <translation id="4991892293325936102">Belize</translation>
-<translation id="5042136001778337830"><ph name="START_PARAGRAPH" />k účtu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /><ph name="END_PARAGRAPH" /></translation>
-<translation id="5059105734231232362">Aby došlo k úspěšnému propojení účtu <ph name="IDP_DISPLAY_NAME" /> s touto e-mailovou adresou, musíte odkaz otevřít na stejném zařízení nebo ve stejném prohlížeči.</translation>
+<translation id="5042136001778337830"><ph name="START_PARAGRAPH" />k účtu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /><ph name="END_PARAGRAPH" /></translation>
+<translation id="5059105734231232362">Aby došlo k úspěšnému propojení účtu <ph name="IDP_DISPLAY_NAME" /> s touto e-mailovou adresou, musíte odkaz otevřít na stejném zařízení nebo ve stejném prohlížeči.</translation>
 <translation id="5080084639513001393">Švédsko</translation>
 <translation id="5080899604429810481">Svatý Martin</translation>
-<translation id="5115661695221894994"><ph name="START_PARAGRAPH" />Platnost vaší žádosti o ověření a aktualizaci e-mailu vypršela nebo byl odkaz již použit.<ph name="END_PARAGRAPH" /></translation>
+<translation id="5115661695221894994"><ph name="START_PARAGRAPH" />Platnost vaší žádosti o ověření a aktualizaci e-mailu vypršela nebo byl odkaz již použit.<ph name="END_PARAGRAPH" /></translation>
 <translation id="5143657419516597442">Svatá Lucie</translation>
 <translation id="521218078240459724">@string/app_name</translation>
 <translation id="5241732101105320538">Kontrola e-mailu</translation>
 <translation id="5255830932650472373">Nové heslo</translation>
-<translation id="5301108536112812420">Platnost vaší žádosti o ověření e-mailu vypršela nebo byl odkaz již použit</translation>
+<translation id="5301108536112812420">Platnost vaší žádosti o ověření e-mailu vypršela nebo byl odkaz již použit</translation>
 <translation id="5323041129469627535">Omán</translation>
 <translation id="5326139833547026317">Karibské Nizozemsko</translation>
 <translation id="5347459868860672391">E-mailová adresa byla změněna</translation>
@@ -260,15 +259,15 @@
 <translation id="5443669846203963095">Zásady ochrany soukromí</translation>
 <translation id="5444635161362535036">Lichtenštejnsko</translation>
 <translation id="5483706910421209104">Změnit jméno</translation>
-<translation id="5487696047685227891">Zařízení nebo aplikace byla z druhé fáze ověření odebrána.</translation>
+<translation id="5487696047685227891">Zařízení nebo aplikace byla z druhé fáze ověření odebrána.</translation>
 <translation id="5490651768073507833">Otevřete odkaz na stejném zařízení nebo ve stejném prohlížeči, kde jste proces přihlášení započali.</translation>
 <translation id="5524360735013196510">Nizozemsko</translation>
 <translation id="5528189843379142883">Rovníková Guinea</translation>
 <translation id="5529036554155743092">Austrálie</translation>
-<translation id="5537884323453943551">Trinidad a Tobago</translation>
+<translation id="5537884323453943551">Trinidad a Tobago</translation>
 <translation id="5543493820882105191">Zadejte své jméno</translation>
 <translation id="55439745111619380">Ascension</translation>
-<translation id="5569341882117077010">Došlo k chybě sítě</translation>
+<translation id="5569341882117077010">Došlo k chybě sítě</translation>
 <translation id="5581239183924693195">Přihlášení přes <ph name="IDP_DISPLAY_NAME" /></translation>
 <translation id="5585451911077299623">Zvolte heslo.</translation>
 <translation id="5602886107840188229">Britské indickooceánské území</translation>
@@ -292,7 +291,7 @@
 <translation id="5840803301882074743">Tonga</translation>
 <translation id="5850752921356750845">Wallis a Futuna</translation>
 <translation id="5853516492584814656">Nepodařilo se změnit e-mailovou adresu</translation>
-<translation id="5905720181746284549">K přihlášení jste již použili adresu <ph name="STRING" />. Zadejte příslušné heslo k účtu.</translation>
+<translation id="5905720181746284549">K přihlášení jste již použili adresu <ph name="STRING" />. Zadejte příslušné heslo k účtu.</translation>
 <translation id="5921101578434778028">Anguilla</translation>
 <translation id="5948592577241492942">Tento e-mail již existuje, ovšem bez nastaveného způsobu přihlášení. Obnovte heslo, abyste mohli účet začít používat.</translation>
 <translation id="5985902459796151462">Dominikánská republika</translation>
@@ -307,16 +306,17 @@
 <translation id="61182948399263957">
 <ph name="P_START" />Přihlaste se do aplikace <ph name="APP_NAME" /> &lt;/p&gt;&lt;/p&gt;
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
-<translation id="6132202686885223981">Zkontrolujte, jestli nemáte plnou schránku příchozích správ nebo nedošlo k nějakému jiného problému se schránkou.</translation>
+<translation id="6132202686885223981">Zkontrolujte, jestli nemáte plnou schránku příchozích správ nebo nedošlo k nějakému jiného problému se schránkou.</translation>
 <translation id="6135589730599211649">Klient uvedl neplatný rozsah.</translation>
 <translation id="6143147250106939258">Kvóta pro tuto operaci byla překročena. Zkuste to znovu později.</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Alžírsko</translation>
-<translation id="6213969168046789596">Provedli jste příliš mnoho neplatných pokusů o zadání hesla. Opakujte akci za chvíli.</translation>
+<translation id="6213969168046789596">Provedli jste příliš mnoho neplatných pokusů o zadání hesla. Opakujte akci za chvíli.</translation>
 <translation id="6216759405419177713">Norfolk</translation>
-<translation id="6245066275978703471">Telefonní číslo bylo automaticky ověřeno</translation>
-<translation id="6269083314054226194">Chyba sítě. Zkontrolujte připojení k internetu.</translation>
-<translation id="6295157125625453859">Ověřeno!</translation>
+<translation id="6238170540438416559">Klepnutím na tlačítko <ph name="PH_1" /> vyjadřujete svůj souhlas s dokumentem <ph name="PP" />. Může být odeslána SMS a mohou být účtovány poplatky za zprávy a data.</translation>
+<translation id="6265373887273416711">Ověřit telefonní číslo</translation>
+<translation id="6283536862756552051">Chcete-li změnit heslo, musíte nejprve zadat aktuální heslo.</translation>
+<translation id="6299890279889400823">Zpět</translation>
 <translation id="6316446940976157217">Indie</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Pokračovat</translation>
@@ -327,9 +327,9 @@
 <translation id="6443180961828792673">Kosovo</translation>
 <translation id="6450170205342035038">Bulharsko</translation>
 <translation id="6470057025778734988">Prostřednictvím tohoto účtu už se nebudete moci přihlásit.</translation>
-<translation id="6472297146424049005">Zkontrolujte připojení k internetu.</translation>
+<translation id="6472297146424049005">Zkontrolujte připojení k internetu.</translation>
 <translation id="6483116480230343278">Registrace…</translation>
-<translation id="6494734506607758748">Chcete-li změnit e-mailovou adresu přidruženou k vašemu účtu, musíte se znovu přihlásit.</translation>
+<translation id="6494734506607758748">Chcete-li změnit e-mailovou adresu přidruženou k vašemu účtu, musíte se znovu přihlásit.</translation>
 <translation id="6508909904815637928">Vanuatu</translation>
 <translation id="6520863029476703422">Americká Samoa</translation>
 <translation id="6527597037551425211">Brazílie</translation>
@@ -355,7 +355,7 @@
 <translation id="6769550797775698634">Kamerun</translation>
 <translation id="6775190982418995854">Špicberky a ostrov Jan Mayen</translation>
 <translation id="6775835872637240659">Ukrajina</translation>
-<translation id="6779584651193963121">Pokud žádné z uvedených řešení nepomohlo, můžete si e-mail nechat zaslat znovu. Odkaz v prvním e-mailu pak bude deaktivován.</translation>
+<translation id="6779584651193963121">Pokud žádné z uvedených řešení nepomohlo, můžete si e-mail nechat zaslat znovu. Odkaz v prvním e-mailu pak bude deaktivován.</translation>
 <translation id="6782010235320729294">Turkmenistán</translation>
 <translation id="6821607741326790458">Jamajka</translation>
 <translation id="6834335872619414720">GitHub</translation>
@@ -366,15 +366,15 @@
 <translation id="6921505896641453739">E-mail</translation>
 <translation id="6929813273561975780">Další</translation>
 <translation id="6951302238647056860">Platnost kódu vypršela</translation>
-<translation id="6961220857430789248">Na adresu <ph name="STRING" /> byl odeslán přihlašovací e-mail s dalšími pokyny. Dokončete přihlášení podle instrukcí v e-mailu.</translation>
+<translation id="6961220857430789248">Na adresu <ph name="STRING" /> byl odeslán přihlašovací e-mail s dalšími pokyny. Dokončete přihlášení podle instrukcí v e-mailu.</translation>
 <translation id="6984204927251307445">Potvrzení·e-mailu</translation>
 <translation id="6996552808101270965">Další informace</translation>
-<translation id="6999773882165218263">Jméno a příjmení</translation>
+<translation id="6999773882165218263">Jméno a příjmení</translation>
 <translation id="7012506961150923116">Grenada</translation>
 <translation id="7024571478138322659">Západní Sahara</translation>
-<translation id="7025117765722694556">V současném stavu systému nelze požadavek provést.</translation>
-<translation id="7062299334696934251">Došlo k neznámé chybě.</translation>
-<translation id="7064251114893721966">K přihlášení jste již použili adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Zadejte příslušné heslo k účtu.</translation>
+<translation id="7025117765722694556">V současném stavu systému nelze požadavek provést.</translation>
+<translation id="7062299334696934251">Došlo k neznámé chybě.</translation>
+<translation id="7064251114893721966">K přihlášení jste již použili adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Zadejte příslušné heslo k účtu.</translation>
 <translation id="7085136866191400000">Přihlašovací e-mail odeslán</translation>
 <translation id="7089485669419398254">Irsko</translation>
 <translation id="7093343209860483088">Demokratická republika Kongo</translation>
@@ -385,14 +385,14 @@
 <translation id="7192078949090526171">San Marino</translation>
 <translation id="7197455001919474950">Kypr</translation>
 <translation id="7198563013006562060">Šalamounovy ostrovy</translation>
-<translation id="7207660930894629055">Pokračovat s adresou <ph name="USER_EMAIL" />?</translation>
+<translation id="7207660930894629055">Pokračovat s adresou <ph name="USER_EMAIL" />?</translation>
 <translation id="720983450833499456">Abyste na tomto zařízení zůstali přihlášeni pomocí e-mailu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />, musíte si obnovit heslo.</translation>
 <translation id="7223410082658239002">Maledivy</translation>
 <translation id="7254028881697834212">Svatý Tomáš a Princův ostrov</translation>
 <translation id="7268827299582726485">Dokončete přihlášení potvrzním e-mailové adresy</translation>
 <translation id="7272145663101316762">Slovinsko</translation>
 <translation id="7280309713358692490">Jižní Korea</translation>
-<translation id="7283725113395426048">Konflikt souběžnosti, jako je konflikt mezi čtením, úpravou a psaním.</translation>
+<translation id="7283725113395426048">Konflikt souběžnosti, jako je konflikt mezi čtením, úpravou a psaním.</translation>
 <translation id="7290147808482957603">Metoda API nebyla implementována serverem.</translation>
 <translation id="7291567990403335374">Lesotho</translation>
 <translation id="7291656724505689727">Přihlášení pomocí telefonu</translation>
@@ -410,28 +410,28 @@
 <translation id="7592224526951017144">Německo</translation>
 <translation id="7595933825828475368">Nepřišel vám e-mail?</translation>
 <translation id="7615083347713899917">Kyrgyzstán</translation>
-<translation id="7643408533407091568">K přihlášení jste již použili adresu <ph name="EMAIL_ADDR" />.
-        Zadejte příslušné heslo k účtu.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znak a kombinaci písmen a číslic}few{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znaky a kombinaci písmen a číslic}many{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znaku a kombinaci písmen a číslic}other{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znaků a kombinaci písmen a číslic}}</translation>
+<translation id="7643408533407091568">K přihlášení jste již použili adresu <ph name="EMAIL_ADDR" />.
+        Zadejte příslušné heslo k účtu.</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znak a kombinaci písmen a číslic}few{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znaky a kombinaci písmen a číslic}many{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znaku a kombinaci písmen a číslic}other{Heslo není dostatečně silné. Použijte alespoň <ph name="PH_1" /> znaků a kombinaci písmen a číslic}}</translation>
 <translation id="7699755204074920022">Zimbabwe</translation>
 <translation id="7746977132739352062">Požadavek nebyl ověřen, protože token OAuth chybí, je neplatný nebo mu vypršela platnost.</translation>
-<translation id="7782885946428624225">Při ověřování telefonního čísla došlo k potížím</translation>
+<translation id="7782885946428624225">Při ověřování telefonního čísla došlo k potížím</translation>
 <translation id="7796914496604415892">Bylo rozpoznáno nové zařízení nebo prohlížeč</translation>
-<translation id="786166109137986817">Přihlásit se k účtu <ph name="DISPLAY_NAME" /></translation>
+<translation id="786166109137986817">Přihlásit se k účtu <ph name="DISPLAY_NAME" /></translation>
 <translation id="7868540442111212282">Česko</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Přihlásit se přes GitHub</translation>
 <translation id="792838323404934335">Grónsko</translation>
 <translation id="7956645158976161232">Libye</translation>
 <translation id="8017277252219866084">Keňa</translation>
-<translation id="8028653067082554952">Dojde k odstranění všech údajů souvisejících s vaším účtem. Tuto akci nebude možné vrátit zpět. Opravdu chcete účet smazat?</translation>
-<translation id="8033786138248870436">Po klepnutí na Ověřit může být odeslána SMS. Mohou být účtovány poplatky za zprávy a data.</translation>
+<translation id="8028653067082554952">Dojde k odstranění všech údajů souvisejících s vaším účtem. Tuto akci nebude možné vrátit zpět. Opravdu chcete účet smazat?</translation>
+<translation id="8033786138248870436">Po klepnutí na Ověřit může být odeslána SMS. Mohou být účtovány poplatky za zprávy a data.</translation>
 <translation id="8047183472745080590">Bolívie</translation>
 <translation id="8047565947836609247">Portoriko</translation>
 <translation id="8055755007915250245">Odpojit účet?</translation>
 <translation id="8063505483150915580">Vánoční ostrov</translation>
 <translation id="8077378925683571933">
-<ph name="P_START" />S pozdravem<ph name="P_END" />
+<ph name="P_START" />S pozdravem<ph name="P_END" />
 <ph name="P_START" />váš tým aplikace <ph name="APP_NAME" /><ph name="P_END" /></translation>
 <translation id="8138904368098176683">Súdán</translation>
 <translation id="815425460105074455">Bahamy</translation>
@@ -483,26 +483,26 @@
 <translation id="8869797682387766327">Ostrov Man</translation>
 <translation id="8893950153780006385">Malajsie</translation>
 <translation id="8895840173743975193">Kokosové ostrovy</translation>
-<translation id="8916080112145514151">Pokud stále chcete připojit svůj účet <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, otevřete odkaz na zařízení, na kterém jste s přihlášením začali. Jinak klepněte na Pokračovat a přihlaste se na tomto zařízení.</translation>
+<translation id="8916080112145514151">Pokud stále chcete připojit svůj účet <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, otevřete odkaz na zařízení, na kterém jste s přihlášením začali. Jinak klepněte na Pokračovat a přihlaste se na tomto zařízení.</translation>
 <translation id="8920674952994839257">Znovu</translation>
 <translation id="8939353296336237380">Původně jste chtěli připojit <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> ke svému e-mailovému účtu, ale otevřeli jste odkaz na jiném zařízení, na kterém nejste přihlášeni.</translation>
-<translation id="8971555482255213064">Znovu zaslat kód za 0:<ph name="PH_1" /></translation>
+<translation id="8971555482255213064">Znovu zaslat kód za 0:<ph name="PH_1" /></translation>
 <translation id="8984161590699631096">Maroko</translation>
-<translation id="8994098794339484800">Pokud toto zařízení nepoznáváte, někdo se možná snaží získat přístup k vašemu účtu. Zvažte <ph name="START_LINK" />okamžitou změnu hesla<ph name="END_LINK" />.</translation>
+<translation id="8994098794339484800">Pokud toto zařízení nepoznáváte, někdo se možná snaží získat přístup k vašemu účtu. Zvažte <ph name="START_LINK" />okamžitou změnu hesla<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladéš</translation>
 <translation id="9022632332691561239">Telefon</translation>
 <translation id="9028063588419847334">Finsko</translation>
 <translation id="9078135685219203661">Spojené Arabské Emiráty</translation>
-<translation id="9121203582272050974">Vás e-mail byl ověren a změněn</translation>
+<translation id="9121203582272050974">Vás e-mail byl ověren a změněn</translation>
 <translation id="9156150178611681179">Heslo</translation>
 <translation id="9168877696443530714">Středoafrická republika</translation>
 <translation id="9186194643192393179">Curaçao</translation>
-<translation id="9193130710600355008">Kvůli neobvyklé aktivitě jsme zablokovali všechny požadavky z tohoto zařízení. Zkuste to znovu později.</translation>
+<translation id="9193130710600355008">Kvůli neobvyklé aktivitě jsme zablokovali všechny požadavky z tohoto zařízení. Zkuste to znovu později.</translation>
 <translation id="919456844206936371">Tunisko</translation>
 <translation id="9209678713072395487">Heslo bylo změněno</translation>
 <translation id="954276184636809129">Řecko</translation>
 <translation id="959388308828818789">Druhý faktor odebrán</translation>
 <translation id="965930633376049617">Angola</translation>
 <translation id="988087302893519488">Kuvajt</translation>
-<translation id="994914101700264849">Zadaný e-mail a heslo se neshodují</translation>
+<translation id="994914101700264849">Zadaný e-mail a heslo se neshodují</translation>
 </translationbundle>

--- a/translations/da.xtb
+++ b/translations/da.xtb
@@ -1,6 +1,6 @@
 <translationbundle lang="da">
 <translation id="1003362845472634045">Loginmail sendt</translation>
-<translation id="10081113082271688">Forkert bekræftelseskode</translation>
+<translation id="10081113082271688">Forkert verificeringskode</translation>
 <translation id="1024070574104100559">St. Vincent</translation>
 <translation id="1080228854514607739">Maillinket er ugyldigt. Dette kan skyldes, at maillinket er udløbet, eller at du allerede har brugt det til at logge ind. Genstart loginprocessen.</translation>
 <translation id="1088824719285122027">Dette telefonnummer er blevet brugt for mange gange</translation>
@@ -21,7 +21,7 @@
 <translation id="1310034618729602982">Prøv at opdatere din mail igen</translation>
 <translation id="1312824004897469797">Der er opstået en netværksfejl. Prøv igen senere.</translation>
 <translation id="1315809131562953678">Angiv et gyldigt telefonnummer</translation>
-<translation id="1335716056288807013">Ved at trykke på Bekræft accepterer du vores <ph name="START_LINK_1" />Servicevilkår<ph name="END_LINK" /> og <ph name="START_LINK_2" />Privatlivspolitik<ph name="END_LINK" />. Der bliver evt. sendt en sms. Der opkræves muligvis gebyrer for beskeder og data.</translation>
+<translation id="1335716056288807013">Ved at trykke på Verificer accepterer du vores <ph name="START_LINK_1" />Servicevilkår<ph name="END_LINK" /> og <ph name="START_LINK_2" />Privatlivspolitik<ph name="END_LINK" />. Der bliver evt. sendt en sms. Der opkræves muligvis gebyrer for beskeder og data.</translation>
 <translation id="137210131544215127">Angiv din adgangskode</translation>
 <translation id="1393433815796487579">Udført</translation>
 <translation id="1412449974349991050">Haiti</translation>
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Cookøerne</translation>
 <translation id="1870056762032541323">Koden er forkert. Prøv igen.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hej <ph name="DISPLAY_NAME" /><ph name="P_END" /></translation>
-<translation id="1966996824429980990">Slet konto</translation>
+<translation id="1912929493041975510">Adgangskoden skal være på mindst 6 tegn</translation>
+<translation id="1933044638365301516">Log ind med <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Angiv den 6-cifrede kode, vi sendte til <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Følg vejledningen, der blev sendt til <ph name="PH_1" />, for at gendanne din adgangskode.</translation>
 <translation id="2035855087334775326">Ungarn</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">USA</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Stærke adgangskoder har mindst 6 tegn og en blanding af bogstaver og tal</translation>
 <translation id="2074008538308369451">Servicevilkår</translation>
 <translation id="2089802663554186342">Sessionen er afsluttet</translation>
 <translation id="2108717231438756650">Storbritannien og Nordirland</translation>
@@ -62,7 +61,7 @@
 <translation id="2124070231227334770">Moldova</translation>
 <translation id="2124843735553988177">Godkend de nødvendige tilladelser for at logge ind på applikationen</translation>
 <translation id="2130553359919781209">Malawi</translation>
-<translation id="2187260952722791093">Bekræftet!</translation>
+<translation id="2187260952722791093">Verificeret!</translation>
 <translation id="2192561962270021282">Angiv dit telefonnummer</translation>
 <translation id="2206856445831770486">GitHub</translation>
 <translation id="2223717216014247341">Privatlivspolitik</translation>
@@ -110,7 +109,7 @@
 <translation id="2674823936234616183">Usbekistan</translation>
 <translation id="2696162410887720551">Ålandsøerne</translation>
 <translation id="2725769874498146298">Din login-session er udløbet. Prøv igen.</translation>
-<translation id="2741235824871026219">Bekræft</translation>
+<translation id="2741235824871026219">Verificer</translation>
 <translation id="2752984808025184019">Sydafrika</translation>
 <translation id="2760636260031093254">Angiv din mailadresse for at fortsætte</translation>
 <translation id="276938411216176478">Brugerkontoen er blevet deaktiveret af en administrator.</translation>
@@ -134,7 +133,7 @@
 <translation id="3154748063569624719">Du ønskede oprindeligt at logge ind med <ph name="PENDING_EMAIL" /></translation>
 <translation id="3164676761565983157">Venezuela</translation>
 <translation id="3170526549630869494">Har du problemer med at logge ind?</translation>
-<translation id="3204914819635733576">Bekræft, at det er dig</translation>
+<translation id="3204914819635733576">Verificer, at det er dig</translation>
 <translation id="3215050409577090361">Der opstod et problem under godkendelsen af din anmodning. Gå endnu en gang til den webadresse, der omdirigerede dig til denne side, for at påbegynde godkendelsesprocessen igen.</translation>
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">Ny adgangskode</translation>
@@ -173,17 +172,17 @@
 <translation id="3736041829854387744">Burundi</translation>
 <translation id="3755663127769565780">Mauretanien</translation>
 <translation id="3813801701232240278">Twitter</translation>
-<translation id="3814740523815122846">Din mail er blevet bekræftet</translation>
+<translation id="3814740523815122846">Din mail er blevet verificeret</translation>
 <translation id="3819556544383051267">Papua Ny Guinea</translation>
 <translation id="3828991952827504549">Den angivne ressource blev ikke fundet.</translation>
-<translation id="3862053977934420187">Bekræfter…</translation>
+<translation id="3862053977934420187">Verificerer…</translation>
 <translation id="3898029444496274961">Log ind</translation>
 <translation id="3905423743526704083">Østtimor</translation>
 <translation id="3908950705971364393">Djibouti</translation>
 <translation id="3954166521214262397">6-cifret kode</translation>
 <translation id="3987987513436822097">Comorerne</translation>
 <translation id="4009306200855295525">Land</translation>
-<translation id="4021489444336102711">Bekræft</translation>
+<translation id="4021489444336102711">Verificer</translation>
 <translation id="4022450612826261789">Kosovo</translation>
 <translation id="4025579119565425333">Prøv disse almindelige løsninger:</translation>
 <translation id="4056653682525186486">Log ind med <ph name="XXX" /></translation>
@@ -230,8 +229,8 @@
 <translation id="4871106926303956169">Turks- og Caicosøerne</translation>
 <translation id="4877597386645466815">Send koden igen om <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
-<ph name="P_START" />Din konto i <ph name="APP_NAME" /> er blevet opdateret med et telefonnummer til totrinsbekræftelse, der slutter på <ph name="SECOND_FACTOR" />.<ph name="P_END" />
-<ph name="P_START" />Hvis det ikke er dig, der har tilføjet dette telefonnummer til totrinsbekræftelse, skal du klikke på nedenstående link for at fjerne det.<ph name="P_END" />
+<ph name="P_START" />Din konto i <ph name="APP_NAME" /> er blevet opdateret med et telefonnummer til totrinsverificering, der slutter på <ph name="SECOND_FACTOR" />.<ph name="P_END" />
+<ph name="P_START" />Hvis det ikke er dig, der har tilføjet dette telefonnummer til totrinsverificering, skal du klikke på nedenstående link for at fjerne det.<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="4923375331439013137">Kunne ikke fjerne din anden faktor</translation>
 <translation id="4955175001894453989">Tilføj adgangskode</translation>
@@ -243,12 +242,12 @@
 <translation id="5059105734231232362">Hvis det skal lykkes at knytte din <ph name="IDP_DISPLAY_NAME" />-konto til mailadressen på denne måde, skal du åbne linket med den samme enhed eller i samme browser.</translation>
 <translation id="5080084639513001393">Sverige</translation>
 <translation id="5080899604429810481">Saint-Martin</translation>
-<translation id="5115661695221894994"><ph name="START_PARAGRAPH" />Din anmodning om at bekræfte og opdatere din mail er udløbet, eller linket er allerede blevet brugt.<ph name="END_PARAGRAPH" /></translation>
+<translation id="5115661695221894994"><ph name="START_PARAGRAPH" />Din anmodning om at verificere og opdatere din mail er udløbet, eller linket er allerede blevet brugt.<ph name="END_PARAGRAPH" /></translation>
 <translation id="5143657419516597442">St. Lucia</translation>
 <translation id="521218078240459724">@string/app_name</translation>
 <translation id="5241732101105320538">Tjek din mail</translation>
 <translation id="5255830932650472373">Ny adgangskode</translation>
-<translation id="5301108536112812420">Din anmodning om at bekræfte din mail er udløbet, eller linket er allerede brugt</translation>
+<translation id="5301108536112812420">Din anmodning om at verificere din mail er udløbet, eller linket er allerede brugt</translation>
 <translation id="5323041129469627535">Oman</translation>
 <translation id="5326139833547026317">Hollandsk Caribien</translation>
 <translation id="5347459868860672391">Opdateret mailadresse</translation>
@@ -282,7 +281,7 @@
 <translation id="5664080586064341046">St. Kitts</translation>
 <translation id="5668881954117611594">Tilbage</translation>
 <translation id="5699028034244995851">Angiv din mailadresse for at fortsætte</translation>
-<translation id="5701178667798108817">Bekræft dit telefonnummer</translation>
+<translation id="5701178667798108817">Verificer dit telefonnummer</translation>
 <translation id="5715637701147651513">Liberia</translation>
 <translation id="5747263508495256858">Log ud</translation>
 <translation id="5771034676910614239">Madagaskar</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Algeriet</translation>
 <translation id="6213969168046789596">Du har indtastet en forkert adgangskode for mange gange. Prøv igen om et par minutter.</translation>
 <translation id="6216759405419177713">Norfolkøen</translation>
-<translation id="6245066275978703471">Telefonnummeret blev bekræftet automatisk</translation>
-<translation id="6269083314054226194">Netværksfejl. Tjek din internetforbindelse.</translation>
-<translation id="6295157125625453859">Bekræftet!</translation>
+<translation id="6238170540438416559">Når du trykker på "<ph name="PH_1" />", indikerer du, at du accepterer vores <ph name="PP" />. Der sendes måske en sms. Der opkræves muligvis gebyrer for beskeder og data.</translation>
+<translation id="6265373887273416711">Verificer dit telefonnummer</translation>
+<translation id="6283536862756552051">For at ændre din adgangskode skal du først angive din nuværende adgangskode.</translation>
+<translation id="6299890279889400823">Tilbage</translation>
 <translation id="6316446940976157217">Indien</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Fortsæt</translation>
@@ -396,7 +396,7 @@
 <translation id="7290147808482957603">API-metoden blev ikke implementeret af serveren.</translation>
 <translation id="7291567990403335374">Lesotho</translation>
 <translation id="7291656724505689727">Log ind med telefon</translation>
-<translation id="7320029088567935126">Prøv at bekræfte din mail igen</translation>
+<translation id="7320029088567935126">Prøv at verificere din mail igen</translation>
 <translation id="7331038350037712642">Aserbajdsjan</translation>
 <translation id="7359542696390093035">Tilladelse mangler</translation>
 <translation id="743266754881673808">Google</translation>
@@ -415,7 +415,7 @@
 <translation id="7652546345268886994">{plural_var,plural, =1{Adgangskoden er ikke stærk nok. Brug mindst <ph name="PH_1" /> tegn og en blanding af bogstaver og tal}one{Adgangskoden er ikke stærk nok. Brug mindst <ph name="PH_1" /> tegn og en blanding af bogstaver og tal}other{Adgangskoden er ikke stærk nok. Brug mindst <ph name="PH_1" /> tegn og en blanding af bogstaver og tal}}</translation>
 <translation id="7699755204074920022">Zimbabwe</translation>
 <translation id="7746977132739352062">Anmodningen blev ikke godkendt på grund af manglende, ugyldigt eller udløbet OAuth-token.</translation>
-<translation id="7782885946428624225">Dit telefonnummer kunne ikke bekræftes</translation>
+<translation id="7782885946428624225">Dit telefonnummer kunne ikke verificeres</translation>
 <translation id="7796914496604415892">Der er registreret en ny enhed eller browser</translation>
 <translation id="786166109137986817">Log ind på <ph name="DISPLAY_NAME" /></translation>
 <translation id="7868540442111212282">Tjekkiet</translation>
@@ -425,7 +425,7 @@
 <translation id="7956645158976161232">Libyen</translation>
 <translation id="8017277252219866084">Kenya</translation>
 <translation id="8028653067082554952">Dette vil slette alle data, der er knyttet til din konto, og kan ikke fortrydes. Er du sikker på, at du vil slette din konto?</translation>
-<translation id="8033786138248870436">Der sendes en sms, når du trykker på Bekræft. Der opkræves muligvis gebyrer for beskeder og data.</translation>
+<translation id="8033786138248870436">Der sendes en sms, når du trykker på Verificer. Der opkræves muligvis gebyrer for beskeder og data.</translation>
 <translation id="8047183472745080590">Bolivia</translation>
 <translation id="8047565947836609247">Puerto Rico</translation>
 <translation id="8055755007915250245">Fjern tilknytning til konto?</translation>
@@ -458,7 +458,7 @@
 <translation id="847294590390666986">Taiwan</translation>
 <translation id="8477554788963470892">Sierra Leone</translation>
 <translation id="8498398269542501379">Tjek, om mailen er blevet markeret som spam eller filtreret fra.</translation>
-<translation id="8505200776212389923">Bekræfter…</translation>
+<translation id="8505200776212389923">Verificerer…</translation>
 <translation id="8505941919386646914">Martinique</translation>
 <translation id="8534746304953308378">Togo</translation>
 <translation id="8572093925387077451">Du har allerede en konto</translation>
@@ -477,7 +477,7 @@
 <translation id="877434849857020571">Guernsey</translation>
 <translation id="8784650258250067845">Nigeria</translation>
 <translation id="8826577014688910360">Nordkorea</translation>
-<translation id="8833554344900398690"><ph name="IDV_CODE_PLACE_HOLDER" /> er din bekræftelseskode.</translation>
+<translation id="8833554344900398690"><ph name="IDV_CODE_PLACE_HOLDER" /> er din verificeringskode.</translation>
 <translation id="8835993416611657377">Mexico</translation>
 <translation id="884992060285817042">Bhutan</translation>
 <translation id="8869797682387766327">Isle of Man</translation>
@@ -493,7 +493,7 @@
 <translation id="9022632332691561239">Telefon</translation>
 <translation id="9028063588419847334">Finland</translation>
 <translation id="9078135685219203661">Forenede Arabiske Emirater</translation>
-<translation id="9121203582272050974">Din mail er blevet bekræftet og ændret</translation>
+<translation id="9121203582272050974">Din mail er blevet verificeret og ændret</translation>
 <translation id="9156150178611681179">Adgangskode</translation>
 <translation id="9168877696443530714">Den Centralafrikanske Republik</translation>
 <translation id="9186194643192393179">Curaçao</translation>

--- a/translations/de.xtb
+++ b/translations/de.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">Über Ihre IP-Adresse werden zu viele Kontoanfragen gesendet. Bitte versuchen Sie es in einigen Minuten noch einmal.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Sie können sich jetzt mit Ihrem neuen Konto anmelden</translation>
+<translation id="1535200361681091160">E-Mail-Adresse eingeben</translation>
 <translation id="1544981664986460902">Der Client hat ein ungültiges Argument angegeben.</translation>
 <translation id="1575848116712334589">Tschad</translation>
 <translation id="1630237004390596779">Code in <ph name="STRING" /> erneut senden</translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Cookinseln</translation>
 <translation id="1870056762032541323">Falscher Code. Versuchen Sie es noch einmal.</translation>
 <translation id="1898579907513173256">Macau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hallo <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Konto löschen</translation>
+<translation id="1912929493041975510">Das Passwort muss aus mindestens 6 Zeichen bestehen</translation>
+<translation id="1933044638365301516">Mit <ph name="STRING" /> anmelden</translation>
 <translation id="1987722456379605552">Geben Sie den 6-stelligen Code ein, den wir an <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /> gesendet haben</translation>
-<translation id="2016421613709283485">Folgen Sie der an <ph name="PH_1" /> gesendeten Anleitung, um Ihr Passwort zurückzusetzen.</translation>
+<translation id="1999379687946415948"><ph name="IDV_CODE_PLACE_HOLDER" /> ist Ihr Code für <ph name="APP_NAME" />.</translation>
+<translation id="2033662766890821456">Code erneut senden</translation>
 <translation id="2035855087334775326">Ungarn</translation>
 <translation id="2040904406955887821">Suriname</translation>
 <translation id="2046207054419739276">USA</translation>
 <translation id="2049229571938383319">St. Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Starke Passwörter umfassen mindestens sechs Zeichen und eine Mischung aus Buchstaben und Ziffern</translation>
 <translation id="2074008538308369451">Nutzungsbedingungen</translation>
 <translation id="2089802663554186342">Sitzung beendet</translation>
 <translation id="2108717231438756650">Vereinigtes Königreich</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Cabo Verde</translation>
 <translation id="2301396996587599046">Mazedonien</translation>
 <translation id="2310948428656960769">Angemeldet.</translation>
+<translation id="2321152797538991921">Das Passwort muss ein nicht alphanumerisches Zeichen enthalten</translation>
 <translation id="2324942959480650701">Gast</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">Ihr Browser unterstützt Web Storage nicht. Bitte versuchen Sie es mit einem anderen Browser.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">Bei der Authentifizierung Ihrer Anfrage ist ein Problem aufgetreten. Rufen Sie die URL, über die Sie auf diese Seite weitergeleitet wurden, bitte noch einmal auf und starten Sie den Authentifizierungsprozess neu.</translation>
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">Neues Passwort</translation>
+<translation id="3245143966477136343">Das Passwort muss einen Kleinbuchstaben enthalten</translation>
 <translation id="3250864391349648273">Gabun</translation>
 <translation id="3259479674319858599">Sie haben <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> bereits verwendet. Melden Sie sich mit <ph name="IDP_DISPLAY_NAME" /> an, um fortzufahren.</translation>
 <translation id="3275852444431525182">Neuseeland</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Folgen Sie der an <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> gesendeten Anleitung, um Ihr Passwort zurückzusetzen</translation>
 <translation id="4588392627302012849">Mit E-Mail-Adresse anmelden</translation>
 <translation id="4595119411041064617">Wenn Sie auf "<ph name="PH_1" />" tippen, erhalten Sie möglicherweise eine SMS. Es können Gebühren für SMS und Datenübertragung anfallen.</translation>
+<translation id="4603232692404395592">Das Passwort darf höchstens <ph name="MAX_PASSWORD_LENGTH" /> Zeichen enthalten</translation>
 <translation id="4632709875751031323">Russland</translation>
 <translation id="4644169548516814280">Die E-Mail-Adresse wird bereits für ein anderes Konto verwendet</translation>
 <translation id="4692014002063276828">Polen</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Überprüfen Sie den Speicherplatz und weitere Einstellungen Ihres Posteingangs, die Probleme bereiten könnten.</translation>
 <translation id="6135589730599211649">Der Client hat einen ungültigen Bereich angegeben.</translation>
 <translation id="6143147250106939258">Das Kontingent für diesen Vorgang wurde überschritten. Versuchen Sie es später noch einmal.</translation>
+<translation id="615787395595800956">Passwortanforderungen nicht erfüllt:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Algerien</translation>
 <translation id="6213969168046789596">Sie haben zu oft ein falsches Passwort eingegeben. Bitte versuchen Sie es in einigen Minuten noch einmal.</translation>
 <translation id="6216759405419177713">Norfolkinsel</translation>
-<translation id="6245066275978703471">Telefonnummer wurde automatisch bestätigt</translation>
-<translation id="6269083314054226194">Netzwerkfehler. Überprüfen Sie Ihre Internetverbindung.</translation>
-<translation id="6295157125625453859">Bestätigt</translation>
+<translation id="6238170540438416559">Indem Sie auf "<ph name="PH_1" />" tippen, stimmen Sie unserer <ph name="PP" /> zu. Sie erhalten möglicherweise eine SMS und es können Gebühren für die Nachricht und die Datenübertragung anfallen.</translation>
+<translation id="6265373887273416711">Telefonnummer bestätigen</translation>
+<translation id="6283536862756552051">Um das Passwort zu ändern, müssen Sie zuerst Ihr aktuelles Passwort eingeben.</translation>
+<translation id="6299890279889400823">Zurück</translation>
 <translation id="6316446940976157217">Indien</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Weiter</translation>
+<translation id="6355621963154078138">Das Passwort muss ein numerisches Zeichen enthalten</translation>
 <translation id="6359400968059656782">Sie können sich jetzt mit Ihrem neuen Passwort anmelden</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxemburg</translation>
@@ -412,13 +419,14 @@
 <translation id="7595933825828475368">Probleme beim Empfangen von E-Mails?</translation>
 <translation id="7615083347713899917">Kirgisistan</translation>
 <translation id="7643408533407091568">Sie haben <ph name="EMAIL_ADDR" /> bereits zur Anmeldung verwendet. Geben Sie das Passwort für dieses Konto ein.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Das Passwort ist zu schwach. Verwenden Sie mindestens <ph name="PH_1" /> Zeichen und eine Mischung aus Buchstaben und Ziffern.}other{Das Passwort ist zu schwach. Verwenden Sie mindestens <ph name="PH_1" /> Zeichen und eine Mischung aus Buchstaben und Ziffern.}}</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Das Passwort ist zu schwach. Verwenden Sie mindestens <ph name="PH_1" /> Zeichen und eine Mischung aus Buchstaben und Ziffern.}other{Das Passwort ist zu schwach. Verwenden Sie mindestens <ph name="PH_1" /> Zeichen und eine Mischung aus Buchstaben und Ziffern.}}</translation>
 <translation id="7699755204074920022">Simbabwe</translation>
 <translation id="7746977132739352062">Die Anfrage konnte aufgrund eines fehlenden, ungültigen oder abgelaufenen OAuth-Tokens nicht authentifiziert werden.</translation>
 <translation id="7778245738233381641">Gib einen sechsstelligen Bestätigungscode für die Telefonnummer an.</translation>
 <translation id="7790301903034097323">Passwort auswählen</translation>
 <translation id="7796914496604415892">Neues Gerät oder neuer Browser erkannt</translation>
 <translation id="786166109137986817">Jetzt in <ph name="DISPLAY_NAME" /> anmelden</translation>
+<translation id="7863575218808091551">Das Passwort muss einen Großbuchstaben enthalten</translation>
 <translation id="7868540442111212282">Tschechien</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Über GitHub anmelden</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151">Wenn Sie Ihr <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />-Konto weiterhin verbinden möchten, öffnen Sie den Link bitte auf dem Gerät, auf dem Sie den Anmeldevorgang gestartet haben. Andernfalls tippen Sie auf "Weiter", um sich auf diesem Gerät anzumelden.</translation>
 <translation id="8920674952994839257">Wiederholen</translation>
 <translation id="8939353296336237380">Sie haben versucht, <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> auf einem Gerät, auf dem Sie nicht angemeldet sind, mit Ihrem E-Mail-Konto zu verbinden.</translation>
-<translation id="8971555482255213064">Code in 0:<ph name="PH_1" /> erneut senden</translation>
+<translation id="8955469172512804617">Durch Tippen auf <ph name="BTN" /> stimmen Sie der <ph name="PP" /> zu.</translation>
+<translation id="8980953965669178372">Fertig</translation>
 <translation id="8984161590699631096">Marokko</translation>
 <translation id="8994098794339484800">Wenn Sie dieses Gerät nicht kennen, versucht möglicherweise jemand, auf Ihr Konto zuzugreifen. Sie sollten Ihr <ph name="START_LINK" />Passwort sofort ändern<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesch</translation>
 <translation id="9022632332691561239">Telefonnummer</translation>
 <translation id="9028063588419847334">Irland</translation>
 <translation id="9078135685219203661">Vereinigte Arabische Emirate</translation>
+<translation id="9085311482535098646">Das Passwort muss mindestens <ph name="MIN_PASSWORD_LENGTH" /> Zeichen enthalten</translation>
 <translation id="9121203582272050974">Ihr E-Mail-Adresse wurde überprüft und geändert</translation>
 <translation id="9156150178611681179">Passwort</translation>
 <translation id="9168877696443530714">Zentralafrikanische Republik</translation>

--- a/translations/el.xtb
+++ b/translations/el.xtb
@@ -8,7 +8,7 @@
 <translation id="1130401182255828006">Λετονία</translation>
 <translation id="1133565039750742069">Αποθήκευση</translation>
 <translation id="1139115784936170936">Σιγκαπούρη</translation>
-<translation id="1163494479861953195">Συνδεθείτε ξανά για να εκτελέσετε αυτήν την ενέργεια</translation>
+<translation id="1163494479861953195">Συνδεθείτε ξανά για να εκτελέσετε αυτή την ενέργεια</translation>
 <translation id="1163771673786684213">Φιλιππίνες</translation>
 <translation id="1170304454812139475">Ρουμανία</translation>
 <translation id="1194565221977667376">Νότια Γεωργία και Νότιες Νήσοι Σάντουιτς</translation>
@@ -42,11 +42,11 @@
 <translation id="1772888465204630090">Αν πατήσετε "Συνέχεια", δηλώνετε ότι συμφωνείτε με τους <ph name="START_LINK" />Όρους Παροχής Υπηρεσιών<ph name="END_LINK" /></translation>
 <translation id="177937029926612729">Αρμενία</translation>
 <translation id="179194004476893686">Βοσνία Ερζεγοβίνη</translation>
-<translation id="1799407952500261728">Νησιά Κουκ</translation>
+<translation id="1799407952500261728">Νήσοι Κουκ</translation>
 <translation id="1870056762032541323">Εσφαλμένος κωδικός. Δοκιμάστε ξανά.</translation>
 <translation id="1898579907513173256">Μακάο</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Γεια σας <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Διαγραφή λογαριασμού</translation>
+<translation id="1912929493041975510">Ο κωδικός πρόσβασης πρέπει να αποτελείται τουλάχιστον από 6 χαρακτήρες</translation>
+<translation id="1933044638365301516">Σύνδεση μέσω <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Εισαγάγετε τον 6ψήφιο κωδικό που στείλαμε στο <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Ακολουθήστε τις οδηγίες που στάλθηκαν στο <ph name="PH_1" /> για να ανακτήσετε τον κωδικό πρόσβασής σας.</translation>
 <translation id="2035855087334775326">Ουγγαρία</translation>
@@ -54,11 +54,10 @@
 <translation id="2046207054419739276">Ηνωμένες Πολιτείες</translation>
 <translation id="2049229571938383319">Άγιος Βαρθολομαίος</translation>
 <translation id="2058731785647385204">Μοντσεράτ</translation>
-<translation id="2070709910567585968">Οι ισχυροί κωδικοί πρόσβασης έχουν τουλάχιστον 6 χαρακτήρες και έναν συνδυασμό γραμμάτων και αριθμών</translation>
 <translation id="2074008538308369451">Όροι Παροχής Υπηρεσιών</translation>
 <translation id="2089802663554186342">Η περίοδος σύνδεσης έληξε</translation>
 <translation id="2108717231438756650">Ηνωμένο Βασίλειο</translation>
-<translation id="2120419640334291526">Νησιά Κέιμαν</translation>
+<translation id="2120419640334291526">Νήσοι Κέιμαν</translation>
 <translation id="2124070231227334770">Μολδαβία</translation>
 <translation id="2124843735553988177">Παραχωρήστε τα απαραίτητα δικαιώματα για να συνδεθείτε στην εφαρμογή</translation>
 <translation id="2130553359919781209">Μαλάουι</translation>
@@ -103,7 +102,7 @@
 <translation id="2621854044487969847">Βρετανικές Παρθένοι Νήσοι</translation>
 <translation id="2623430226615357954">Παράβλεψη</translation>
 <translation id="2626214972556632989">Εισαγάγετε έναν έγκυρο αριθμό τηλεφώνου</translation>
-<translation id="2652952163277051394">Αυτός ο τύπος λογαριασμού δεν υποστηρίζεται από αυτήν την εφαρμογή</translation>
+<translation id="2652952163277051394">Αυτός ο τύπος λογαριασμού δεν υποστηρίζεται από αυτή την εφαρμογή</translation>
 <translation id="2660271277401013037">Ο κωδικός ενέργειας δεν είναι έγκυρος. Αυτό μπορεί να συμβεί αν ο κωδικός έχει λανθασμένη μορφή, έχει λήξει ή χρησιμοποιείται ήδη.</translation>
 <translation id="2665022736179407256">Αυτός ο κωδικός έληξε.</translation>
 <translation id="2668496398414877352">Κόσοβο</translation>
@@ -227,7 +226,7 @@
 <translation id="4783400389150493171">Μπουρκίνα Φάσο</translation>
 <translation id="4852256440857413490">Εσφαλμένος κωδικός. Δοκιμάστε ξανά.</translation>
 <translation id="4866990546854875813">Η περίοδος σύνδεσης που συσχετίζεται με το αίτημα σύνδεσης είτε έληξε είτε διαγράφηκε.</translation>
-<translation id="4871106926303956169">Νησιά Τερκ και Κάικος</translation>
+<translation id="4871106926303956169">Νήσοι Τερκ και Κάικος</translation>
 <translation id="4877597386645466815">Επανάληψη αποστολής κωδικού σε <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
 <ph name="P_START" />Ο λογαριασμός σας στην εφαρμογή <ph name="APP_NAME" /> ενημερώθηκε με έναν αριθμό τηλεφώνου <ph name="SECOND_FACTOR" /> για την επαλήθευση σε 2 βήματα.<ph name="P_END" />
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Αλγερία</translation>
 <translation id="6213969168046789596">Εισαγάγατε λανθασμένο κωδικό πρόσβασης πολλές φορές. Δοκιμάστε ξανά σε μερικά λεπτά.</translation>
 <translation id="6216759405419177713">Νήσος Νόρφολκ</translation>
-<translation id="6245066275978703471">Ο αριθμός τηλεφώνου επαληθεύτηκε αυτόματα</translation>
-<translation id="6269083314054226194">Σφάλμα δικτύου, ελέγξτε τη σύνδεση στο διαδίκτυο.</translation>
-<translation id="6295157125625453859">Επαληθεύτηκε!</translation>
+<translation id="6238170540438416559">Αν πατήσετε "<ph name="PH_1" />", δηλώνετε ότι αποδέχεστε την <ph name="PP" />. Μπορεί να σταλεί ένα SMS. Ενδέχεται να ισχύουν χρεώσεις μηνυμάτων και δεδομένων.</translation>
+<translation id="6265373887273416711">Επαλήθευση του τηλεφώνου σας</translation>
+<translation id="6283536862756552051">Για να αλλάξετε τον κωδικό πρόσβασής σας, θα πρέπει πρώτα να εισαγάγετε τον τρέχοντα κωδικό πρόσβασης.</translation>
+<translation id="6299890279889400823">Πίσω</translation>
 <translation id="6316446940976157217">Ινδία</translation>
 <translation id="6327723482938582895">Μπενίν</translation>
 <translation id="6338643731889005578">Συνέχεια</translation>
@@ -355,7 +355,7 @@
 <translation id="6769550797775698634">Καμερούν</translation>
 <translation id="6775190982418995854">Νήσοι Σβάλμπαρντ και Γιαν Μάγεν</translation>
 <translation id="6775835872637240659">Ουκρανικά</translation>
-<translation id="6779584651193963121">Αν τα παραπάνω βήματα δεν λειτούργησαν, μπορείτε να στείλετε ξανά το μήνυμα ηλεκτρονικού ταχυδρομείου. Έχετε υπόψη ότι με αυτήν την ενέργεια, ο σύνδεσμος στο παλιότερο μήνυμα ηλεκτρονικού ταχυδρομείου θα απενεργοποιηθεί.</translation>
+<translation id="6779584651193963121">Αν τα παραπάνω βήματα δεν λειτούργησαν, μπορείτε να στείλετε ξανά το μήνυμα ηλεκτρονικού ταχυδρομείου. Έχετε υπόψη ότι με αυτή την ενέργεια, ο σύνδεσμος στο παλιότερο μήνυμα ηλεκτρονικού ταχυδρομείου θα απενεργοποιηθεί.</translation>
 <translation id="6782010235320729294">Τουρκμενιστάν</translation>
 <translation id="6821607741326790458">Τζαμάικα</translation>
 <translation id="6834335872619414720">GitHub</translation>
@@ -445,10 +445,10 @@
 <translation id="8340009229650375501">Κατάρ</translation>
 <translation id="8347635771101835254">Ουρουγουάη</translation>
 <translation id="8356629306226578917">Αίγυπτος</translation>
-<translation id="8361109291694366329">Νησιά Μάρσαλ</translation>
+<translation id="8361109291694366329">Νήσοι Μάρσαλ</translation>
 <translation id="8371947480506692029">Άγιος Μαρτίνος</translation>
 <translation id="8395242001819210481">Αντίγκουα και Μπαρμπούντα</translation>
-<translation id="8399150401520737446">Νησιά Βόρειες Μαριάννες</translation>
+<translation id="8399150401520737446">Νήσοι Βόρειες Μαριάννες</translation>
 <translation id="8414177484126578295">Νήσοι Φώκλαντ</translation>
 <translation id="8420860857100049136">Περού</translation>
 <translation id="8422843028108996485">Τρέχων κωδικός πρόσβασης</translation>
@@ -482,7 +482,7 @@
 <translation id="884992060285817042">Μπουτάν</translation>
 <translation id="8869797682387766327">Νήσος Μαν</translation>
 <translation id="8893950153780006385">Μαλαισία</translation>
-<translation id="8895840173743975193">Νησιά Κόκος (Κήλινγκ)</translation>
+<translation id="8895840173743975193">Νήσοι Κόκος (Κήλινγκ)</translation>
 <translation id="8916080112145514151">Αν εξακολουθείτε να θέλετε να συνδέσετε τον λογαριασμό σας <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, ανοίξτε τον σύνδεσμο από την ίδια συσκευή από την οποία ξεκινήσατε τη σύνδεση. Διαφορετικά, πατήστε Συνέχεια για να συνδεθείτε από αυτήν τη συσκευή.</translation>
 <translation id="8920674952994839257">Επανάληψη</translation>
 <translation id="8939353296336237380">Σκοπεύατε να συνδέσετε το <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> με τον λογαριασμό ηλεκτρονικού σας ταχυδρομείου, αλλά χρησιμοποιήσατε άλλη συσκευή για το άνοιγμα του συνδέσμου στην οποία δεν είστε συνδεδεμένοι.</translation>

--- a/translations/en-GB.xtb
+++ b/translations/en-GB.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">Too many account requests are coming from your IP address. Try again in a few minutes.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">You can now sign in with your new account</translation>
+<translation id="1535200361681091160">Enter your email</translation>
 <translation id="1544981664986460902">Client specified an invalid argument.</translation>
 <translation id="1575848116712334589">Chad</translation>
 <translation id="1630237004390596779">Resend code in <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Cook Islands</translation>
 <translation id="1870056762032541323">Wrong code. Try again.</translation>
 <translation id="1898579907513173256">Macau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hello <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Delete account</translation>
+<translation id="1912929493041975510">The password must be at least six characters long</translation>
+<translation id="1933044638365301516">Sign in with <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Enter the 6-digit code that we sent to <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Follow the instructions sent to <ph name="PH_1" /> to recover your password.</translation>
+<translation id="1999379687946415948"><ph name="IDV_CODE_PLACE_HOLDER" /> is your code for <ph name="APP_NAME" />.</translation>
+<translation id="2033662766890821456">Resend code</translation>
 <translation id="2035855087334775326">Hungary</translation>
 <translation id="2040904406955887821">Suriname</translation>
 <translation id="2046207054419739276">United States</translation>
 <translation id="2049229571938383319">Saint Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Strong passwords have at least 6 characters and a mix of letters and numbers</translation>
 <translation id="2074008538308369451">Terms of Service</translation>
 <translation id="2089802663554186342">Session ended</translation>
 <translation id="2108717231438756650">United Kingdom</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Cape Verde</translation>
 <translation id="2301396996587599046">Macedonia</translation>
 <translation id="2310948428656960769">Signed in!</translation>
+<translation id="2321152797538991921">Password must contain a non-alphanumeric character</translation>
 <translation id="2324942959480650701">Guest</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">The browser you are using does not support Web Storage. Please try again in a different browser.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">An issue was encountered when authenticating your request. Please visit the URL that redirected you to this page again to restart the authentication process.</translation>
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">New password</translation>
+<translation id="3245143966477136343">Password must contain a lowercase character</translation>
 <translation id="3250864391349648273">Gabon</translation>
 <translation id="3259479674319858599">You've already used <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Sign in with <ph name="IDP_DISPLAY_NAME" /> to continue.</translation>
 <translation id="3275852444431525182">New Zealand</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Follow the instructions sent to <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> to recover your password</translation>
 <translation id="4588392627302012849">Sign in with email</translation>
 <translation id="4595119411041064617">By tapping '<ph name="PH_1" />', an SMS may be sent. Message &amp; data rates may apply.</translation>
+<translation id="4603232692404395592">Password may contain at most <ph name="MAX_PASSWORD_LENGTH" /> characters</translation>
 <translation id="4632709875751031323">Russia</translation>
 <translation id="4644169548516814280">The email address is already being used by another account</translation>
 <translation id="4692014002063276828">Poland</translation>
@@ -266,7 +270,7 @@
 <translation id="5524360735013196510">Netherlands</translation>
 <translation id="5528189843379142883">Equatorial Guinea</translation>
 <translation id="5529036554155743092">Australia</translation>
-<translation id="5537884323453943551">Trinidad and Tobago</translation>
+<translation id="5537884323453943551">Trinidad and Tobago</translation>
 <translation id="5543493820882105191">Enter your name</translation>
 <translation id="55439745111619380">Ascension Island</translation>
 <translation id="5569341882117077010">A network error has occurred</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Check that your inbox space is not running out, or for other inbox settings-related issues.</translation>
 <translation id="6135589730599211649">Client specified an invalid range.</translation>
 <translation id="6143147250106939258">The quota for this operation has been exceeded. Try again later.</translation>
+<translation id="615787395595800956">Missing password requirements:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Algeria</translation>
 <translation id="6213969168046789596">You have entered an incorrect password too many times. Please try again in a few minutes.</translation>
 <translation id="6216759405419177713">Norfolk Island</translation>
-<translation id="6245066275978703471">Phone number automatically verified</translation>
-<translation id="6269083314054226194">Network error, check your Internet connection.</translation>
-<translation id="6295157125625453859">Verified.</translation>
+<translation id="6238170540438416559">By tapping '<ph name="PH_1" />', you are indicating that you accept our <ph name="PP" />. An SMS may be sent. Message &amp; data rates may apply.</translation>
+<translation id="6265373887273416711">Verify your phone number</translation>
+<translation id="6283536862756552051">In order to change your password, you first need to enter your current password.</translation>
+<translation id="6299890279889400823">Back</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Continue</translation>
+<translation id="6355621963154078138">Password must contain a numeric character</translation>
 <translation id="6359400968059656782">You can now sign in with your new password</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxembourg</translation>
@@ -378,7 +385,7 @@
 <translation id="7064251114893721966">You've already used <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> to sign in. Enter your password for that account.</translation>
 <translation id="7085136866191400000">Sign-in email sent</translation>
 <translation id="7089485669419398254">Ireland</translation>
-<translation id="7093343209860483088">Democratic Republic of the Congo</translation>
+<translation id="7093343209860483088">Democratic Republic of the Congo</translation>
 <translation id="7118080999850002096">Recover password</translation>
 <translation id="7150917293543492988">Republic of Congo</translation>
 <translation id="7157317431934821052">The resource that a client tried to create already exists.</translation>
@@ -420,6 +427,7 @@
 <translation id="7790301903034097323">Choose password</translation>
 <translation id="7796914496604415892">New device or browser detected</translation>
 <translation id="786166109137986817">Sign in to <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">Password must contain an uppercase character</translation>
 <translation id="7868540442111212282">Czechia</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Sign in with GitHub</translation>
@@ -493,13 +501,15 @@
 <translation id="8916080112145514151">If you still want to connect your <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> account, open the link on the device that you used to start the sign in process. Otherwise, tap "Continue" to sign in on this device.</translation>
 <translation id="8920674952994839257">Retry</translation>
 <translation id="8939353296336237380">You originally intended to connect <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> to your email account, but have opened the link on a different device on which you are not signed in.</translation>
-<translation id="8971555482255213064">Resend code in 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">By tapping <ph name="BTN" /> you are indicating that you agree to the <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Done</translation>
 <translation id="8984161590699631096">Morocco</translation>
 <translation id="8994098794339484800">If you don't recognise this device, someone might be trying to access your account. Consider <ph name="START_LINK" />changing your password right away<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesh</translation>
 <translation id="9022632332691561239">Phone</translation>
 <translation id="9028063588419847334">Finland</translation>
 <translation id="9078135685219203661">United Arab Emirates</translation>
+<translation id="9085311482535098646">Password must contain at least <ph name="MIN_PASSWORD_LENGTH" /> characters</translation>
 <translation id="9121203582272050974">Your email has been verified and changed</translation>
 <translation id="9156150178611681179">Password</translation>
 <translation id="9168877696443530714">Central African Republic</translation>

--- a/translations/en-XA.xtb
+++ b/translations/en-XA.xtb
@@ -30,7 +30,9 @@
 <translation id="1451880131543823984">[ᐅ<ph name="START_STRONG" />ᐊᐅ<ph name="EMAIL" />ᐊᐅ<ph name="END_STRONG" />ᐊ îš ñöţ åûţĥöŕîžéð ţö vîéŵ ţĥé ŕéqûéšţéð þåĝé. one two three four five six seven eight nine ten eleven]</translation>
 <translation id="1479035434297790822">[Ţöö måñý åççöûñţ ŕéqûéšţš åŕé çömîñĝ ƒŕöm ýöûŕ ÎÞ åððŕéšš. Ţŕý åĝåîñ îñ å ƒéŵ mîñûţéš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]</translation>
 <translation id="1483249363694224399">[Šŕî Ļåñķå one two]</translation>
+<translation id="1501741971280143794">[Éñţéŕ å våļîð þĥöñé ñûmбéŕ. one two three four five six]</translation>
 <translation id="1507995441600689506">[Ýöû çåñ ñöŵ šîĝñ îñ ŵîţĥ ýöûŕ ñéŵ åççöûñţ one two three four five six seven eight nine]</translation>
+<translation id="1535200361681091160">[Éñţéŕ ýöûŕ émåîļ one two]</translation>
 <translation id="1544981664986460902">[Çļîéñţ šþéçîƒîéð åñ îñvåļîð åŕĝûméñţ. one two three four five six seven eight]</translation>
 <translation id="1575848116712334589">[Çĥåð one]</translation>
 <translation id="1630237004390596779">[Ŕéšéñð çöðé îñ ᐅ<ph name="STRING" />ᐊ one two three four]</translation>
@@ -45,16 +47,16 @@
 <translation id="1799407952500261728">[Çööķ Îšļåñðš one two]</translation>
 <translation id="1870056762032541323">[Ŵŕöñĝ çöðé. Ţŕý åĝåîñ. one two three four five]</translation>
 <translation id="1898579907513173256">[Måçåû one]</translation>
-<translation id="1929332760123475919">[ᐅ<ph name="P_START" />ᐊĤéļļö ᐅ<ph name="DISPLAY_NAME" />ᐊ,ᐅ<ph name="P_END" />ᐊ one two three four]</translation>
-<translation id="1966996824429980990">[Ðéļéţé åççöûñţ one two]</translation>
+<translation id="1912929493041975510">[Ţĥé þåššŵöŕð mûšţ бé åţ ļéåšţ 6 çĥåŕåçţéŕš ļöñĝ one two three four five six seven eight nine ten]</translation>
+<translation id="1933044638365301516">[Šîĝñ îñ ŵîţĥ ᐅ<ph name="STRING" />ᐊ one two three four]</translation>
 <translation id="1987722456379605552">[Éñţéŕ ţĥé 6-ðîĝîţ çöðé ŵé šéñţ ţö ᐅ<ph name="START_LINK" />ᐊᐅ<ph name="PHONE_NUMBER" />ᐊᐅ<ph name="END_LINK" />ᐊ one two three four five six seven eight nine]</translation>
-<translation id="2016421613709283485">[Föļļöŵ ţĥé îñšţŕûçţîöñš šéñţ ţö ᐅ<ph name="PH_1" />ᐊ ţö ŕéçövéŕ ýöûŕ þåššŵöŕð. one two three four five six seven eight nine ten eleven twelve]</translation>
+<translation id="1999379687946415948">[ᐅ<ph name="IDV_CODE_PLACE_HOLDER" />ᐊ îš ýöûŕ çöðé ƒöŕ ᐅ<ph name="APP_NAME" />ᐊ. one two three four five six]</translation>
+<translation id="2033662766890821456">[Ŕéšéñð çöðé one two]</translation>
 <translation id="2035855087334775326">[Ĥûñĝåŕý one]</translation>
 <translation id="2040904406955887821">[Šûŕîñåmé one]</translation>
 <translation id="2046207054419739276">[Ûñîţéð Šţåţéš one two]</translation>
 <translation id="2049229571938383319">[Šåîñţ Бåŕţĥéļémý one two]</translation>
 <translation id="2058731785647385204">[Möñţšéŕŕåţ one two]</translation>
-<translation id="2070709910567585968">[Šţŕöñĝ þåššŵöŕðš ĥåvé åţ ļéåšţ 6 çĥåŕåçţéŕš åñð å mîx öƒ ļéţţéŕš åñð ñûmбéŕš one two three four five six seven eight nine ten eleven twelve thirteen fourteen]</translation>
 <translation id="2074008538308369451">[Ţéŕmš öƒ Šéŕvîçé one two]</translation>
 <translation id="2089802663554186342">[Šéššîöñ éñðéð one two]</translation>
 <translation id="2108717231438756650">[Ûñîţéð Ķîñĝðöm one two]</translation>
@@ -74,6 +76,7 @@
 <translation id="2285049245646335550">[Çåþé Véŕðé one two]</translation>
 <translation id="2301396996587599046">[Måçéðöñîå one two]</translation>
 <translation id="2310948428656960769">[Šîĝñéð îñ¡ one two]</translation>
+<translation id="2321152797538991921">[Þåššŵöŕð mûšţ çöñţåîñ å ñöñ-åļþĥåñûméŕîç çĥåŕåçţéŕ one two three four five six seven eight nine ten eleven]</translation>
 <translation id="2324942959480650701">[Ĝûéšţ one]</translation>
 <translation id="2331781584136059536">[Ĝĥåñå one]</translation>
 <translation id="2338909515537249568">[Ţĥé бŕöŵšéŕ ýöû åŕé ûšîñĝ ðöéš ñöţ šûþþöŕţ Ŵéб Šţöŕåĝé. Þļéåšé ţŕý åĝåîñ îñ å ðîƒƒéŕéñţ бŕöŵšéŕ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]</translation>
@@ -139,6 +142,7 @@
 <translation id="3215050409577090361">[Åñ îššûé ŵåš éñçöûñţéŕéð ŵĥéñ åûţĥéñţîçåţîñĝ ýöûŕ ŕéqûéšţ. Þļéåšé vîšîţ ţĥé ÛŔĻ ţĥåţ ŕéðîŕéçţéð ýöû ţö ţĥîš þåĝé åĝåîñ ţö ŕéšţåŕţ ţĥé åûţĥéñţîçåţîöñ þŕöçéšš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]</translation>
 <translation id="3216149523061905579">[Ðömîñîçå one]</translation>
 <translation id="3223688630903046698">[Ñéŵ þåššŵöŕð one two]</translation>
+<translation id="3245143966477136343">[Þåššŵöŕð mûšţ çöñţåîñ å ļöŵéŕ çåšé çĥåŕåçţéŕ one two three four five six seven eight nine]</translation>
 <translation id="3250864391349648273">[Ĝåбöñ one]</translation>
 <translation id="3259479674319858599">[Ýöû’vé åļŕéåðý ûšéð ᐅ<ph name="START_STRONG" />ᐊᐅ<ph name="EMAIL" />ᐊᐅ<ph name="END_STRONG" />ᐊ. Šîĝñ îñ ŵîţĥ ᐅ<ph name="IDP_DISPLAY_NAME" />ᐊ ţö çöñţîñûé. one two three four five six seven eight nine ten eleven twelve]</translation>
 <translation id="3275852444431525182">[Ñéŵ Žéåļåñð one two]</translation>
@@ -216,6 +220,7 @@
 <translation id="4571870355114729513">[Föļļöŵ ţĥé îñšţŕûçţîöñš šéñţ ţö ᐅ<ph name="START_STRONG" />ᐊᐅ<ph name="EMAIL" />ᐊᐅ<ph name="END_STRONG" />ᐊ ţö ŕéçövéŕ ýöûŕ þåššŵöŕð one two three four five six seven eight nine ten eleven twelve thirteen]</translation>
 <translation id="4588392627302012849">[Šîĝñ îñ ŵîţĥ émåîļ one two three four]</translation>
 <translation id="4595119411041064617">[Бý ţåþþîñĝ “ᐅ<ph name="PH_1" />ᐊ”, åñ ŠMŠ måý бé šéñţ. Méššåĝé &amp; ðåţå ŕåţéš måý åþþļý. one two three four five six seven eight nine ten eleven twelve thirteen]</translation>
+<translation id="4603232692404395592">[Þåššŵöŕð måý çöñţåîñ åţ möšţ ᐅ<ph name="MAX_PASSWORD_LENGTH" />ᐊ çĥåŕåçţéŕš one two three four five six seven eight nine]</translation>
 <translation id="4632709875751031323">[Ŕûššîå one]</translation>
 <translation id="4644169548516814280">[Ţĥé émåîļ åððŕéšš îš åļŕéåðý ûšéð бý åñöţĥéŕ åççöûñţ one two three four five six seven eight nine ten eleven]</translation>
 <translation id="4692014002063276828">[Þöļåñð one]</translation>
@@ -311,16 +316,19 @@
 <translation id="6132202686885223981">[Çĥéçķ ţĥåţ ýöûŕ îñбöx šþåçé îš ñöţ ŕûññîñĝ öûţ öŕ öţĥéŕ îñбöx šéţţîñĝš ŕéļåţéð îššûéš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]</translation>
 <translation id="6135589730599211649">[Çļîéñţ šþéçîƒîéð åñ îñvåļîð ŕåñĝé. one two three four five six seven]</translation>
 <translation id="6143147250106939258">[Ţĥé qûöţå ƒöŕ ţĥîš öþéŕåţîöñ ĥåš бééñ éxçééðéð. Ţŕý åĝåîñ ļåţéŕ. one two three four five six seven eight nine ten eleven twelve thirteen]</translation>
+<translation id="615787395595800956">[Mîššîñĝ þåššŵöŕð ŕéqûîŕéméñţš: one two three four]</translation>
 <translation id="6189573836664806798">[Þåŕåĝûåý one]</translation>
 <translation id="6192657410634245771">[Åļĝéŕîå one]</translation>
 <translation id="6213969168046789596">[Ýöû ĥåvé éñţéŕéð åñ îñçöŕŕéçţ þåššŵöŕð ţöö måñý ţîméš. Þļéåšé ţŕý åĝåîñ îñ å ƒéŵ mîñûţéš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]</translation>
 <translation id="6216759405419177713">[Ñöŕƒöļķ Îšļåñð one two]</translation>
-<translation id="6245066275978703471">[Þĥöñé ñûmбéŕ åûţömåţîçåļļý véŕîƒîéð one two three four five six seven eight]</translation>
-<translation id="6269083314054226194">[Ñéţŵöŕķ éŕŕöŕ, çĥéçķ ýöûŕ îñţéŕñéţ çöññéçţîöñ. one two three four five six seven eight nine ten]</translation>
-<translation id="6295157125625453859">[Véŕîƒîéð¡ one two]</translation>
+<translation id="6238170540438416559">[Бý ţåþþîñĝ “ᐅ<ph name="PH_1" />ᐊ”, ýöû åŕé îñðîçåţîñĝ ţĥåţ ýöû åççéþţ öûŕ ᐅ<ph name="PP" />ᐊ. Åñ ŠMŠ måý бé šéñţ. Méššåĝé &amp; ðåţå ŕåţéš måý åþþļý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]</translation>
+<translation id="6265373887273416711">[Véŕîƒý ýöûŕ þĥöñé ñûmбéŕ one two three four five]</translation>
+<translation id="6283536862756552051">[Îñ öŕðéŕ ţö çĥåñĝé ýöûŕ þåššŵöŕð, ýöû ƒîŕšţ ñééð ţö éñţéŕ ýöûŕ çûŕŕéñţ þåššŵöŕð. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]</translation>
+<translation id="6299890279889400823">[Бåçķ one]</translation>
 <translation id="6316446940976157217">[Îñðîå one]</translation>
 <translation id="6327723482938582895">[Бéñîñ one]</translation>
 <translation id="6338643731889005578">[Çöñţîñûé one]</translation>
+<translation id="6355621963154078138">[Þåššŵöŕð mûšţ çöñţåîñ å ñûméŕîç çĥåŕåçţéŕ one two three four five six seven eight nine]</translation>
 <translation id="6359400968059656782">[Ýöû çåñ ñöŵ šîĝñ îñ ŵîţĥ ýöûŕ ñéŵ þåššŵöŕð one two three four five six seven eight nine]</translation>
 <translation id="6363241121027868570">[Åŕûбå one]</translation>
 <translation id="6377222208046638522">[Ļûxémбöûŕĝ one two]</translation>
@@ -420,6 +428,7 @@
 <translation id="7790301903034097323">[Çĥööšé þåššŵöŕð one two]</translation>
 <translation id="7796914496604415892">[Ñéŵ ðévîçé öŕ бŕöŵšéŕ ðéţéçţéð one two three four five six seven]</translation>
 <translation id="786166109137986817">[Šîĝñ îñ ţö ᐅ<ph name="DISPLAY_NAME" />ᐊ one two three]</translation>
+<translation id="7863575218808091551">[Þåššŵöŕð mûšţ çöñţåîñ åñ ûþþéŕ çåšé çĥåŕåçţéŕ one two three four five six seven eight nine]</translation>
 <translation id="7868540442111212282">[Çžéçĥ Ŕéþûбļîç one two]</translation>
 <translation id="7874584525604421364">[Ţûvåļû one]</translation>
 <translation id="7926046652648626866">[Šîĝñ îñ ŵîţĥ ĜîţĤûб one two three four]</translation>
@@ -493,13 +502,15 @@
 <translation id="8916080112145514151">[Îƒ ýöû šţîļļ ŵåñţ ţö çöññéçţ ýöûŕ ᐅ<ph name="START_STRONG" />ᐊᐅ<ph name="IDP_DISPLAY_NAME" />ᐊᐅ<ph name="END_STRONG" />ᐊ åççöûñţ, öþéñ ţĥé ļîñķ öñ ţĥé šåmé ðévîçé ŵĥéŕé ýöû šţåŕţéð šîĝñ-îñ. Öţĥéŕŵîšé, ţåþ Çöñţîñûé ţö šîĝñ-îñ öñ ţĥîš ðévîçé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]</translation>
 <translation id="8920674952994839257">[Ŕéţŕý one]</translation>
 <translation id="8939353296336237380">[Ýöû öŕîĝîñåļļý îñţéñðéð ţö çöññéçţ ᐅ<ph name="START_STRONG" />ᐊᐅ<ph name="IDP_DISPLAY_NAME" />ᐊᐅ<ph name="END_STRONG" />ᐊ ţö ýöûŕ émåîļ åççöûñţ бûţ ĥåvé öþéñéð ţĥé ļîñķ öñ å ðîƒƒéŕéñţ ðévîçé ŵĥéŕé ýöû åŕé ñöţ šîĝñéð îñ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]</translation>
-<translation id="8971555482255213064">[Ŕéšéñð çöðé îñ 0:ᐅ<ph name="PH_1" />ᐊ one two three four five]</translation>
+<translation id="8955469172512804617">[Бý ţåþþîñĝ ᐅ<ph name="BTN" />ᐊ ýöû åŕé îñðîçåţîñĝ ţĥåţ ýöû åĝŕéé ţö ţĥé ᐅ<ph name="PP" />ᐊ. one two three four five six seven eight nine ten eleven twelve]</translation>
+<translation id="8980953965669178372">[Ðöñé one]</translation>
 <translation id="8984161590699631096">[Möŕöççö one]</translation>
 <translation id="8994098794339484800">[Îƒ ýöû ðöñ'ţ ŕéçöĝñîžé ţĥîš ðévîçé, šöméöñé mîĝĥţ бé ţŕýîñĝ ţö åççéšš ýöûŕ åççöûñţ. Çöñšîðéŕ ᐅ<ph name="START_LINK" />ᐊçĥåñĝîñĝ ýöûŕ þåššŵöŕð ŕîĝĥţ åŵåýᐅ<ph name="END_LINK" />ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]</translation>
 <translation id="900153878296575829">[Бåñĝļåðéšĥ one two]</translation>
 <translation id="9022632332691561239">[Þĥöñé one]</translation>
 <translation id="9028063588419847334">[Fîñļåñð one]</translation>
 <translation id="9078135685219203661">[Ûñîţéð Åŕåб Émîŕåţéš one two three]</translation>
+<translation id="9085311482535098646">[Þåššŵöŕð mûšţ çöñţåîñ åţ ļéåšţ ᐅ<ph name="MIN_PASSWORD_LENGTH" />ᐊ çĥåŕåçţéŕš one two three four five six seven eight nine]</translation>
 <translation id="9121203582272050974">[Ýöûŕ émåîļ ĥåš бééñ véŕîƒîéð åñð çĥåñĝéð one two three four five six seven eight]</translation>
 <translation id="9156150178611681179">[Þåššŵöŕð one]</translation>
 <translation id="9168877696443530714">[Çéñţŕåļ Åƒŕîçåñ Ŕéþûбļîç one two three]</translation>

--- a/translations/es-419.xtb
+++ b/translations/es-419.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">Recibimos demasiadas solicitudes de cuenta desde tu dirección IP. Vuelve a intentarlo en unos minutos.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Ahora puedes acceder con tu cuenta nueva</translation>
+<translation id="1535200361681091160">Ingresa tu correo electrónico</translation>
 <translation id="1544981664986460902">El cliente especificó un argumento no válido.</translation>
 <translation id="1575848116712334589">Chad</translation>
 <translation id="1630237004390596779">Volver a enviar el código en <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Islas Cook</translation>
 <translation id="1870056762032541323">Código incorrecto. Vuelve a intentarlo.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hola, <ph name="DISPLAY_NAME" />:<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Borrar cuenta</translation>
+<translation id="1912929493041975510">La contraseña debe tener al menos 6 caracteres</translation>
+<translation id="1933044638365301516">Acceder con <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Ingresa el código de 6 dígitos que enviamos al número <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Sigue las instrucciones que se enviaron a <ph name="PH_1" /> para recuperar la contraseña.</translation>
+<translation id="1999379687946415948"><ph name="IDV_CODE_PLACE_HOLDER" /> es tu código para <ph name="APP_NAME" />.</translation>
+<translation id="2033662766890821456">Volver a enviar el código</translation>
 <translation id="2035855087334775326">Hungría</translation>
 <translation id="2040904406955887821">Surinam</translation>
 <translation id="2046207054419739276">Estados Unidos</translation>
 <translation id="2049229571938383319">San Bartolomé</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Las contraseñas seguras deben tener al menos 6 caracteres, además de incluir letras y números.</translation>
 <translation id="2074008538308369451">Condiciones del Servicio</translation>
 <translation id="2089802663554186342">Finalizó la sesión</translation>
 <translation id="2108717231438756650">Reino Unido</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Cabo Verde</translation>
 <translation id="2301396996587599046">Macedonia</translation>
 <translation id="2310948428656960769">Accediste</translation>
+<translation id="2321152797538991921">La contraseña debe tener un carácter que no sea alfanumérico</translation>
 <translation id="2324942959480650701">Invitado</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">El navegador que estás usando no es compatible con el almacenamiento web. Vuelve a intentarlo en otro navegador.</translation>
@@ -139,10 +141,11 @@
 <translation id="3215050409577090361">Hubo un problema al autenticar tu solicitud. Vuelve a la URL que te redireccionó a esta página para reiniciar el proceso de autenticación.</translation>
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">Nueva contraseña</translation>
+<translation id="3245143966477136343">La contraseña debe tener un carácter en minúscula</translation>
 <translation id="3250864391349648273">Gabón</translation>
 <translation id="3259479674319858599">Ya usaste <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Accede con <ph name="IDP_DISPLAY_NAME" /> para continuar.</translation>
 <translation id="3275852444431525182">Nueva Zelanda</translation>
-<translation id="3314478375063334511">Myanmar [Birmania]</translation>
+<translation id="3314478375063334511">Birmania [Myanmar]</translation>
 <translation id="3361878270020566601">Islandia</translation>
 <translation id="3364952477229333586">Etiopía</translation>
 <translation id="3372254675985592547">Cuba</translation>
@@ -203,7 +206,7 @@
 <translation id="4331763189922924781">Montenegro</translation>
 <translation id="4372962701784304822">Mozambique</translation>
 <translation id="4377158577300329881">La dirección de correo electrónico no coincide con una cuenta existente.</translation>
-<translation id="4386334763822785837">Turquía</translation>
+<translation id="4386334763822785837">Türkiye</translation>
 <translation id="4413304190485210039">Tayikistán</translation>
 <translation id="4432634970196611353">Laos</translation>
 <translation id="4440507149645221385">Teléfono</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Sigue las instrucciones que se enviaron a <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> para restablecer la contraseña.</translation>
 <translation id="4588392627302012849">Acceder con el correo electrónico</translation>
 <translation id="4595119411041064617">Si presionas “<ph name="PH_1" />”, se enviará un SMS. Se aplicarán las tarifas de mensajes y datos.</translation>
+<translation id="4603232692404395592">La contraseña puede tener un máximo de <ph name="MAX_PASSWORD_LENGTH" /> caracteres</translation>
 <translation id="4632709875751031323">Rusia</translation>
 <translation id="4644169548516814280">Otra cuenta ya usa esta dirección de correo electrónico.</translation>
 <translation id="4692014002063276828">Polonia</translation>
@@ -231,7 +235,7 @@
 <translation id="4871106926303956169">Islas Turcas y Caicos</translation>
 <translation id="4877597386645466815">Reenviar el código en <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
-<ph name="P_START" />Se agregó el número de teléfono <ph name="SECOND_FACTOR" /> a tu cuenta de <ph name="APP_NAME" /> para usar la verificación en dos pasos.<ph name="P_END" />
+<ph name="P_START" />Se agregó el número de teléfono <ph name="SECOND_FACTOR" /> a tu cuenta de <ph name="APP_NAME" /> para usar la verificación en 2 pasos.<ph name="P_END" />
 <ph name="P_START" />Si tú no realizaste este cambio, haz clic en el siguiente vínculo para quitar el número.<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="4923375331439013137">No se pudo quitar tu segundo factor</translation>
@@ -301,7 +305,7 @@
 <translation id="5989709845715452405">Recuperar contraseña</translation>
 <translation id="5995596766674622541">Ingresa el código de 6 dígitos que enviamos al número <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="6006148985615990975">Ruanda</translation>
-<translation id="6032262985756512833">Ingresa el código de <ph name="STRING" /> dígitos que enviamos a</translation>
+<translation id="6032262985756512833">Ingresa el código de <ph name="STRING" /> dígitos que enviamos a</translation>
 <translation id="6044396095102058216">Este número de teléfono se usó demasiadas veces</translation>
 <translation id="6083089720215618333">El correo electrónico que proporcionaste no coincide con la sesión actual a la que accediste.</translation>
 <translation id="6091051069256411999">Twitter</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Verifica que el espacio de tu bandeja de entrada no se esté agotando o revisa cualquier otro problema relacionado con la configuración de la bandeja de entrada.</translation>
 <translation id="6135589730599211649">El cliente especificó un rango no válido.</translation>
 <translation id="6143147250106939258">Se excedió la cuota para esta operación. Vuelve a intentarlo más tarde.</translation>
+<translation id="615787395595800956">No se cumplen algunos requisitos de contraseña:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Argelia</translation>
 <translation id="6213969168046789596">Ingresaste una contraseña incorrecta demasiadas veces. Vuelve a intentarlo en unos minutos.</translation>
 <translation id="6216759405419177713">Isla Norfolk</translation>
-<translation id="6245066275978703471">Se verificó automáticamente el número de teléfono</translation>
-<translation id="6269083314054226194">Se produjo un error de red. Comprueba tu conexión a Internet.</translation>
-<translation id="6295157125625453859">¡Verificado!</translation>
+<translation id="6238170540438416559">Si presionas “<ph name="PH_1" />”, indicas que aceptas nuestras <ph name="PP" />. Es posible que se te envíe un SMS. Podrían aplicarse las tarifas de mensajes y datos.</translation>
+<translation id="6265373887273416711">Verifica tu número de teléfono</translation>
+<translation id="6283536862756552051">Para cambiar tu contraseña, primero debes ingresar la contraseña actual.</translation>
+<translation id="6299890279889400823">Atrás</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benín</translation>
 <translation id="6338643731889005578">Continuar</translation>
+<translation id="6355621963154078138">La contraseña debe tener un carácter numérico</translation>
 <translation id="6359400968059656782">Ahora puedes acceder con tu contraseña nueva</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxemburgo</translation>
@@ -330,7 +337,7 @@
 <translation id="6470057025778734988">Ya no podrás acceder con tu cuenta</translation>
 <translation id="6472297146424049005">Verifica tu conexión a Internet.</translation>
 <translation id="6483116480230343278">Registrando…</translation>
-<translation id="6502083090260346644">Si presionas “<ph name="STRING" />”, es posible que se envíe un SMS. Podrían aplicarse tarifas de mensajes y datos.</translation>
+<translation id="6494734506607758748">Para cambiar la dirección de correo electrónico asociada con tu cuenta, debes acceder de nuevo.</translation>
 <translation id="6508909904815637928">Vanuatu</translation>
 <translation id="6520863029476703422">Samoa Americana</translation>
 <translation id="6527597037551425211">Brasil</translation>
@@ -419,6 +426,7 @@
 <translation id="7790301903034097323">Elegir contraseña</translation>
 <translation id="7796914496604415892">Se detectó un dispositivo o navegador nuevo</translation>
 <translation id="786166109137986817">Acceder a <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">La contraseña debe tener un carácter en mayúscula</translation>
 <translation id="7868540442111212282">República Checa</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Acceder con GitHub</translation>
@@ -491,13 +499,15 @@
 <translation id="8916080112145514151">Si aún quieres conectar tu cuenta de <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, abre el vínculo en el mismo dispositivo en el que accediste. En caso contrario, presiona Continuar para acceder en este dispositivo.</translation>
 <translation id="8920674952994839257">Reintentar</translation>
 <translation id="8939353296336237380">Originalmente, intentaste conectar <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> con tu cuenta de correo electrónico, pero abriste el vínculo en un dispositivo diferente en el que no accediste.</translation>
-<translation id="8971555482255213064">Se reenviará el código en 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">Si presionas <ph name="BTN" />, indicas que aceptas la <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Listo</translation>
 <translation id="8984161590699631096">Marruecos</translation>
 <translation id="8994098794339484800">Si no reconoces este dispositivo, es probable que otra persona esté tratando de acceder a tu cuenta. <ph name="START_LINK" />Cambia tu contraseña de inmediato<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladés</translation>
 <translation id="9022632332691561239">Teléfono</translation>
 <translation id="9028063588419847334">Finlandia</translation>
 <translation id="9078135685219203661">Emiratos Árabes Unidos</translation>
+<translation id="9085311482535098646">La contraseña debe tener un mínimo de <ph name="MIN_PASSWORD_LENGTH" /> caracteres</translation>
 <translation id="9121203582272050974">Se verificó y cambió tu correo electrónico</translation>
 <translation id="9156150178611681179">Contraseña</translation>
 <translation id="9168877696443530714">República Centroafricana</translation>

--- a/translations/es.xtb
+++ b/translations/es.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">Estamos recibiendo demasiadas peticiones desde tu dirección IP. Vuelve a intentarlo en unos minutos.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Ya puedes iniciar sesión con la cuenta nueva</translation>
+<translation id="1535200361681091160">Introduce tu correo electrónico</translation>
 <translation id="1544981664986460902">El cliente especificó un argumento que no es válido.</translation>
 <translation id="1575848116712334589">Chad</translation>
 <translation id="1630237004390596779">Reenviar código en <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Islas Cook</translation>
 <translation id="1870056762032541323">El código es incorrecto. Vuelve a intentarlo.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hola, <ph name="DISPLAY_NAME" />:<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Eliminar cuenta</translation>
+<translation id="1912929493041975510">La contraseña debe tener al menos 6 caracteres</translation>
+<translation id="1933044638365301516">Iniciar sesión con <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Introduce el código de seis dígitos que hemos enviado a <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Sigue las instrucciones que te hemos enviado a <ph name="PH_1" /> para recuperar la contraseña.</translation>
+<translation id="1999379687946415948">El código de <ph name="APP_NAME" /> es <ph name="IDV_CODE_PLACE_HOLDER" />.</translation>
+<translation id="2033662766890821456">Reenviar código</translation>
 <translation id="2035855087334775326">Hungría</translation>
 <translation id="2040904406955887821">Surinam</translation>
 <translation id="2046207054419739276">Estados Unidos</translation>
 <translation id="2049229571938383319">San Bartolomé</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Las contraseñas seguras contienen 6 caracteres como mínimo y combinan letras y números.</translation>
 <translation id="2074008538308369451">Términos del Servicio</translation>
 <translation id="2089802663554186342">La sesión ha finalizado</translation>
 <translation id="2108717231438756650">Reino Unido</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Cabo Verde</translation>
 <translation id="2301396996587599046">Macedonia</translation>
 <translation id="2310948428656960769">Has iniciado sesión.</translation>
+<translation id="2321152797538991921">La contraseña debe tener un carácter no alfanumérico</translation>
 <translation id="2324942959480650701">Invitado</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">El navegador que estás usando no es compatible con el almacenamiento web. Vuelve a intentarlo con otro navegador.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">Se ha producido un error al autenticar tu solicitud. Vuelve a visitar la URL que te redirigió a esta página para reiniciar el proceso de autenticación.</translation>
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">Nueva contraseña</translation>
+<translation id="3245143966477136343">La contraseña debe tener un carácter en minúscula</translation>
 <translation id="3250864391349648273">Gabón</translation>
 <translation id="3259479674319858599">Ya has usado <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> para iniciar sesión. Hazlo con <ph name="IDP_DISPLAY_NAME" /> para continuar.</translation>
 <translation id="3275852444431525182">Nueva Zelanda</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Sigue los pasos que te hemos enviado a <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> para recuperar tu contraseña.</translation>
 <translation id="4588392627302012849">Iniciar sesión con el correo electrónico</translation>
 <translation id="4595119411041064617">Al tocar <ph name="PH_1" />, podría enviarse un SMS. Es posible que se apliquen cargos de mensajería y de uso de datos.</translation>
+<translation id="4603232692404395592">La contraseña puede tener como máximo <ph name="MAX_PASSWORD_LENGTH" /> caracteres</translation>
 <translation id="4632709875751031323">Rusia</translation>
 <translation id="4644169548516814280">Otra cuenta ya usa esta dirección de correo electrónico</translation>
 <translation id="4692014002063276828">Polonia</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Comprueba que no te estés quedando sin espacio en la bandeja de entrada y que no haya ningún problema con su configuración.</translation>
 <translation id="6135589730599211649">El cliente especificó un intervalo que no es válido.</translation>
 <translation id="6143147250106939258">Se ha superado la cuota de esta aplicación. Inténtalo de nuevo más tarde.</translation>
+<translation id="615787395595800956">Requisitos de contraseña no cumplidos:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Argelia</translation>
 <translation id="6213969168046789596">Has introducido una contraseña incorrecta demasiadas veces. Vuelve a intentarlo en unos minutos.</translation>
 <translation id="6216759405419177713">Isla Norfolk</translation>
-<translation id="6245066275978703471">Se ha verificado automáticamente el número de teléfono</translation>
-<translation id="6269083314054226194">Se ha producido un error de red. Comprueba la conexión a Internet.</translation>
-<translation id="6295157125625453859">Verificado</translation>
+<translation id="6238170540438416559">Si tocas <ph name="PH_1" />, confirmas que aceptas nuestra <ph name="PP" />. Podría enviarse un SMS, por lo que es posible que se apliquen cargos de mensajería y de uso de datos.</translation>
+<translation id="6265373887273416711">Verificar el número de teléfono</translation>
+<translation id="6283536862756552051">Para poder cambiar la contraseña, primero debes introducir la contraseña actual.</translation>
+<translation id="6299890279889400823">Atrás</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benín</translation>
 <translation id="6338643731889005578">Continuar</translation>
+<translation id="6355621963154078138">La contraseña debe tener un carácter numérico</translation>
 <translation id="6359400968059656782">Ya puedes iniciar sesión con la nueva contraseña</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxemburgo</translation>
@@ -420,6 +427,7 @@
 <translation id="7790301903034097323">Elige una contraseña</translation>
 <translation id="7796914496604415892">Se ha detectado un nuevo dispositivo o navegador</translation>
 <translation id="786166109137986817">Iniciar sesión en <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">La contraseña debe tener un carácter en mayúscula</translation>
 <translation id="7868540442111212282">República Checa</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Iniciar sesión con GitHub</translation>
@@ -493,13 +501,15 @@
 <translation id="8916080112145514151">Si sigues queriendo conectar tu cuenta de <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, abre el enlace en el mismo dispositivo en el que empezaste el inicio de sesión. De lo contrario, toca Continuar para iniciar sesión en este dispositivo.</translation>
 <translation id="8920674952994839257">Reintentar</translation>
 <translation id="8939353296336237380">En un principio intentaste conectar <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> con tu cuenta de correo electrónico, pero has abierto el enlace en un dispositivo diferente en el que no has iniciado sesión.</translation>
-<translation id="8971555482255213064">Volver a enviar el código en 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">Al tocar <ph name="BTN" />, indicas que aceptas la <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Hecho</translation>
 <translation id="8984161590699631096">Marruecos</translation>
 <translation id="8994098794339484800">Si no reconoces este dispositivo, es posible que otra persona esté intentando acceder a tu cuenta. Te recomendamos que <ph name="START_LINK" />cambies tu contraseña de inmediato<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladés</translation>
 <translation id="9022632332691561239">Teléfono</translation>
 <translation id="9028063588419847334">Finlandia</translation>
 <translation id="9078135685219203661">Emiratos Árabes Unidos</translation>
+<translation id="9085311482535098646">La contraseña debe tener al menos <ph name="MIN_PASSWORD_LENGTH" /> caracteres</translation>
 <translation id="9121203582272050974">Se ha verificado y modificado tu correo electrónico</translation>
 <translation id="9156150178611681179">Contraseña</translation>
 <translation id="9168877696443530714">República Centroafricana</translation>

--- a/translations/fa.xtb
+++ b/translations/fa.xtb
@@ -21,7 +21,7 @@
 <translation id="1310034618729602982">ایمیلتان را دوباره به‌روزرسانی کنید</translation>
 <translation id="1312824004897469797">خطای شبکه رخ داد. بعداً دوباره امتحان کنید.</translation>
 <translation id="1315809131562953678">شماره تلفن معتبری وارد کنید</translation>
-<translation id="1335716056288807013">درصورت ضربه‌زدن روی «تأیید»، موافقتتان را با <ph name="START_LINK_1" />شرایط خدمات<ph name="END_LINK" /> و <ph name="START_LINK_2" />خطمشی حریم‌خصوصی<ph name="END_LINK" /> اعلام می‌کنید. پیامکی ارسال خواهد شد و ممکن است هزینه داده و «پیام» محاسبه شود.</translation>
+<translation id="1335716056288807013">درصورت ضربه‌زدن روی «تأیید»، موافقتتان را با <ph name="START_LINK_1" />شرایط خدمات<ph name="END_LINK" /> و <ph name="START_LINK_2" />خطمشی حریم خصوصی<ph name="END_LINK" /> اعلام می‌کنید. پیامکی ارسال خواهد شد و ممکن است هزینه داده و «پیام» محاسبه شود.</translation>
 <translation id="137210131544215127">گذرواژه‌تان را وارد کنید</translation>
 <translation id="1393433815796487579">انجام شد</translation>
 <translation id="1412449974349991050">هاییتی</translation>
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">جزایر کوک</translation>
 <translation id="1870056762032541323">کد اشتباه است. دوباره امتحان کنید.</translation>
 <translation id="1898579907513173256">ماکائو</translation>
-<translation id="1929332760123475919"><ph name="P_START" />سلام <ph name="DISPLAY_NAME" />،<ph name="P_END" /></translation>
-<translation id="1966996824429980990">حذف حساب</translation>
+<translation id="1912929493041975510">گذرواژه باید حداقل ۶ نویسه داشته باشد</translation>
+<translation id="1933044638365301516">ورود به سیستم با <ph name="STRING" /></translation>
 <translation id="1987722456379605552">کد ۶ رقمی‌ای که به <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /> ارسال کردیم را وارد کنید</translation>
 <translation id="2016421613709283485">برای بازیابی گذرواژه‌تان، دستورالعمل‌های ارسال‌شده به <ph name="PH_1" /> را دنبال کنید.</translation>
 <translation id="2035855087334775326">مجارستان</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">ایالات متحده امریکا</translation>
 <translation id="2049229571938383319">سن بارتلمی</translation>
 <translation id="2058731785647385204">مونتسرات</translation>
-<translation id="2070709910567585968">گذرواژه قوی باید حداقل شامل ۶ نویسه و ترکیبی از حروف و اعداد باشد</translation>
 <translation id="2074008538308369451">شرایط خدمات</translation>
 <translation id="2089802663554186342">جلسه تمام شد</translation>
 <translation id="2108717231438756650">پادشاهی متحد بریتانیا</translation>
@@ -65,7 +64,7 @@
 <translation id="2187260952722791093">تأیید شد!</translation>
 <translation id="2192561962270021282">شماره تلفن خود را وارد کنید</translation>
 <translation id="2206856445831770486">GitHub</translation>
-<translation id="2223717216014247341">خط‌مشی حریم‌خصوصی</translation>
+<translation id="2223717216014247341">خط‌مشی حریم خصوصی</translation>
 <translation id="2224563296468523455">گوام</translation>
 <translation id="2245182894886860848">یا از سهمیه منبع خارج شدید یا از حداکثر مجاز فراتر رفتید.</translation>
 <translation id="2249420035688424170">کرواسی</translation>
@@ -134,7 +133,7 @@
 <translation id="3154748063569624719">در اصل می‌خواستید با <ph name="PENDING_EMAIL" /> وارد سیستم شوید</translation>
 <translation id="3164676761565983157">ونزوئلا</translation>
 <translation id="3170526549630869494">مشکل در ورود به سیستم؟</translation>
-<translation id="3204914819635733576">تأیید کنید این خود شما هستید</translation>
+<translation id="3204914819635733576">تأیید کنید این شمایید</translation>
 <translation id="3215050409577090361">هنگام راستی‌آزمایی درخواستتان خطایی رخ داد. لطفاً برای بازراه‌اندازی فرایند راستی‌آزمایی، دوباره به نشانی وبی که شما را به این صفحه هدایت کرد بروید.</translation>
 <translation id="3216149523061905579">دومینیکا</translation>
 <translation id="3223688630903046698">گذرواژه جدید</translation>
@@ -191,7 +190,7 @@
 <translation id="4066104405592701692">استونی</translation>
 <translation id="4147949012570877154">حذف</translation>
 <translation id="4163133799286985193">آرژانتین</translation>
-<translation id="4166504762096983411">درصورت ادامه‌دادن، موافقتتان را با <ph name="START_LINK_1" />شرایط خدمات<ph name="END_LINK" /> و <ph name="START_LINK_2" />خطمشی حریم‌خصوصی<ph name="END_LINK" /> اعلام می‌کنید.</translation>
+<translation id="4166504762096983411">درصورت ادامه‌دادن، موافقتتان را با <ph name="START_LINK_1" />شرایط خدمات<ph name="END_LINK" /> و <ph name="START_LINK_2" />خطمشی حریم خصوصی<ph name="END_LINK" /> اعلام می‌کنید.</translation>
 <translation id="420554669252656972">نشانی ایمیل  جدید را وارد کنید</translation>
 <translation id="4210333062216604630">لغو پیوند</translation>
 <translation id="4242716276491763916">جمهوری گینه</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">الجزایر</translation>
 <translation id="6213969168046789596">دفعات خیلی زیادی گذرواژه را نادرست وارد کرده‌اید. لطفاً پس از چند دقیقه دوباره امتحان کنید.</translation>
 <translation id="6216759405419177713">جزیره نورفک</translation>
-<translation id="6245066275978703471">شماره تلفن به‌طور خودکار به‌تأیید رسید</translation>
-<translation id="6269083314054226194">خطای شبکه. اتصال اینترنت را بررسی کنید.</translation>
-<translation id="6295157125625453859">تأیید شد!</translation>
+<translation id="6238170540438416559">درصورت ضربه‌زدن روی «<ph name="PH_1" />»، موافقتتان را با <ph name="PP" /> اعلام می‌کنید. پیامکی ارسال می‌شود. ممکن است هزینه داده و «پیام» محاسبه شود.</translation>
+<translation id="6265373887273416711">تأیید شماره تلفن</translation>
+<translation id="6283536862756552051">برای تغییر گذرواژه‌‌، ابتدا باید گذرواژه کنونی‌تان را وارد کنید.</translation>
+<translation id="6299890279889400823">قبلی</translation>
 <translation id="6316446940976157217">هند</translation>
 <translation id="6327723482938582895">بنین</translation>
 <translation id="6338643731889005578">ادامه</translation>
@@ -344,7 +344,7 @@
 <translation id="6655128609744896303">کد ارسال شد!</translation>
 <translation id="6683477520421532707">رئونیون</translation>
 <translation id="6683810982254923169">بازنشانی دوباره گذرواژه‌ کاربر</translation>
-<translation id="6689542920381638295">ادامه به‌عنوان مهمان</translation>
+<translation id="6689542920381638295">ادامه دادن به‌عنوان مهمان</translation>
 <translation id="6719973195813381061">اکوادور</translation>
 <translation id="6721310522324861790">سنگال</translation>
 <translation id="6724344978634903280">بوتسوانا</translation>
@@ -381,7 +381,7 @@
 <translation id="7118080999850002096">بازیابی گذرواژه</translation>
 <translation id="7150917293543492988">جمهوری کنگو</translation>
 <translation id="7157317431934821052">منبعی که کارخواه قصد ایجادش را داشت از قبل موجود است.</translation>
-<translation id="7174424882502155514">ادامه به‌عنوان مهمان</translation>
+<translation id="7174424882502155514">ادامه دادن به‌عنوان مهمان</translation>
 <translation id="7192078949090526171">سن مارینو</translation>
 <translation id="7197455001919474950">قبرس</translation>
 <translation id="7198563013006562060">جزایر سلیمان</translation>
@@ -424,7 +424,7 @@
 <translation id="792838323404934335">گرینلند</translation>
 <translation id="7956645158976161232">لیبی</translation>
 <translation id="8017277252219866084">کنیا</translation>
-<translation id="8028653067082554952">با این کار همه داده‌های مرتبط با حسابتان پاک می‌شود که قابل واگرد نیست. مطمئنید می‌خواهید حسابتان حذف شود؟</translation>
+<translation id="8028653067082554952">با این کار همه داده‌های مرتبط با حسابتان پاک می‌شود که واگردشدنی نیست. مطمئنید می‌خواهید حسابتان حذف شود؟</translation>
 <translation id="8033786138248870436">با ضربه زدن روی تأیید پیامکی ارسال می‌شود. ممکن است هزینه انتقال داده و پیام اعمال شود.</translation>
 <translation id="8047183472745080590">بولیوی</translation>
 <translation id="8047565947836609247">پورتوریکو</translation>
@@ -458,7 +458,7 @@
 <translation id="847294590390666986">تایوان</translation>
 <translation id="8477554788963470892">سیرالئون</translation>
 <translation id="8498398269542501379">ببینید ایمیل به‌عنوان هرزنامه یا فیلترشده مشخص نشده باشد.</translation>
-<translation id="8505200776212389923">درحال تأیید…</translation>
+<translation id="8505200776212389923">درحال تأیید کردن…</translation>
 <translation id="8505941919386646914">مارتینیک</translation>
 <translation id="8534746304953308378">توگو</translation>
 <translation id="8572093925387077451">از قبل حسابی دارید</translation>

--- a/translations/fi.xtb
+++ b/translations/fi.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Cookinsaaret</translation>
 <translation id="1870056762032541323">Väärä koodi. Yritä uudelleen.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hei <ph name="DISPLAY_NAME" /><ph name="P_END" /></translation>
-<translation id="1966996824429980990">Poista tili</translation>
+<translation id="1912929493041975510">Salasanassa on oltava vähintään 6 merkkiä</translation>
+<translation id="1933044638365301516">Kirjaudu palvelun <ph name="STRING" /> kautta</translation>
 <translation id="1987722456379605552">Anna 6 merkin pituinen koodi, jonka lähetimme numeroon <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" />.</translation>
 <translation id="2016421613709283485">Palauta salasana noudattamalla osoitteeseen <ph name="PH_1" /> lähetettyjä ohjeita.</translation>
 <translation id="2035855087334775326">Unkari</translation>
@@ -54,10 +54,9 @@
 <translation id="2046207054419739276">Yhdysvallat</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Vahvassa salasanassa on vähintään 6 merkkiä, ja se sisältää kirjaimia ja numeroita.</translation>
 <translation id="2074008538308369451">Käyttöehdot</translation>
 <translation id="2089802663554186342">Istunto päättyi</translation>
-<translation id="2108717231438756650">Iso-Britannia</translation>
+<translation id="2108717231438756650">Yhdistynyt kuningaskunta</translation>
 <translation id="2120419640334291526">Caymansaaret</translation>
 <translation id="2124070231227334770">Moldova</translation>
 <translation id="2124843735553988177">Valtuuta tarvittavat käyttöoikeudet sovellukseen kirjautumista varten.</translation>
@@ -315,9 +314,10 @@
 <translation id="6192657410634245771">Algeria</translation>
 <translation id="6213969168046789596">Olet antanut virheellisen salasanan liian monta kertaa. Yritä uudelleen muutaman minuutin kuluttua.</translation>
 <translation id="6216759405419177713">Norfolkinsaari</translation>
-<translation id="6245066275978703471">Puhelinnumero vahvistettu automaattisesti</translation>
-<translation id="6269083314054226194">Verkkovirhe, tarkista internetyhteys.</translation>
-<translation id="6295157125625453859">Vahvistettu!</translation>
+<translation id="6238170540438416559">Napauttamalla <ph name="PH_1" /> vahvistat hyväksyväsi seuraavan: <ph name="PP" />. Tekstiviesti voidaan lähettää, ja datan ja viestien käyttö voi olla maksullista.</translation>
+<translation id="6265373887273416711">Puhelinnumeron vahvistaminen</translation>
+<translation id="6283536862756552051">Jotta voit vaihtaa salasanasi, sinun on annettava ensin nykyinen salasanasi.</translation>
+<translation id="6299890279889400823">Takaisin</translation>
 <translation id="6316446940976157217">Intia</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Jatka</translation>

--- a/translations/fil.xtb
+++ b/translations/fil.xtb
@@ -1,6 +1,6 @@
 <translationbundle lang="fil">
 <translation id="1003362845472634045">Naipadala ang email sa pag-sign in</translation>
-<translation id="10081113082271688">Maling verification code</translation>
+<translation id="10081113082271688">Maling verification code</translation>
 <translation id="1024070574104100559">St. Vincent</translation>
 <translation id="1080228854514607739">Invalid ang link ng email. Maaaring mangyari ito kung nag-expire na ang link sa email o ginamit na para maka-sign in. Paki-restart ang daloy ng pag-login.</translation>
 <translation id="1088824719285122027">Masyadong maraming beses nang nagamit ang numero ng teleponong ito</translation>
@@ -8,7 +8,7 @@
 <translation id="1130401182255828006">Latvia</translation>
 <translation id="1133565039750742069">I-save</translation>
 <translation id="1139115784936170936">Singapore</translation>
-<translation id="1163494479861953195">Mag-log in muli upang isagawa ang operasyong ito</translation>
+<translation id="1163494479861953195">Mag-log in muli upang isagawa ang operasyong ito</translation>
 <translation id="1163771673786684213">Philippines</translation>
 <translation id="1170304454812139475">Romania</translation>
 <translation id="1194565221977667376">South Georgia and The South Sandwich Islands</translation>
@@ -25,42 +25,41 @@
 <translation id="137210131544215127">Ilagay ang iyong password</translation>
 <translation id="1393433815796487579">Tapos Na</translation>
 <translation id="1412449974349991050">Haiti</translation>
-<translation id="144766329299583285">Kung hindi mo hiniling na baguhin ang iyong email sa pag-sign in, posibleng may taong sinusubukang i-access ang iyong account at dapat mong <ph name="START_LINK" />palitan ang iyong password kaagad<ph name="END_LINK" />.</translation>
+<translation id="144766329299583285">Kung hindi mo hiniling na baguhin ang iyong email sa pag-sign in, posibleng may taong sinusubukang i-access ang iyong account at dapat mong <ph name="START_LINK" />palitan ang iyong password kaagad<ph name="END_LINK" />.</translation>
 <translation id="1449981769524156676">Heard Island and McDonald Islands</translation>
 <translation id="1451880131543823984">Walang pahintulot ang<ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> na tingnan ang hiniling na page.</translation>
-<translation id="1479035434297790822">Masyadong maraming kahilingan ng account mula sa iyong IP address. Subukang muli pagkalipas ng ilang minuto.</translation>
+<translation id="1479035434297790822">Masyadong maraming kahilingan ng account mula sa iyong IP address. Subukang muli pagkalipas ng ilang minuto.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
-<translation id="1507995441600689506">Makakapag-sign in ka na ngayon gamit ang iyong bagong account</translation>
+<translation id="1507995441600689506">Makakapag-sign in ka na ngayon gamit ang iyong bagong account</translation>
 <translation id="1544981664986460902">May tinukoy na invalid na argument ang client.</translation>
 <translation id="1575848116712334589">Chad</translation>
 <translation id="1632452818656545062">Sa pag-tap sa "<ph name="PH_1" />", ipinababatid mo na tinatanggap mo ang aming <ph name="TOS" /> at <ph name="PP" />. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</translation>
 <translation id="1653501608290591291">Belarus</translation>
-<translation id="1667376103923043653">Hindi tumutugma ang email address na iyon sa isang kasalukuyang account.</translation>
-<translation id="173576986138855124">Sa pamamagitan ng pag-tap sa "<ph name="PH_1" />," maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</translation>
+<translation id="1667376103923043653">Hindi tumutugma ang email address na iyon sa isang kasalukuyang account.</translation>
+<translation id="173576986138855124">Sa pamamagitan ng pag-tap sa "<ph name="PH_1" />," maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</translation>
 <translation id="1739056958326110545">Saint Helena</translation>
 <translation id="1743026758446868773">Barbados</translation>
-<translation id="1772888465204630090">Sa pamamagitan ng pag-tap sa Magpatuloy isinasaad mo na sumasang-ayon ka sa <ph name="START_LINK" />Mga Tuntunin ng Serbisyo<ph name="END_LINK" /></translation>
+<translation id="1772888465204630090">Sa pamamagitan ng pag-tap sa Magpatuloy isinasaad mo na sumasang-ayon ka sa <ph name="START_LINK" />Mga Tuntunin ng Serbisyo<ph name="END_LINK" /></translation>
 <translation id="177937029926612729">Armenia</translation>
 <translation id="179194004476893686">Bosnia and Herzegovina</translation>
 <translation id="1799407952500261728">Cook Islands</translation>
 <translation id="1870056762032541323">Maling code. Subukang muli.</translation>
 <translation id="1898579907513173256">Macau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Kumusta <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">I-delete ang account</translation>
-<translation id="1987722456379605552">Ilagay ang 6-digit na code na ipinadala namin sa <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Sundin ang mga tagubilin na ipinadala sa <ph name="PH_1" /> upang ma-recover ang iyong password.</translation>
+<translation id="1912929493041975510">Dapat 6 na character man lang ang haba ng password</translation>
+<translation id="1933044638365301516">Mag-sign in gamit ang <ph name="STRING" /></translation>
+<translation id="1987722456379605552">Ilagay ang 6-digit na code na ipinadala namin sa <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
+<translation id="2016421613709283485">Sundin ang mga tagubilin na ipinadala sa <ph name="PH_1" /> upang ma-recover ang iyong password.</translation>
 <translation id="2035855087334775326">Hungary</translation>
 <translation id="2040904406955887821">Suriname</translation>
 <translation id="2046207054419739276">United States</translation>
 <translation id="2049229571938383319">Saint Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Kailangang may 6 na character man lang at kumbinasyon ng mga titik at mga numero ang mga malalakas na password</translation>
 <translation id="2074008538308369451">Mga Tuntunin ng Serbisyo</translation>
 <translation id="2089802663554186342">Natapos na ang session</translation>
 <translation id="2108717231438756650">United Kingdom</translation>
 <translation id="2120419640334291526">Cayman Islands</translation>
 <translation id="2124070231227334770">Moldova</translation>
-<translation id="2124843735553988177">Pahintulutan ang mga kinakailangang pahintulot upang makapag-sign in sa application</translation>
+<translation id="2124843735553988177">Pahintulutan ang mga kinakailangang pahintulot upang makapag-sign in sa application</translation>
 <translation id="2130553359919781209">Malawi</translation>
 <translation id="2187260952722791093">Na-verify!</translation>
 <translation id="2192561962270021282">Ilagay ang numero ng iyong telepono</translation>
@@ -76,9 +75,9 @@
 <translation id="2310948428656960769">Naka-sign in!</translation>
 <translation id="2324942959480650701">Bisita</translation>
 <translation id="2331781584136059536">Ghana</translation>
-<translation id="2338909515537249568">Hindi sinusuportahan ng browser na ginagamit mo ang Web Storage. Pakisubukang muli sa ibang browser.</translation>
+<translation id="2338909515537249568">Hindi sinusuportahan ng browser na ginagamit mo ang Web Storage. Pakisubukang muli sa ibang browser.</translation>
 <translation id="2342152898808240937">Kinansela ng client ang kahilingan.</translation>
-<translation id="2356282732642724501"><ph name="START_PARAGRAPH" />Nagkaproblema sa pagbabalik sa iyong email sa pag-sign in.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Kung susubukan mong muli at hindi pa rin ma-reset ang iyong email, subukang humingi ng tulong sa iyong administrator.<ph name="END_PARAGRAPH" /></translation>
+<translation id="2356282732642724501"><ph name="START_PARAGRAPH" />Nagkaproblema sa pagbabalik sa iyong email sa pag-sign in.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Kung susubukan mong muli at hindi pa rin ma-reset ang iyong email, subukang humingi ng tulong sa iyong administrator.<ph name="END_PARAGRAPH" /></translation>
 <translation id="2375419764963116430">Bahrain</translation>
 <translation id="2392247362473363900">Internal na error sa server.</translation>
 <translation id="2405828009195143258">Iran</translation>
@@ -89,8 +88,8 @@
 <translation id="2460064915291012298">Seychelles</translation>
 <translation id="2490672522100125425">Inalis ang <ph name="START_STRONG" /><ph name="FACTOR_ID" /> <ph name="PHONE_NUMBER" /><ph name="END_STRONG" /> bilang pangalawang hakbang sa pag-authenticate.</translation>
 <translation id="2494962141967044042">Hindi nakapag-upgrade ang kasalukuyang anonymous na user. Nauugnay na ang di-anonymous na kredensyal sa ibang account ng user.</translation>
-<translation id="2541179214468543429">Nagpasok ka ng di-wastong password nang masyadong maraming beses. Pakisubukang muli pagkalipas ng ilang minuto.</translation>
-<translation id="2561835578785502516">Ang iyong kahilingan na i-reset ang iyong password ay nag-expire na o nagamit na ang link</translation>
+<translation id="2541179214468543429">Nagpasok ka ng di-wastong password nang masyadong maraming beses. Pakisubukang muli pagkalipas ng ilang minuto.</translation>
+<translation id="2561835578785502516">Ang iyong kahilingan na i-reset ang iyong password ay nag-expire na o nagamit na ang link</translation>
 <translation id="2562498793334241360">Makakapag-sign in ka na ngayon gamit ang bago mong email <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="2581514546525533462">Hindi suportado ang ibinigay na country code</translation>
 <translation id="2600950452451016107">Tiyakin na hindi ka nagkamali sa pagbaybay ng iyong email.</translation>
@@ -108,10 +107,10 @@
 <translation id="2668496398414877352">Kosovo</translation>
 <translation id="2674823936234616183">Uzbekistan</translation>
 <translation id="2696162410887720551">Aland Islands</translation>
-<translation id="2725769874498146298">Nag-expire ang iyong sign-in session. Pakisubukang muli.</translation>
+<translation id="2725769874498146298">Nag-expire ang iyong sign-in session. Pakisubukang muli.</translation>
 <translation id="2741235824871026219">I-verify</translation>
 <translation id="2752984808025184019">South Africa</translation>
-<translation id="2760636260031093254">Ilagay ang iyong email address upang magpatuloy</translation>
+<translation id="2760636260031093254">Ilagay ang iyong email address upang magpatuloy</translation>
 <translation id="276938411216176478">Na-disable ng isang administrator ang user account.</translation>
 <translation id="2782685789517131804">Nagpadala ng email sa pag-sign in na may mga karagdagang tagubilin sa <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Tingnan ang iyong email para makumpleto ang pag-sign in.</translation>
 <translation id="2828509010894808185">Gumawa ng account</translation>
@@ -130,7 +129,7 @@
 <translation id="3122584863645047144">U.S. Virgin Islands</translation>
 <translation id="3141549453511344986">Mag-sign in gamit ang telepono</translation>
 <translation id="3147551458884186429">Indonesia</translation>
-<translation id="3154748063569624719">Una mong gustong mag-sign in gamit ang <ph name="PENDING_EMAIL" /></translation>
+<translation id="3154748063569624719">Una mong gustong mag-sign in gamit ang <ph name="PENDING_EMAIL" /></translation>
 <translation id="3164676761565983157">Venezuela</translation>
 <translation id="3170526549630869494">Nagkaproblema sa pag-sign in?</translation>
 <translation id="3204914819635733576">I-verify na ikaw ito</translation>
@@ -138,7 +137,7 @@
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">Bagong password</translation>
 <translation id="3250864391349648273">Gabon</translation>
-<translation id="3259479674319858599">Nagamit mo na ang <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Mag-sign in gamit ang <ph name="IDP_DISPLAY_NAME" /> upang magpatuloy.</translation>
+<translation id="3259479674319858599">Nagamit mo na ang <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Mag-sign in gamit ang <ph name="IDP_DISPLAY_NAME" /> upang magpatuloy.</translation>
 <translation id="3275852444431525182">New Zealand</translation>
 <translation id="3314478375063334511">Myanmar [Burma]</translation>
 <translation id="3361878270020566601">Iceland</translation>
@@ -171,7 +170,7 @@
 <translation id="3736041829854387744">Burundi</translation>
 <translation id="3755663127769565780">Mauritania</translation>
 <translation id="3813801701232240278">Twitter</translation>
-<translation id="3814740523815122846">Na-verify na ang iyong email</translation>
+<translation id="3814740523815122846">Na-verify na ang iyong email</translation>
 <translation id="3819556544383051267">Papua New Guinea</translation>
 <translation id="3828991952827504549">Hindi natagpuan ang tinukoy na resource.</translation>
 <translation id="3862053977934420187">Bine-verify...</translation>
@@ -184,13 +183,13 @@
 <translation id="4021489444336102711">I-verify</translation>
 <translation id="4022450612826261789">Kosovo</translation>
 <translation id="4025579119565425333">Subukan ang mga karaniwang pag-aayos na ito:</translation>
-<translation id="4056653682525186486">Mag-sign in gamit ang <ph name="XXX" /></translation>
+<translation id="4056653682525186486">Mag-sign in gamit ang <ph name="XXX" /></translation>
 <translation id="4064888056475403511">Subukang buksan ang link gamit ang parehong device o browser kung saan mo sinimulan ang proseso ng pag-sign in.</translation>
 <translation id="4066104405592701692">Estonia</translation>
 <translation id="4147949012570877154">I-delete</translation>
 <translation id="4163133799286985193">Argentina</translation>
 <translation id="4166504762096983411">Sa pagpapatuloy, ipinababatid mo na tinatanggap mo ang aming <ph name="START_LINK_1" />Mga Tuntunin ng Serbisyo<ph name="END_LINK" /> at <ph name="START_LINK_2" />Patakaran sa Privacy<ph name="END_LINK" />.</translation>
-<translation id="420554669252656972">Ilagay ang bagong email address</translation>
+<translation id="420554669252656972">Ilagay ang bagong email address</translation>
 <translation id="4210333062216604630">I-unlink</translation>
 <translation id="4242716276491763916">Guinea Conakry</translation>
 <translation id="4248546264350694306">Switzerland</translation>
@@ -199,7 +198,7 @@
 <translation id="4329551945958214898">Japan</translation>
 <translation id="4331763189922924781">Montenegro</translation>
 <translation id="4372962701784304822">Mozambique</translation>
-<translation id="4377158577300329881">Hindi tumutugma ang email address na iyon sa isang kasalukuyang account</translation>
+<translation id="4377158577300329881">Hindi tumutugma ang email address na iyon sa isang kasalukuyang account</translation>
 <translation id="4386334763822785837">Turkey</translation>
 <translation id="4413304190485210039">Tajikistan</translation>
 <translation id="4432634970196611353">Laos</translation>
@@ -208,36 +207,36 @@
 <translation id="4498504413765490964">Honduras</translation>
 <translation id="450385255996536115">Nag-time out ang operasyon.</translation>
 <translation id="4515732781724470190">Niger</translation>
-<translation id="4521614244485847733">Hindi tumutugma ang email address na iyon sa isang kasalukuyang account</translation>
+<translation id="4521614244485847733">Hindi tumutugma ang email address na iyon sa isang kasalukuyang account</translation>
 <translation id="4556476996891737119">Jordan</translation>
-<translation id="4571870355114729513">Sundin ang mga tagubilin na ipinadala sa <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> upang ma-recover ang iyong password</translation>
-<translation id="4588392627302012849">Mag-sign in gamit ang email</translation>
+<translation id="4571870355114729513">Sundin ang mga tagubilin na ipinadala sa <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> upang ma-recover ang iyong password</translation>
+<translation id="4588392627302012849">Mag-sign in gamit ang email</translation>
 <translation id="4595119411041064617">Sa pag-tap sa “<ph name="PH_1" />,“ maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</translation>
 <translation id="4632709875751031323">Russia</translation>
-<translation id="4644169548516814280">Ginagamit na ang email address ng ibang account</translation>
+<translation id="4644169548516814280">Ginagamit na ang email address ng ibang account</translation>
 <translation id="4692014002063276828">Poland</translation>
 <translation id="4723701728629289714">Israel</translation>
 <translation id="4725154639671888461">Nagkaroon ng error</translation>
 <translation id="4751937685196678080">Numero</translation>
 <translation id="4769553102874508676">Walang sapat na pahintulot ang client.</translation>
-<translation id="4773060157545352832">Sagutin ang reCAPTCHA</translation>
+<translation id="4773060157545352832">Sagutin ang reCAPTCHA</translation>
 <translation id="4775051289386800916">Nicaragua</translation>
 <translation id="4783400389150493171">Burkina Faso</translation>
 <translation id="4852256440857413490">Maling code. Subukang muli.</translation>
 <translation id="4866990546854875813">Maaaring nag-expire na o na-clear ang session na kaugnay nitong kahilingan sa pag-sign in.</translation>
 <translation id="4871106926303956169">Turks and Caicos Islands</translation>
-<translation id="4877597386645466815">Ipadala muli ang code sa <ph name="TIME_REMAINING" /></translation>
+<translation id="4877597386645466815">Ipadala muli ang code sa <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
 <ph name="P_START" />Na-update ang iyong account sa <ph name="APP_NAME" /> gamit ang isang numero ng telepono <ph name="SECOND_FACTOR" /> para sa 2-step na verification.<ph name="P_END" />
 <ph name="P_START" />Kung hindi mo idinagdag ang numero ng telepono na ito para sa 2-step na verification, i-click ang link sa ibaba para maalis ito.<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="4923375331439013137">Hindi maalis ang iyong pangalawang factor</translation>
-<translation id="4955175001894453989">Magdagdag ng password</translation>
+<translation id="4955175001894453989">Magdagdag ng password</translation>
 <translation id="496366313824211679">El Salvador</translation>
 <translation id="4982483807073820954">Upang baguhin ang password sa iyong account, kailangan mong mag-sign in muli.</translation>
 <translation id="4991626049082973728">Serbia</translation>
 <translation id="4991892293325936102">Belize</translation>
-<translation id="5042136001778337830"><ph name="START_PARAGRAPH" />para sa <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /><ph name="END_PARAGRAPH" /></translation>
+<translation id="5042136001778337830"><ph name="START_PARAGRAPH" />para sa <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /><ph name="END_PARAGRAPH" /></translation>
 <translation id="5059105734231232362">Para matagumpay na maikonekta ng flow na ito ang iyong <ph name="IDP_DISPLAY_NAME" /> account gamit ang email na ito, kailangan mong buksan ang link na ito sa parehong device o browser.</translation>
 <translation id="5080084639513001393">Sweden</translation>
 <translation id="5080899604429810481">Saint Martin</translation>
@@ -245,10 +244,10 @@
 <translation id="5143657419516597442">St. Lucia</translation>
 <translation id="5241732101105320538">Suriin ang iyong email</translation>
 <translation id="5255830932650472373">Bagong password</translation>
-<translation id="5301108536112812420">Ang iyong kahilingan na i-verify ang iyong email ay nag-expire na o nagamit na ang link</translation>
+<translation id="5301108536112812420">Ang iyong kahilingan na i-verify ang iyong email ay nag-expire na o nagamit na ang link</translation>
 <translation id="5323041129469627535">Oman</translation>
 <translation id="5326139833547026317">Caribbean Netherlands</translation>
-<translation id="5347459868860672391">Na-update na email address</translation>
+<translation id="5347459868860672391">Na-update na email address</translation>
 <translation id="5397737236938796917">Matagumpay kang naka-sign out.</translation>
 <translation id="5406620662929585965">Mag-sign in gamit ang telepono</translation>
 <translation id="5407010562344541906">Numero ng telepono</translation>
@@ -266,8 +265,8 @@
 <translation id="5543493820882105191">Ilagay ang iyong pangalan</translation>
 <translation id="55439745111619380">Ascension Island</translation>
 <translation id="5569341882117077010">Nagkaroon ng error sa network</translation>
-<translation id="5581239183924693195">Mag-sign in sa <ph name="IDP_DISPLAY_NAME" /></translation>
-<translation id="5585451911077299623">Pumili ng password</translation>
+<translation id="5581239183924693195">Mag-sign in sa <ph name="IDP_DISPLAY_NAME" /></translation>
+<translation id="5585451911077299623">Pumili ng password</translation>
 <translation id="5602886107840188229">British Indian Ocean Territory</translation>
 <translation id="5604510594682955626">Uganda</translation>
 <translation id="5606731250220630939">Norway</translation>
@@ -278,7 +277,7 @@
 <translation id="5649486931917149784">Password</translation>
 <translation id="5664080586064341046">St. Kitts</translation>
 <translation id="5668881954117611594">Bumalik</translation>
-<translation id="5699028034244995851">Ilagay ang iyong email address upang magpatuloy</translation>
+<translation id="5699028034244995851">Ilagay ang iyong email address upang magpatuloy</translation>
 <translation id="5701178667798108817">I-verify ang numero ng iyong telepono</translation>
 <translation id="5715637701147651513">Liberia</translation>
 <translation id="5747263508495256858">Mag-sign Out</translation>
@@ -288,16 +287,16 @@
 <translation id="5840765100196379855">Panama</translation>
 <translation id="5840803301882074743">Tonga</translation>
 <translation id="5850752921356750845">Wallis and Futuna</translation>
-<translation id="5853516492584814656">Hindi ma-update ang iyong email address</translation>
-<translation id="5905720181746284549">Nagamit mo na ang <ph name="STRING" /> upang mag-sign in. Ilagay ang iyong password para sa account na iyon.</translation>
+<translation id="5853516492584814656">Hindi ma-update ang iyong email address</translation>
+<translation id="5905720181746284549">Nagamit mo na ang <ph name="STRING" /> upang mag-sign in. Ilagay ang iyong password para sa account na iyon.</translation>
 <translation id="5921101578434778028">Anguilla</translation>
-<translation id="5948592577241492942">Umiiral na ang email na ito nang walang anumang paraan ng pag-sign in. Paki-reset ng password upang ma-recover.</translation>
+<translation id="5948592577241492942">Umiiral na ang email na ito nang walang anumang paraan ng pag-sign in. Paki-reset ng password upang ma-recover.</translation>
 <translation id="5985902459796151462">Dominican Republic</translation>
 <translation id="5987586156626209007">Jersey</translation>
-<translation id="5989709845715452405">I-recover ang password</translation>
-<translation id="5995596766674622541">Ilagay ang 6-digit na code na ipinadala namin sa <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
+<translation id="5989709845715452405">I-recover ang password</translation>
+<translation id="5995596766674622541">Ilagay ang 6-digit na code na ipinadala namin sa <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="6006148985615990975">Rwanda</translation>
-<translation id="6032262985756512833">Ilagay ang <ph name="STRING" />-digit na code na ipinadala namin sa</translation>
+<translation id="6032262985756512833">Ilagay ang <ph name="STRING" />-digit na code na ipinadala namin sa</translation>
 <translation id="6044396095102058216">Masyadong maraming beses nang nagamit ang numero ng teleponong ito</translation>
 <translation id="6083089720215618333">Hindi tumutugma ang ibinigay na email sa kasalukuyang session ng pag-sign-in.</translation>
 <translation id="6091051069256411999">Twitter</translation>
@@ -309,30 +308,31 @@
 <translation id="6143147250106939258">Nahigitan ang quota para sa operasyong ito. Subukang muli sa ibang pagkakataon.</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Algeria</translation>
-<translation id="6213969168046789596">Nagpasok ka ng di-wastong password nang masyadong maraming beses. Pakisubukang muli pagkalipas ng ilang minuto.</translation>
+<translation id="6213969168046789596">Nagpasok ka ng di-wastong password nang masyadong maraming beses. Pakisubukang muli pagkalipas ng ilang minuto.</translation>
 <translation id="6216759405419177713">Norfolk Island</translation>
-<translation id="6245066275978703471">Awtomatikong na-verify ang numero ng telepono</translation>
-<translation id="6269083314054226194">Error sa network, tingnan ang koneksyon mo sa internet.</translation>
-<translation id="6295157125625453859">Na-verify!</translation>
+<translation id="6238170540438416559">Sa pag-tap sa "<ph name="PH_1" />", ipinababatid mo na tinatanggap mo ang aming <ph name="PP" />. Maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</translation>
+<translation id="6265373887273416711">I-verify ang numero ng iyong telepono</translation>
+<translation id="6283536862756552051">Upang baguhin ang iyong password, kailangan mo munang ipasok ang iyong kasalukuyang password.</translation>
+<translation id="6299890279889400823">Bumalik</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Magpatuloy</translation>
-<translation id="6359400968059656782">Makakapag-sign in ka na ngayon gamit ang iyong bagong password</translation>
+<translation id="6359400968059656782">Makakapag-sign in ka na ngayon gamit ang iyong bagong password</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxembourg</translation>
 <translation id="6381974517529371884">Faroe Islands</translation>
 <translation id="6443180961828792673">Kosovo</translation>
 <translation id="6450170205342035038">Bulgaria</translation>
-<translation id="6470057025778734988">Hindi ka na makakapag-sign in gamit ang iyong account</translation>
+<translation id="6470057025778734988">Hindi ka na makakapag-sign in gamit ang iyong account</translation>
 <translation id="6472297146424049005">Tingnan ang iyong koneksyon sa internet.</translation>
 <translation id="6483116480230343278">Nagsa-sign up...</translation>
-<translation id="6494734506607758748">Upang baguhin ang email address na nauugnay sa iyong account, kailangan mong mag-sign in muli.</translation>
+<translation id="6494734506607758748">Upang baguhin ang email address na nauugnay sa iyong account, kailangan mong mag-sign in muli.</translation>
 <translation id="6508909904815637928">Vanuatu</translation>
 <translation id="6520863029476703422">American Samoa</translation>
 <translation id="6527597037551425211">Brazil</translation>
 <translation id="6555167606025370230">Magpatuloy sa <ph name="APP_NAME" /></translation>
 <translation id="657697593815023638">Swaziland</translation>
-<translation id="6584652721889639596">Hindi makapagpadala ng code ng pag-reset ng password sa tinukoy na email</translation>
+<translation id="6584652721889639596">Hindi makapagpadala ng code ng pag-reset ng password sa tinukoy na email</translation>
 <translation id="6608262346670935090">I-dismiss</translation>
 <translation id="6611519013130079637">Belgium</translation>
 <translation id="6618737424980030515">Georgia</translation>
@@ -340,7 +340,7 @@
 <translation id="6653313985929651858">Naipadala ang email sa pag-sign in\n</translation>
 <translation id="6655128609744896303">Naipadala ang code!</translation>
 <translation id="6683477520421532707">Réunion</translation>
-<translation id="6683810982254923169">Subukang i-reset muli ang iyong password</translation>
+<translation id="6683810982254923169">Subukang i-reset muli ang iyong password</translation>
 <translation id="6689542920381638295">Magpatuloy bilang bisita</translation>
 <translation id="6719973195813381061">Ecuador</translation>
 <translation id="6721310522324861790">Senegal</translation>
@@ -348,7 +348,7 @@
 <translation id="6728600931059699935">Micronesia</translation>
 <translation id="6739369526953005057">Hong Kong</translation>
 <translation id="6740430702644152657">Albania</translation>
-<translation id="6765051113469046531">Naibalik na ang iyong email sa pag-sign in sa <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
+<translation id="6765051113469046531">Naibalik na ang iyong email sa pag-sign in sa <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="6769550797775698634">Cameroon</translation>
 <translation id="6775190982418995854">Svalbard and Jan Mayen</translation>
 <translation id="6775835872637240659">Ukraine</translation>
@@ -371,18 +371,18 @@
 <translation id="7024571478138322659">Western Sahara</translation>
 <translation id="7025117765722694556">Hindi maaaring isagawa ang kahilingan sa kasalukuyang status ng system.</translation>
 <translation id="7062299334696934251">Nagkaroon ng hindi malamang error.</translation>
-<translation id="7064251114893721966">Nagamit mo na ang <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> upang mag-sign in. Ilagay ang iyong password para sa account na iyon.</translation>
+<translation id="7064251114893721966">Nagamit mo na ang <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> upang mag-sign in. Ilagay ang iyong password para sa account na iyon.</translation>
 <translation id="7085136866191400000">Naipadala na ang email sa pag-sign in</translation>
 <translation id="7089485669419398254">Ireland</translation>
 <translation id="7093343209860483088">Democratic Republic Congo</translation>
-<translation id="7118080999850002096">I-recover ang password</translation>
+<translation id="7118080999850002096">I-recover ang password</translation>
 <translation id="7150917293543492988">Republic of Congo</translation>
 <translation id="7157317431934821052">Mayroon nang resource na sinubukang gawin ng client.</translation>
 <translation id="7174424882502155514">Magpatuloy bilang bisita</translation>
 <translation id="7192078949090526171">San Marino</translation>
 <translation id="7197455001919474950">Cyprus</translation>
 <translation id="7198563013006562060">Solomon Islands</translation>
-<translation id="7207660930894629055">Magpatuloy sa <ph name="USER_EMAIL" />?</translation>
+<translation id="7207660930894629055">Magpatuloy sa <ph name="USER_EMAIL" />?</translation>
 <translation id="720983450833499456">Para magpatuloy sa pag-sign in gamit ang <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> sa device na ito, kailangan mong ma-recover ang password.</translation>
 <translation id="7223410082658239002">Maldives</translation>
 <translation id="7254028881697834212">São Tomé and Príncipe</translation>
@@ -393,7 +393,7 @@
 <translation id="7290147808482957603">Hindi naimplementa ng server ang API method.</translation>
 <translation id="7291567990403335374">Lesotho</translation>
 <translation id="7291656724505689727">Mag-sign in gamit ang telepono</translation>
-<translation id="7320029088567935126">Subukang i-verify muli ang iyong email</translation>
+<translation id="7320029088567935126">Subukang i-verify muli ang iyong email</translation>
 <translation id="7331038350037712642">Azerbaijan</translation>
 <translation id="7359542696390093035">Hindi Pinahintulutan</translation>
 <translation id="743266754881673808">Google</translation>
@@ -407,12 +407,12 @@
 <translation id="7592224526951017144">Germany</translation>
 <translation id="7595933825828475368">Nagkakaproblema sa pagtanggap ng email?</translation>
 <translation id="7615083347713899917">Kyrgyzstan</translation>
-<translation id="7643408533407091568">Nagamit mo na ang <ph name="EMAIL_ADDR" />
-        upang mag-sign in. Ilagay ang iyong password para sa account na iyon.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Hindi masyadong malakas ang password. Gumamit ng <ph name="PH_1" /> character man lang at kumbinasyon ng mga titik at mga numero}one{Hindi masyadong malakas ang password. Gumamit ng <ph name="PH_1" /> character man lang at kumbinasyon ng mga titik at mga numero}other{Hindi masyadong malakas ang password. Gumamit ng <ph name="PH_1" /> na character man lang at kumbinasyon ng mga titik at mga numero}}</translation>
+<translation id="7643408533407091568">Nagamit mo na ang <ph name="EMAIL_ADDR" />
+        upang mag-sign in. Ilagay ang iyong password para sa account na iyon.</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Hindi masyadong malakas ang password. Gumamit ng <ph name="PH_1" /> character man lang at kumbinasyon ng mga titik at mga numero}one{Hindi masyadong malakas ang password. Gumamit ng <ph name="PH_1" /> character man lang at kumbinasyon ng mga titik at mga numero}other{Hindi masyadong malakas ang password. Gumamit ng <ph name="PH_1" /> na character man lang at kumbinasyon ng mga titik at mga numero}}</translation>
 <translation id="7699755204074920022">Zimbabwe</translation>
 <translation id="7746977132739352062">Hindi na-authenticate ang kahilingan dahil sa nawawala, invalid, o nag-expire na OAuth token.</translation>
-<translation id="7782885946428624225">Nagkaproblema sa pag-verify ng numero ng iyong telepono</translation>
+<translation id="7782885946428624225">Nagkaproblema sa pag-verify ng numero ng iyong telepono</translation>
 <translation id="7796914496604415892">May nakitang bagong device o browser</translation>
 <translation id="786166109137986817">Mag-sign in sa <ph name="DISPLAY_NAME" /></translation>
 <translation id="7868540442111212282">Czechia</translation>
@@ -421,8 +421,8 @@
 <translation id="792838323404934335">Greenland</translation>
 <translation id="7956645158976161232">Libya</translation>
 <translation id="8017277252219866084">Kenya</translation>
-<translation id="8028653067082554952">Buburahin nito ang lahat ng data na nauugnay sa iyong account, at hindi na maa-undo. Sigurado ka bang gusto mong i-delete ang iyong account?</translation>
-<translation id="8033786138248870436">Sa pamamagitan ng pag-tap sa I-verify, maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</translation>
+<translation id="8028653067082554952">Buburahin nito ang lahat ng data na nauugnay sa iyong account, at hindi na maa-undo. Sigurado ka bang gusto mong i-delete ang iyong account?</translation>
+<translation id="8033786138248870436">Sa pamamagitan ng pag-tap sa I-verify, maaaring magpadala ng SMS. Maaaring ipatupad ang mga rate ng pagmemensahe at data.</translation>
 <translation id="8047183472745080590">Bolivia</translation>
 <translation id="8047565947836609247">Puerto Rico</translation>
 <translation id="8055755007915250245">I-unlink ang account?</translation>
@@ -448,7 +448,7 @@
 <translation id="8399150401520737446">Northern Mariana Islands</translation>
 <translation id="8414177484126578295">Falkland Islands [Islas Malvinas]</translation>
 <translation id="8420860857100049136">Peru</translation>
-<translation id="8422843028108996485">Kasalukuyang password</translation>
+<translation id="8422843028108996485">Kasalukuyang password</translation>
 <translation id="8426535539577812032">Welcome</translation>
 <translation id="8426971145354765033">Fiji</translation>
 <translation id="8448940737083561161">Kiribati</translation>
@@ -459,8 +459,8 @@
 <translation id="8505941919386646914">Martinique</translation>
 <translation id="8534746304953308378">Togo</translation>
 <translation id="8572093925387077451">Mayroon ka nang account</translation>
-<translation id="8585285847459057945">Binago ang iyong email sa pag-sign in para sa <ph name="APP_NAME" /></translation>
-<translation id="8585655327529919573">Kumuha ng mga tagubilin na ipadala sa email na ito na magpapaliwanag kung paano i-reset ang iyong password</translation>
+<translation id="8585285847459057945">Binago ang iyong email sa pag-sign in para sa <ph name="APP_NAME" /></translation>
+<translation id="8585655327529919573">Kumuha ng mga tagubilin na ipadala sa email na ito na magpapaliwanag kung paano i-reset ang iyong password</translation>
 <translation id="8652838224332661203">Nauru</translation>
 <translation id="8657280305228520442">Brunei</translation>
 <translation id="8657544769531875987">Chile</translation>
@@ -474,16 +474,16 @@
 <translation id="877434849857020571">Guernsey</translation>
 <translation id="8784650258250067845">Nigeria</translation>
 <translation id="8826577014688910360">North Korea</translation>
-<translation id="8833554344900398690"><ph name="IDV_CODE_PLACE_HOLDER" /> ang iyong code sa pag-verify.</translation>
+<translation id="8833554344900398690"><ph name="IDV_CODE_PLACE_HOLDER" /> ang iyong code sa pag-verify.</translation>
 <translation id="8835993416611657377">Mexico</translation>
 <translation id="884992060285817042">Bhutan</translation>
 <translation id="8869797682387766327">Isle of Man</translation>
 <translation id="8893950153780006385">Malaysia</translation>
 <translation id="8895840173743975193">Cocos [Keeling] Islands</translation>
 <translation id="8916080112145514151">Kung gusto mo pa ring ikonekta ang iyong <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> account, buksan ang link sa mismong device kung saan ka nagsimula ng pag-sign-in. Kung hindi, i-tap ang Magpatuloy para mag-sign in sa device na ito.</translation>
-<translation id="8920674952994839257">Subukang Muli</translation>
+<translation id="8920674952994839257">Subukan Ulit</translation>
 <translation id="8939353296336237380">Orihinal na sinadya mong ikonekta ang <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> sa iyong email account pero nabuksan ang link sa ibang device kung saan hindi ka naka-sign in.</translation>
-<translation id="8971555482255213064">Ipadala muli ang code sa loob ng 0:<ph name="PH_1" /></translation>
+<translation id="8971555482255213064">Ipadala muli ang code sa loob ng 0:<ph name="PH_1" /></translation>
 <translation id="8984161590699631096">Morocco</translation>
 <translation id="8994098794339484800">Kung hindi mo kilala ang device na ito, maaaring may uma-access ng iyong account. Isaalang-alang ang <ph name="START_LINK" />agad na pagpapalit ng iyong password<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesh</translation>

--- a/translations/fr.xtb
+++ b/translations/fr.xtb
@@ -28,9 +28,10 @@
 <translation id="144766329299583285">Si vous n'avez pas demandé à modifier l'adresse de connexion, il se peut que quelqu'un tente d'accéder à votre compte. Vous devriez <ph name="START_LINK" />modifier immédiatement votre mot de passe<ph name="END_LINK" />.</translation>
 <translation id="1449981769524156676">Heard et McDonald (Îles)</translation>
 <translation id="1451880131543823984"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> n'est pas autorisé à voir la page demandée.</translation>
-<translation id="1479035434297790822">De trop nombreuses demandes de compte proviennent de votre adresse IP. Veuillez réessayer dans quelques minutes.</translation>
+<translation id="1479035434297790822">De trop nombreuses demandes de compte proviennent de votre adresse IP. Veuillez réessayer dans quelques minutes.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Vous pouvez maintenant vous connecter avec votre nouveau compte</translation>
+<translation id="1535200361681091160">Saisissez votre adresse e-mail</translation>
 <translation id="1544981664986460902">Le client a spécifié un argument incorrect.</translation>
 <translation id="1575848116712334589">Tchad</translation>
 <translation id="1630237004390596779">Renvoyer le code dans <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Cook (Îles)</translation>
 <translation id="1870056762032541323">Code erroné. Veuillez réessayer.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Bonjour <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Supprimer le compte</translation>
-<translation id="1987722456379605552">Saisissez le code à six chiffres envoyé au <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Suivez les instructions envoyées à l'adresse <ph name="PH_1" /> pour récupérer votre mot de passe.</translation>
+<translation id="1912929493041975510">Le mot de passe doit comporter au moins 6 caractères.</translation>
+<translation id="1933044638365301516">Se connecter avec <ph name="STRING" /></translation>
+<translation id="1987722456379605552">Saisissez le code à six chiffres envoyé au <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
+<translation id="1999379687946415948">Votre code pour <ph name="APP_NAME" /> est <ph name="IDV_CODE_PLACE_HOLDER" />.</translation>
+<translation id="2033662766890821456">Renvoyer le code</translation>
 <translation id="2035855087334775326">Hongrie</translation>
 <translation id="2040904406955887821">Surinam</translation>
 <translation id="2046207054419739276">États-Unis</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Les mots de passe sécurisés comportent au moins six caractères et une combinaison de chiffres et de lettres</translation>
 <translation id="2074008538308369451">Conditions d'utilisation</translation>
 <translation id="2089802663554186342">Session terminée</translation>
 <translation id="2108717231438756650">Royaume-Uni</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Cap-Vert</translation>
 <translation id="2301396996587599046">Macédoine</translation>
 <translation id="2310948428656960769">Connecté</translation>
+<translation id="2321152797538991921">Le mot de passe doit comporter un caractère non alphanumérique</translation>
 <translation id="2324942959480650701">Invité</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">Le navigateur que vous utilisez n'est pas compatible avec le stockage Web. Veuillez réessayer dans un navigateur différent.</translation>
@@ -87,12 +89,12 @@
 <translation id="2448487988481516351">Nouvelle-Calédonie</translation>
 <translation id="2451742558284013472">Monaco</translation>
 <translation id="2460064915291012298">Seychelles</translation>
-<translation id="2490672522100125425">Le facteur suivant de la deuxième étape d'authentification a été supprimé : <ph name="START_STRONG" /><ph name="FACTOR_ID" /> <ph name="PHONE_NUMBER" /><ph name="END_STRONG" />.</translation>
+<translation id="2490672522100125425">Le facteur suivant de la deuxième étape d'authentification a été supprimé : <ph name="START_STRONG" /><ph name="FACTOR_ID" /> <ph name="PHONE_NUMBER" /><ph name="END_STRONG" />.</translation>
 <translation id="2494962141967044042">Échec de la mise à jour de l'utilisateur anonyme actuel. Les identifiants non anonymes sont déjà associés à un autre compte utilisateur.</translation>
 <translation id="2541179214468543429">Vous avez saisi un mot de passe incorrect un trop grand nombre de fois. Veuillez réessayer dans quelques minutes.</translation>
 <translation id="2561560038714758184">Sécurité</translation>
 <translation id="2561835578785502516">Votre demande de réinitialisation du mot de passe a expiré ou ce lien a déjà été utilisé</translation>
-<translation id="2562498793334241360">Vous pouvez maintenant vous connecter avec votre nouvelle adresse e-mail : <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
+<translation id="2562498793334241360">Vous pouvez maintenant vous connecter avec votre nouvelle adresse e-mail : <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="2581514546525533462">Le code pays indiqué n'est pas accepté.</translation>
 <translation id="2600950452451016107">Vérifiez que votre adresse e-mail est correcte.</translation>
 <translation id="2610891451939662786">Twitter</translation>
@@ -134,11 +136,12 @@
 <translation id="3147551458884186429">Indonésie</translation>
 <translation id="3154748063569624719">Initialement, vous souhaitiez vous connecter avec l'adresse <ph name="PENDING_EMAIL" /></translation>
 <translation id="3164676761565983157">Venezuela</translation>
-<translation id="3170526549630869494">Vous ne parvenez pas à vous connecter ?</translation>
+<translation id="3170526549630869494">Vous ne parvenez pas à vous connecter ?</translation>
 <translation id="3204914819635733576">Confirmez qu'il s'agit bien de vous</translation>
 <translation id="3215050409577090361">Une erreur s'est produite lors de l'authentification de votre requête. Veuillez retourner sur la page qui vous a redirigé ici pour relancer le processus d'authentification.</translation>
 <translation id="3216149523061905579">Dominique</translation>
 <translation id="3223688630903046698">Nouveau mot de passe</translation>
+<translation id="3245143966477136343">Le mot de passe doit comporter une minuscule</translation>
 <translation id="3250864391349648273">Gabon</translation>
 <translation id="3259479674319858599">Vous avez déjà utilisé l'adresse <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Connectez-vous avec <ph name="IDP_DISPLAY_NAME" /> pour continuer.</translation>
 <translation id="3275852444431525182">Nouvelle-Zélande</translation>
@@ -181,12 +184,12 @@
 <translation id="3898029444496274961">Se connecter</translation>
 <translation id="3905423743526704083">Timor Oriental</translation>
 <translation id="3908950705971364393">Djibouti</translation>
-<translation id="3954166521214262397">Code à six chiffres</translation>
+<translation id="3954166521214262397">Code à six chiffres</translation>
 <translation id="3987987513436822097">Comores</translation>
 <translation id="3998148019488053682">Vous devez saisir un code de validation.</translation>
 <translation id="4011940631682920330">Le code d'action n'est pas valide. Ce problème peut survenir si le code est incorrect, s'il est arrivé à expiration ou s'il a déjà été utilisé.</translation>
 <translation id="4022450612826261789">Kosovo</translation>
-<translation id="4025579119565425333">Essayez les solutions courantes suivantes :</translation>
+<translation id="4025579119565425333">Essayez les solutions courantes suivantes :</translation>
 <translation id="4056653682525186486">Se connecter avec <ph name="XXX" /></translation>
 <translation id="4064888056475403511">Essayez d'ouvrir le lien en utilisant le même appareil ou navigateur que celui sur lequel vous avez commencé le processus de connexion.</translation>
 <translation id="4066104405592701692">Estonie</translation>
@@ -198,7 +201,7 @@
 <translation id="4242716276491763916">Guinée</translation>
 <translation id="4248546264350694306">Suisse</translation>
 <translation id="4266056491449352939">Andorre</translation>
-<translation id="4322167048992801895">Vous n'avez pas reçu l'e-mail ?</translation>
+<translation id="4322167048992801895">Vous n'avez pas reçu l'e-mail ?</translation>
 <translation id="4329551945958214898">Japon</translation>
 <translation id="4331763189922924781">Monténégro</translation>
 <translation id="4372962701784304822">Mozambique</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Suivez les instructions envoyées à l'adresse <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> pour récupérer votre mot de passe</translation>
 <translation id="4588392627302012849">Se connecter avec une adresse e-mail</translation>
 <translation id="4595119411041064617">En appuyant sur "<ph name="PH_1" />", vous déclencherez peut-être l'envoi d'un SMS. Des frais de messages et de données peuvent être facturés.</translation>
+<translation id="4603232692404395592">Le mot de passe ne doit pas comporter plus de <ph name="MAX_PASSWORD_LENGTH" /> caractères</translation>
 <translation id="4632709875751031323">Russie</translation>
 <translation id="4644169548516814280">L'adresse e-mail est déjà utilisée par un autre compte</translation>
 <translation id="4692014002063276828">Pologne</translation>
@@ -229,7 +233,7 @@
 <translation id="4852256440857413490">Code erroné. Veuillez réessayer.</translation>
 <translation id="4866990546854875813">La session associée à cette demande de connexion a expiré ou a été effacée.</translation>
 <translation id="4871106926303956169">Turks-et-Caïcos (Îles)</translation>
-<translation id="4877597386645466815">Renvoyer le code dans <ph name="TIME_REMAINING" /></translation>
+<translation id="4877597386645466815">Renvoyer le code dans <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
 <ph name="P_START" />Un numéro de téléphone <ph name="SECOND_FACTOR" /> a été enregistré dans votre compte <ph name="APP_NAME" /> pour la validation en deux étapes.<ph name="P_END" />
 <ph name="P_START" />Si vous n'avez pas ajouté ce numéro de téléphone, cliquez sur le lien ci-dessous pour le supprimer.<ph name="P_END" />
@@ -299,9 +303,9 @@
 <translation id="5985902459796151462">République dominicaine</translation>
 <translation id="5987586156626209007">Jersey</translation>
 <translation id="5989709845715452405">Récupérer votre mot de passe</translation>
-<translation id="5995596766674622541">Saisissez le code à six chiffres envoyé au <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
+<translation id="5995596766674622541">Saisissez le code à six chiffres envoyé au <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="6006148985615990975">Rwanda</translation>
-<translation id="6032262985756512833">Saisissez le code à <ph name="STRING" /> chiffres envoyé au</translation>
+<translation id="6032262985756512833">Saisissez le code à <ph name="STRING" /> chiffres envoyé au</translation>
 <translation id="6044396095102058216">Ce numéro de téléphone a été utilisé un trop grand nombre de fois</translation>
 <translation id="6083089720215618333">L'adresse e-mail fournie ne correspond pas à celle utilisée pour la session de connexion en cours.</translation>
 <translation id="6091051069256411999">Twitter</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Vérifiez que votre boîte de réception n'est pas pleine et que les paramètres sont correctement définis.</translation>
 <translation id="6135589730599211649">Le client a spécifié une plage non valide.</translation>
 <translation id="6143147250106939258">Le quota pour cette opération a été dépassé. Réessayez plus tard.</translation>
+<translation id="615787395595800956">Exigences pour les mots de passe non remplies :</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Algérie</translation>
 <translation id="6213969168046789596">Vous avez saisi un mot de passe incorrect un trop grand nombre de fois. Veuillez réessayer dans quelques minutes.</translation>
 <translation id="6216759405419177713">Norfolk (Île)</translation>
-<translation id="6245066275978703471">Numéro de téléphone validé automatiquement</translation>
-<translation id="6269083314054226194">Erreur de réseau, vérifiez votre connexion Internet.</translation>
-<translation id="6295157125625453859">Le code a bien été validé.</translation>
+<translation id="6238170540438416559">En appuyant sur "<ph name="PH_1" />", vous acceptez les <ph name="PP" />. Vous déclencherez peut-être l'envoi d'un SMS. Des frais de messages et de données peuvent être facturés.</translation>
+<translation id="6265373887273416711">Valider votre numéro de téléphone</translation>
+<translation id="6283536862756552051">Pour modifier votre mot de passe, vous devez d'abord saisir votre mot de passe actuel.</translation>
+<translation id="6299890279889400823">Retour</translation>
 <translation id="6316446940976157217">Inde</translation>
 <translation id="6327723482938582895">Bénin</translation>
 <translation id="6338643731889005578">Continuer</translation>
+<translation id="6355621963154078138">Le mot de passe doit comporter un caractère numérique</translation>
 <translation id="6359400968059656782">Vous pouvez maintenant vous connecter avec votre nouveau mot de passe</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxembourg</translation>
@@ -350,9 +357,9 @@
 <translation id="6721310522324861790">Sénégal</translation>
 <translation id="6724344978634903280">Botswana</translation>
 <translation id="6728600931059699935">Micronésie</translation>
-<translation id="6739369526953005057">Hong Kong</translation>
+<translation id="6739369526953005057">Hong Kong</translation>
 <translation id="6740430702644152657">Albanie</translation>
-<translation id="6765051113469046531">Votre adresse e-mail de connexion est de nouveau la suivante : <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
+<translation id="6765051113469046531">Votre adresse e-mail de connexion est de nouveau la suivante : <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="6769550797775698634">Cameroun</translation>
 <translation id="6775190982418995854">Svalbard et Jan Mayen</translation>
 <translation id="6775835872637240659">Ukrainien</translation>
@@ -386,7 +393,7 @@
 <translation id="7192078949090526171">Saint-Marin</translation>
 <translation id="7197455001919474950">Chypre</translation>
 <translation id="7198563013006562060">Salomon (Îles)</translation>
-<translation id="7207660930894629055">Souhaitez-vous continuer avec l'adresse <ph name="USER_EMAIL" /> ?</translation>
+<translation id="7207660930894629055">Souhaitez-vous continuer avec l'adresse <ph name="USER_EMAIL" /> ?</translation>
 <translation id="720983450833499456">Pour vous connecter avec l'adresse e-mail <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> sur cet appareil, vous devez récupérer votre mot de passe.</translation>
 <translation id="7223410082658239002">Maldives</translation>
 <translation id="7254028881697834212">Sao Tomé-et-Principe</translation>
@@ -409,27 +416,28 @@
 <translation id="7560587702704358921">Saint-Pierre-et-Miquelon</translation>
 <translation id="7569285452790032317">Somalie</translation>
 <translation id="7592224526951017144">Allemagne</translation>
-<translation id="7595933825828475368">Vous n'avez pas reçu l'e-mail ?</translation>
+<translation id="7595933825828475368">Vous n'avez pas reçu l'e-mail ?</translation>
 <translation id="7615083347713899917">Kirghizstan</translation>
 <translation id="7643408533407091568">Vous avez déjà utilisé l'adresse e-mail <ph name="EMAIL_ADDR" /> pour vous connecter. Saisissez le mot de passe du compte.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Le mot de passe n'est pas assez sécurisé. Utilisez au moins <ph name="PH_1" /> caractère et une combinaison de chiffres et de lettres.}one{Le mot de passe n'est pas assez sécurisé. Utilisez au moins <ph name="PH_1" /> caractère et une combinaison de chiffres et de lettres.}other{Le mot de passe n'est pas assez sécurisé. Utilisez au moins <ph name="PH_1" /> caractères et une combinaison de chiffres et de lettres.}}</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Le mot de passe n'est pas assez sécurisé. Utilisez au moins <ph name="PH_1" /> caractère et une combinaison de chiffres et de lettres.}one{Le mot de passe n'est pas assez sécurisé. Utilisez au moins <ph name="PH_1" /> caractère et une combinaison de chiffres et de lettres.}other{Le mot de passe n'est pas assez sécurisé. Utilisez au moins <ph name="PH_1" /> caractères et une combinaison de chiffres et de lettres.}}</translation>
 <translation id="7699755204074920022">Zimbabwe</translation>
 <translation id="7746977132739352062">La requête n'a pas été authentifiée en raison d'un jeton OAuth manquant, non valide ou ayant expiré.</translation>
-<translation id="7778245738233381641">Veuillez indiquer un code de validation à six chiffres.</translation>
+<translation id="7778245738233381641">Veuillez indiquer un code de validation à six chiffres.</translation>
 <translation id="7790301903034097323">Choisissez un mot de passe</translation>
 <translation id="7796914496604415892">Nouveau navigateur ou appareil détecté</translation>
 <translation id="786166109137986817">Se connecter à <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">Le mot de passe doit comporter une majuscule</translation>
 <translation id="7868540442111212282">République tchèque</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Se connecter avec GitHub</translation>
 <translation id="792838323404934335">Groenland</translation>
 <translation id="7956645158976161232">Libye</translation>
 <translation id="8017277252219866084">Kenya</translation>
-<translation id="8028653067082554952">Cette action effacera toutes les données associées à votre compte de façon irréversible. Voulez-vous vraiment supprimer votre compte ?</translation>
+<translation id="8028653067082554952">Cette action effacera toutes les données associées à votre compte de façon irréversible. Voulez-vous vraiment supprimer votre compte ?</translation>
 <translation id="8033786138248870436">En appuyant sur "Valider", vous déclencherez peut-être l'envoi d'un SMS. Des frais de messages et de données peuvent être facturés.</translation>
 <translation id="8047183472745080590">Bolivie</translation>
 <translation id="8047565947836609247">Porto Rico</translation>
-<translation id="8055755007915250245">Dissocier le compte ?</translation>
+<translation id="8055755007915250245">Dissocier le compte ?</translation>
 <translation id="8063505483150915580">Christmas (Île)</translation>
 <translation id="8077378925683571933">
 <ph name="P_START" />Merci,<ph name="P_END" />
@@ -444,7 +452,7 @@
 <translation id="8283013172847705078">Costa Rica</translation>
 <translation id="8289427665929658971">Samoa</translation>
 <translation id="8320813901740734879">
-<ph name="P_START" />Le facteur <ph name="SECOND_FACTOR" /> a été ajouté à votre compte <ph name="APP_NAME" /> pour l'authentification à deux facteurs.<ph name="P_END" />
+<ph name="P_START" />Le facteur <ph name="SECOND_FACTOR" /> a été ajouté à votre compte <ph name="APP_NAME" /> pour l'authentification à deux facteurs.<ph name="P_END" />
 <ph name="P_START" />Si vous n'avez pas demandé cette mise à jour, veuillez cliquer sur le lien ci-dessous pour annuler la modification.<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="8335491854074085727">Mali</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151">Si vous souhaitez toujours associer votre compte <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, ouvrez le lien sur l'appareil avec lequel vous avez commencé à vous connecter. Sinon, appuyez sur "Continuer" pour vous connecter depuis un autre appareil.</translation>
 <translation id="8920674952994839257">Réessayer</translation>
 <translation id="8939353296336237380">Vous aviez décidé d'associer votre compte <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> à votre adresse e-mail, mais vous avez ouvert le lien sur un appareil différent de celui avec lequel vous vous êtes connecté.</translation>
-<translation id="8971555482255213064">Renvoyer le code dans 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">En appuyant sur <ph name="BTN" />, vous acceptez les <ph name="PP" />.</translation>
+<translation id="8980953965669178372">OK</translation>
 <translation id="8984161590699631096">Maroc</translation>
 <translation id="8994098794339484800">Si vous ne reconnaissez pas cet appareil, cela signifie peut-être que quelqu'un essaie d'accéder à votre compte. Envisagez de <ph name="START_LINK" />modifier votre mot de passe tout de suite<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesh</translation>
 <translation id="9022632332691561239">Téléphone</translation>
 <translation id="9028063588419847334">Finlande</translation>
 <translation id="9078135685219203661">Émirats arabes unis</translation>
+<translation id="9085311482535098646">Le mot de passe doit comporter au moins <ph name="MIN_PASSWORD_LENGTH" /> caractères</translation>
 <translation id="9121203582272050974">Votre adresse e-mail a été validée et modifiée</translation>
 <translation id="9156150178611681179">Mot de passe</translation>
 <translation id="9168877696443530714">République centrafricaine</translation>

--- a/translations/hi.xtb
+++ b/translations/hi.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">कुक आइलैंड</translation>
 <translation id="1870056762032541323">गलत कोड. फिर से कोशिश करें.</translation>
 <translation id="1898579907513173256">मकाऊ</translation>
-<translation id="1929332760123475919"><ph name="P_START" />नमस्कार <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">खाता हटाएं</translation>
+<translation id="1912929493041975510">पासवर्ड कम से कम छह वर्णों का होना चाहिए</translation>
+<translation id="1933044638365301516"><ph name="STRING" /> से प्रवेश करें</translation>
 <translation id="1987722456379605552">हमारी ओर से <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /> पर भेजा गया 6-अंकों वाला  कोड डालें</translation>
 <translation id="2016421613709283485">अपना पासवर्ड फिर से पाने के लिए <ph name="PH_1" /> पर भेजे गए निर्देशों का पालन करें.</translation>
 <translation id="2035855087334775326">हंगरी</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">संयुक्त राज्य</translation>
 <translation id="2049229571938383319">सेंट बार्थेलेमी</translation>
 <translation id="2058731785647385204">मॉन्टसेरैट</translation>
-<translation id="2070709910567585968">सशक्त पासवर्ड में कम से कम 6 वर्ण होने चाहिए और वे अक्षरों और नंबरों दोनों को मिलाकर बना होना चाहिए</translation>
 <translation id="2074008538308369451">सेवा की शर्तें</translation>
 <translation id="2089802663554186342">सत्र खत्म हो गया है</translation>
 <translation id="2108717231438756650">यूनाइटेड किंगडम</translation>
@@ -94,7 +93,7 @@
 <translation id="2561835578785502516">आपके पासवर्ड रीसेट अनुरोध की समय-सीमा खत्म हो गई है या लिंक का उपयोग पहले ही किया जा चुका है</translation>
 <translation id="2562498793334241360">अब आप अपने नए ईमेल पते <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> से साइन इन कर सकते हैं.</translation>
 <translation id="2581514546525533462">डाला गया देश कोड इस्तेमाल नहीं किया जा सकता है.</translation>
-<translation id="2600950452451016107">देख लें कि आपने ईमेल पते की वर्तनी गलत तो नहीं लिखी है.</translation>
+<translation id="2600950452451016107">देख लें कि आपने ईमेल पते की स्पेलिंग गलत तो नहीं लिखी है.</translation>
 <translation id="2610891451939662786">Twitter</translation>
 <translation id="2612036261782356367">कंबोडिया</translation>
 <translation id="2614081868476050089">सेवा उपलब्ध नहीं है.</translation>
@@ -116,7 +115,7 @@
 <translation id="276938411216176478">उपयोगकर्ता के खाते को एडमिन ने बंद कर दिया है.</translation>
 <translation id="2782685789517131804">साइन-इन पूरा करने के लिए और भी ज़्यादा निर्देशों वाला एक ईमेल <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> पर भेजा गया है. साइन-इन पूरा करने के लिए अपना ईमेल देखें.</translation>
 <translation id="2828509010894808185">खाता बनाएं</translation>
-<translation id="2834770837848769530">अफ़गानिस्तान</translation>
+<translation id="2834770837848769530">अफ़ग़ानिस्तान</translation>
 <translation id="2884525438023347369"><ph name="BTN" /> पर टैप करके आप बताते हैं कि आप <ph name="TOS" /> से सहमत हैं.</translation>
 <translation id="2909392332969582158">कनाडा</translation>
 <translation id="2911018261311455240">डेनमार्क</translation>
@@ -160,14 +159,14 @@
 <translation id="3550380781997195832">वह ईमेल पता सही नहीं है</translation>
 <translation id="3552446912357282301">अनुमति के लिए, कृपया <ph name="START_STRONG" /><ph name="ADMIN_EMAIL" /><ph name="END_STRONG" /> से संपर्क करें.</translation>
 <translation id="3561568594856945084">मायोटे</translation>
-<translation id="3591063723610544836">प्रवेश करें</translation>
+<translation id="3591063723610544836">साइन इन करें</translation>
 <translation id="3593480381831738519">अपना पासवर्ड रीसेट करें</translation>
 <translation id="3597673897213051724">भेजें</translation>
 <translation id="3605933028246642593">नेपाल</translation>
 <translation id="3608140835232496799">तोकेलाउ</translation>
 <translation id="3620185428620643248">प्रमाणीकरण देने वाले के लिए चयनित क्रेडेंशियल समर्थित नहीं है!</translation>
 <translation id="3658306886462996856">दिए गए ईमेल से साइन इन नहीं किया जा सकता. कृपया कोई दूसरा ईमेल डालें.</translation>
-<translation id="3695180913983403205">कृपया नाम और उपनाम डालें.</translation>
+<translation id="3695180913983403205">कृपया नाम और सरनेम डालें.</translation>
 <translation id="3700097473356216716">कोलंबिया</translation>
 <translation id="3703067902498234034">सेव करें को टैप करके आप यह बताते हैं कि आप इससे सहमत हैं </translation>
 <translation id="3736041829854387744">बुरुंडी</translation>
@@ -177,7 +176,7 @@
 <translation id="3819556544383051267">पापुआ न्यू गिनी</translation>
 <translation id="3828991952827504549">बताया गया संसाधन नहीं मिला.</translation>
 <translation id="3862053977934420187">पुष्टि कर रहा है…</translation>
-<translation id="3898029444496274961">प्रवेश करें</translation>
+<translation id="3898029444496274961">साइन इन करें</translation>
 <translation id="3905423743526704083">पूर्वी तिमोर</translation>
 <translation id="3908950705971364393">जिबूती</translation>
 <translation id="3954166521214262397">6-अंकों वाला कोड</translation>
@@ -202,7 +201,7 @@
 <translation id="4331763189922924781">मॉन्टेनेग्रो</translation>
 <translation id="4372962701784304822">मोज़ाम्बिक</translation>
 <translation id="4377158577300329881">वह ईमेल पता किसी मौजूदा खाते से मेल नहीं खाता है</translation>
-<translation id="4386334763822785837">तुर्की</translation>
+<translation id="4386334763822785837">तुर्किये</translation>
 <translation id="4413304190485210039">तजिकिस्तान</translation>
 <translation id="4432634970196611353">लाओस</translation>
 <translation id="4440507149645221385">फ़ोन</translation>
@@ -218,7 +217,7 @@
 <translation id="4632709875751031323">रूस</translation>
 <translation id="4644169548516814280">ईमेल पता पहले से ही किसी दूसरे खाते के लिए उपयोग में लाया जा चुका है</translation>
 <translation id="4692014002063276828">पोलैंड</translation>
-<translation id="4723701728629289714">इज़राइल</translation>
+<translation id="4723701728629289714">इज़रायल</translation>
 <translation id="4725154639671888461">गड़बड़ी का सामना करना पड़ा</translation>
 <translation id="4751937685196678080">नंबर</translation>
 <translation id="4769553102874508676">क्लाइंट के पास ज़रूरी अनुमति नहीं है.</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">अल्जीरिया</translation>
 <translation id="6213969168046789596">आपने कई बार गलत पासवर्ड डाला है. कृपया कुछ मिनटों में फिर से कोशिश करें.</translation>
 <translation id="6216759405419177713">नॉरफ़ोक आइलैंड</translation>
-<translation id="6245066275978703471">फ़ोन नंबर की अपने आप पुष्टि की गई</translation>
-<translation id="6269083314054226194">नेटवर्क में गड़बड़ी है. देखें कि इंटरनेट काम कर रहा है या नहीं.</translation>
-<translation id="6295157125625453859">पुष्टि हो चुकी है!</translation>
+<translation id="6238170540438416559">“<ph name="PH_1" />” पर टैप करके, आप यह बताते हैं कि आप हमारी <ph name="PP" /> मंज़ूर करते हैं. एक मैसेज (एसएमएस) भेजा जा सकता है. मैसेज और डेटा दरें लागू हो सकती हैं.</translation>
+<translation id="6265373887273416711">अपने फ़ोन नंबर की पुष्टि करें</translation>
+<translation id="6283536862756552051">अपना पासवर्ड बदलने के लिए, आपको पहले अपना मौजूदा पासवर्ड डालना होगा.</translation>
+<translation id="6299890279889400823">वापस जाएं</translation>
 <translation id="6316446940976157217">भारत</translation>
 <translation id="6327723482938582895">बेनिन</translation>
 <translation id="6338643731889005578">जारी रखें</translation>
@@ -349,7 +349,7 @@
 <translation id="6721310522324861790">सेनेगल</translation>
 <translation id="6724344978634903280">बोत्सवाना</translation>
 <translation id="6728600931059699935">माइक्रोनेशिया</translation>
-<translation id="6739369526953005057">हांग कांग</translation>
+<translation id="6739369526953005057">हॉन्ग कॉन्ग</translation>
 <translation id="6740430702644152657">अल्बानिया</translation>
 <translation id="6765051113469046531">आपका साइन-इन ईमेल पता बदलकर वापस <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> कर दिया गया है.</translation>
 <translation id="6769550797775698634">कैमरून</translation>
@@ -369,7 +369,7 @@
 <translation id="6961220857430789248">ज़्यादा निर्देशों वाला एक साइन-इन ईमेल <ph name="STRING" /> पर भेजा गया है. साइन-इन पूरा करने के लिए अपना ईमेल देखें.</translation>
 <translation id="6984204927251307445">ईमेल की पुष्टि करें</translation>
 <translation id="6996552808101270965">ज़्यादा जानें</translation>
-<translation id="6999773882165218263">नाम और उपनाम</translation>
+<translation id="6999773882165218263">नाम और सरनेम</translation>
 <translation id="7012506961150923116">ग्रेनेडा</translation>
 <translation id="7024571478138322659">पश्चिमी सहारा</translation>
 <translation id="7025117765722694556">सिस्टम की मौजूदा स्थिति में अनुरोध पूरा नहीं किया जा सकता.</translation>

--- a/translations/hr.xtb
+++ b/translations/hr.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Cookovi Otoci</translation>
 <translation id="1870056762032541323">Pogrešan kôd. Pokušajte ponovo.</translation>
 <translation id="1898579907513173256">Makao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Pozdrav, <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Izbriši račun</translation>
+<translation id="1912929493041975510">Zaporka mora sadržavati najmanje šest znakova</translation>
+<translation id="1933044638365301516">Prijava putem usluge <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Unesite 6-znamenkasti kôd koji smo poslali na broj <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Slijedite upute za ponovno postavljanje zaporke koje smo poslali na e-adresu <ph name="PH_1" />.</translation>
 <translation id="2035855087334775326">Mađarska</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Sjedinjene Američke Države</translation>
 <translation id="2049229571938383319">Saint Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Snažne zaporke sadrže bar 6 znakova koji su kombinacija slova i znamenki</translation>
 <translation id="2074008538308369451">Uvjeti pružanja usluge</translation>
 <translation id="2089802663554186342">Sesija je završila</translation>
 <translation id="2108717231438756650">Ujedinjeno Kraljevstvo</translation>
@@ -135,7 +134,7 @@
 <translation id="3164676761565983157">Venezuela</translation>
 <translation id="3170526549630869494">Problem s prijavom?</translation>
 <translation id="3204914819635733576">Potvrdite svoj identitet</translation>
-<translation id="3215050409577090361">Pri provjeri autentičnosti vašeg zahtjeva došlo je do problema. Ponovo otvorite URL koji vas je preusmjerio na ovu stranicu da biste ponovo pokrenuli postupak provjere autentičnosti.</translation>
+<translation id="3215050409577090361">Pri autentifikaciji vašeg zahtjeva došlo je do problema. Ponovo otvorite URL koji vas je preusmjerio na ovu stranicu da biste ponovo pokrenuli postupak autentifikacije.</translation>
 <translation id="3216149523061905579">Dominika</translation>
 <translation id="3223688630903046698">Nova zaporka</translation>
 <translation id="3250864391349648273">Gabon</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Alžir</translation>
 <translation id="6213969168046789596">Unijeli ste netočnu zaporku previše puta. Pokušajte ponovo za nekoliko minuta.</translation>
 <translation id="6216759405419177713">Otok Norfolk</translation>
-<translation id="6245066275978703471">Telefonski je broj automatski potvrđen</translation>
-<translation id="6269083314054226194">Pogreška na mreži; provjerite internetsku vezu.</translation>
-<translation id="6295157125625453859">Potvrda je uspjela!</translation>
+<translation id="6238170540438416559">Ako dodirnete "<ph name="PH_1" />", potvrđujete da prihvaćate odredbe koje sadrži <ph name="PP" />. Možda ćemo vam poslati SMS. Moguća je naplata poruke i podatkovnog prometa.</translation>
+<translation id="6265373887273416711">Potvrda telefonskog broja</translation>
+<translation id="6283536862756552051">Da biste promijenili zaporku, najprije trebate unijeti trenutačnu zaporku.</translation>
+<translation id="6299890279889400823">Natrag</translation>
 <translation id="6316446940976157217">Indija</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Nastavi</translation>

--- a/translations/hu.xtb
+++ b/translations/hu.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Cook-szigetek</translation>
 <translation id="1870056762032541323">Hibás kód. Próbálja újra.</translation>
 <translation id="1898579907513173256">Makaó</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Kedves <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Fiók törlése</translation>
+<translation id="1912929493041975510">A jelszónak legalább 6 karakterből kell állnia</translation>
+<translation id="1933044638365301516">Bejelentkezés a következővel: <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Adja meg a következő telefonszámra elküldött 6 számjegyű kódot: <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">A jelszó visszaállításához kövesse az ide (<ph name="PH_1" />) elküldött utasításokat.</translation>
 <translation id="2035855087334775326">Magyarország</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Amerikai Egyesült Államok</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Az erős jelszavak legalább 6 karakterből állnak, valamint betűket és számokat egyaránt tartalmaznak.</translation>
 <translation id="2074008538308369451">Általános Szerződési Feltételek</translation>
 <translation id="2089802663554186342">A munkamenet befejeződött</translation>
 <translation id="2108717231438756650">Egyesült Királyság</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Algéria</translation>
 <translation id="6213969168046789596">Túl sokszor adott meg hibás jelszót. Kérjük, néhány perc múlva próbálja újra.</translation>
 <translation id="6216759405419177713">Norfolk-sziget</translation>
-<translation id="6245066275978703471">A telefonszám automatikusan ellenőrizve</translation>
-<translation id="6269083314054226194">Hálózati hiba; ellenőrizze az internetkapcsolatot.</translation>
-<translation id="6295157125625453859">Ellenőrzött!</translation>
+<translation id="6238170540438416559">A(z) „<ph name="PH_1" />” gombra való koppintással elfogadja a következő dokumentumot: <ph name="PP" />. A rendszer SMS-t küldhet Önnek. A szolgáltató ezért üzenet- és adatforgalmi díjat számíthat fel.</translation>
+<translation id="6265373887273416711">Telefonszám igazolása</translation>
+<translation id="6283536862756552051">A jelszó módosításához előbb meg kell adnia a jelenlegi jelszavát.</translation>
+<translation id="6299890279889400823">Vissza</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Folytatás</translation>

--- a/translations/id.xtb
+++ b/translations/id.xtb
@@ -1,3 +1,4 @@
+
 <translationbundle lang="id">
 <translation id="1003362845472634045">Email login terkirim</translation>
 <translation id="10081113082271688">Kode verifikasi salah</translation>
@@ -17,7 +18,7 @@
 <translation id="1268266284642694018">Lebanon</translation>
 <translation id="1294742657282291237">Guyana</translation>
 <translation id="1297168472480293352">Guatemala</translation>
-<translation id="1307255433239736397"><ph name="START_PARAGRAPH" />Terjadi masalah saat menghapus faktor kedua Anda.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Coba hapus lagi. Jika belum berhasil, hubungi dukungan untuk mendapatkan bantuan.<ph name="END_PARAGRAPH" /></translation>
+<translation id="1307255433239736397"><ph name="START_PARAGRAPH" />Terjadi error saat menghapus faktor kedua Anda.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Coba hapus lagi. Jika belum berhasil, hubungi dukungan untuk mendapatkan bantuan.<ph name="END_PARAGRAPH" /></translation>
 <translation id="1310034618729602982">Coba perbarui email Anda lagi</translation>
 <translation id="1312824004897469797">Telah terjadi error pada jaringan. Coba lagi nanti.</translation>
 <translation id="1315809131562953678">Masukan nomor telepon yang valid</translation>
@@ -31,6 +32,7 @@
 <translation id="1479035434297790822">Terlalu banyak permintaan akun yang berasal dari alamat IP Anda. Coba beberapa menit lagi.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Sekarang Anda dapat login dengan akun baru</translation>
+<translation id="1535200361681091160">Masukkan email Anda</translation>
 <translation id="1544981664986460902">Klien menentukan ada argumen yang tidak valid.</translation>
 <translation id="1575848116712334589">Cad</translation>
 <translation id="1630237004390596779">Kirirmkan kembali kode dalam <ph name="STRING" /></translation>
@@ -45,16 +47,16 @@
 <translation id="1799407952500261728">Kepulauan Cook</translation>
 <translation id="1870056762032541323">Kode salah. Coba lagi.</translation>
 <translation id="1898579907513173256">Makau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Halo <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Hapus akun</translation>
+<translation id="1912929493041975510">Sandi harus minimal 6 karakter</translation>
+<translation id="1933044638365301516">Login dengan <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Masukkan kode 6 digit yang kami kirimkan ke <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Ikuti petunjuk yang dikirimkan ke <ph name="PH_1" /> untuk memulihkan sandi Anda.</translation>
+<translation id="1999379687946415948"><ph name="IDV_CODE_PLACE_HOLDER" /> adalah kode Anda untuk <ph name="APP_NAME" />.</translation>
+<translation id="2033662766890821456">Kirim ulang kode</translation>
 <translation id="2035855087334775326">Hungaria</translation>
 <translation id="2040904406955887821">Suriname</translation>
 <translation id="2046207054419739276">Amerika Serikat</translation>
 <translation id="2049229571938383319">Saint Barthelemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Sandi yang kuat harus memiliki minimal 6 karakter dan merupakan kombinasi huruf dan angka</translation>
 <translation id="2074008538308369451">Persyaratan Layanan</translation>
 <translation id="2089802663554186342">Sesi diakhiri</translation>
 <translation id="2108717231438756650">Inggris Raya</translation>
@@ -74,6 +76,7 @@
 <translation id="2285049245646335550">Tanjung Verde</translation>
 <translation id="2301396996587599046">Makedonia</translation>
 <translation id="2310948428656960769">Telah login</translation>
+<translation id="2321152797538991921">Sandi harus mengandung karakter non-alfanumerik</translation>
 <translation id="2324942959480650701">Tamu</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">Browser yang Anda gunakan tidak mendukung Penyimpanan Web. Coba lagi dengan browser berbeda.</translation>
@@ -134,11 +137,12 @@
 <translation id="3147551458884186429">Indonesia</translation>
 <translation id="3154748063569624719">Pada awalnya Anda ingin login dengan <ph name="PENDING_EMAIL" /></translation>
 <translation id="3164676761565983157">Venezuela</translation>
-<translation id="3170526549630869494">Terjadi masalah saat login?</translation>
+<translation id="3170526549630869494">Terjadi error saat login?</translation>
 <translation id="3204914819635733576">Verifikasi bahwa itu Anda</translation>
-<translation id="3215050409577090361">Terjadi kesalahan saat mengautentikasi permintaan Anda. Buka URL yang mengarahkan Anda ke halaman ini lagi untuk memulai ulang proses autentikasi.</translation>
+<translation id="3215050409577090361">Terjadi error saat mengautentikasi permintaan Anda. Buka URL yang mengarahkan Anda ke halaman ini lagi untuk memulai ulang proses autentikasi.</translation>
 <translation id="3216149523061905579">Dominika</translation>
 <translation id="3223688630903046698">Sandi baru</translation>
+<translation id="3245143966477136343">Sandi harus mengandung karakter huruf kecil</translation>
 <translation id="3250864391349648273">Gabon</translation>
 <translation id="3259479674319858599">Anda telah menggunakan <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Login dengan <ph name="IDP_DISPLAY_NAME" /> untuk melanjutkan.</translation>
 <translation id="3275852444431525182">Selandia Baru</translation>
@@ -216,6 +220,7 @@
 <translation id="4571870355114729513">Ikuti petunjuk yang dikirimkan ke <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> untuk memulihkan sandi Anda</translation>
 <translation id="4588392627302012849">Login dengan email</translation>
 <translation id="4595119411041064617">Dengan mengetuk “<ph name="PH_1" />", SMS mungkin akan dikirim. Mungkin dikenakan biaya pesan &amp; data.</translation>
+<translation id="4603232692404395592">Sandi boleh berisi maksimal <ph name="MAX_PASSWORD_LENGTH" /> karakter</translation>
 <translation id="4632709875751031323">Rusia</translation>
 <translation id="4644169548516814280">Alamat email sudah digunakan oleh akun lain</translation>
 <translation id="4692014002063276828">Polandia</translation>
@@ -278,7 +283,7 @@
 <translation id="5611074838440670731">Nomor telepon ini sudah terlalu sering digunakan</translation>
 <translation id="5630396263271753991">Eritrea</translation>
 <translation id="5636713964613741614">Mauritius</translation>
-<translation id="5642254620426025006">Terjadi kesalahan. Coba lagi.</translation>
+<translation id="5642254620426025006">Terjadi error. Coba lagi.</translation>
 <translation id="5649486931917149784">Sandi</translation>
 <translation id="5664080586064341046">Saint Kitts dan Nevis</translation>
 <translation id="5668881954117611594">Kembali</translation>
@@ -311,16 +316,19 @@
 <translation id="6132202686885223981">Pastikan masih ada ruang untuk kotak masuk Anda, atau periksa masalah terkait setelan kotak masuk lainnya.</translation>
 <translation id="6135589730599211649">Klien menentukan ada rentang yang tidak valid.</translation>
 <translation id="6143147250106939258">Kuota untuk operasi ini telah terlampaui. Coba lagi nanti.</translation>
+<translation id="615787395595800956">Persyaratan sandi tidak ada:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Aljazair</translation>
 <translation id="6213969168046789596">Anda telah berkali-kali memasukkan sandi yang salah. Coba beberapa menit lagi.</translation>
 <translation id="6216759405419177713">Pulau Norfolk</translation>
-<translation id="6245066275978703471">Nomor telepon terverifikasi secara otomatis</translation>
-<translation id="6269083314054226194">Error jaringan, periksa koneksi internet Anda.</translation>
-<translation id="6295157125625453859">Terverifikasi!</translation>
+<translation id="6238170540438416559">Dengan mengetuk “<ph name="PH_1" />”, Anda menyatakan bahwa Anda menyetujui <ph name="PP" /> kami. SMS mungkin akan dikirim. Mungkin dikenakan biaya pesan &amp; data.</translation>
+<translation id="6265373887273416711">Verifikasi nomor telepon Anda</translation>
+<translation id="6283536862756552051">Untuk mengubah sandi, Anda harus memasukkan sandi saat ini terlebih dahulu.</translation>
+<translation id="6299890279889400823">Kembali</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Lanjutkan</translation>
+<translation id="6355621963154078138">Sandi harus mengandung karakter numerik</translation>
 <translation id="6359400968059656782">Sekarang Anda dapat login dengan sandi baru</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luksemburg</translation>
@@ -335,7 +343,7 @@
 <translation id="6520863029476703422">Samoa Amerika</translation>
 <translation id="6527597037551425211">Brasil</translation>
 <translation id="6555167606025370230">Lanjutkan ke <ph name="APP_NAME" /></translation>
-<translation id="657697593815023638">Swaziland</translation>
+<translation id="657697593815023638">eSwatini</translation>
 <translation id="6584652721889639596">Tidak dapat mengirimkan kode reset sandi ke email yang ditentukan</translation>
 <translation id="6608262346670935090">Tutup</translation>
 <translation id="6611519013130079637">Belgia</translation>
@@ -410,7 +418,7 @@
 <translation id="7569285452790032317">Somalia</translation>
 <translation id="7592224526951017144">Jerman</translation>
 <translation id="7595933825828475368">Ada masalah saat mendapatkan email?</translation>
-<translation id="7615083347713899917">Kirgiztan</translation>
+<translation id="7615083347713899917">Kirgizstan</translation>
 <translation id="7643408533407091568">Anda telah menggunakan <ph name="EMAIL_ADDR" />
         untuk login. Masukkan sandi untuk akun tersebut.</translation>
 <translation id="7652546345268886994">{plural_var,plural, =1{Sandi tidak cukup kuat. Gunakan minimal <ph name="PH_1" /> karakter dan merupakan kombinasi huruf dan angka}other{Sandi tidak cukup kuat. Gunakan minimal <ph name="PH_1" /> karakter dan merupakan kombinasi huruf dan angka}}</translation>
@@ -420,6 +428,7 @@
 <translation id="7790301903034097323">Pilih sandi</translation>
 <translation id="7796914496604415892">Perangkat atau browser baru terdeteksi</translation>
 <translation id="786166109137986817">Login ke <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">Sandi harus mengandung karakter huruf besar</translation>
 <translation id="7868540442111212282">Republik Ceko</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Login dengan GitHub</translation>
@@ -438,7 +447,7 @@
 <translation id="8130982192244529100">Untuk mengirimkan kode verifikasi, masukkan nomor telepon penerima.</translation>
 <translation id="8138904368098176683">Sudan</translation>
 <translation id="815425460105074455">Bahama</translation>
-<translation id="8177114080110296189">Pantai Gading</translation>
+<translation id="8177114080110296189">Côte d’Ivoire</translation>
 <translation id="8192724270853215748">Palau</translation>
 <translation id="8210009914905612114">Mongolia</translation>
 <translation id="8248811348666273823">Spanyol</translation>
@@ -493,13 +502,15 @@
 <translation id="8916080112145514151">Jika Anda masih ingin menghubungkan akun <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, buka link di perangkat yang sama yang digunakan untuk login. Atau ketuk Lanjutkan untuk login di perangkat ini.</translation>
 <translation id="8920674952994839257">Coba lagi</translation>
 <translation id="8939353296336237380">Anda sebelumnya ingin menghubungkan <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> ke akun email Anda, tapi telah membuka link di perangkat berbeda, yang tidak digunakan untuk login.</translation>
-<translation id="8971555482255213064">Kirimkan ulang kode dalam 0.<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">Dengan mengetuk <ph name="BTN" /> Anda menyatakan setuju dengan <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Selesai</translation>
 <translation id="8984161590699631096">Maroko</translation>
 <translation id="8994098794339484800">Jika Anda tidak mengenali perangkat ini, mungkin ada seseorang yang berusaha untuk mengakses akun Anda. Pertimbangkan untuk <ph name="START_LINK" />segera mengubah sandi Anda<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesh</translation>
 <translation id="9022632332691561239">Telepon</translation>
 <translation id="9028063588419847334">Finlandia</translation>
 <translation id="9078135685219203661">Uni Emirat Arab</translation>
+<translation id="9085311482535098646">Sandi minimal harus <ph name="MIN_PASSWORD_LENGTH" /> karakter</translation>
 <translation id="9121203582272050974">Email Anda telah diverifikasi dan diubah</translation>
 <translation id="9156150178611681179">Sandi</translation>
 <translation id="9168877696443530714">Republik Afrika Tengah</translation>

--- a/translations/it.xtb
+++ b/translations/it.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">Troppe richieste di account provenienti dal tuo indirizzo IP. Riprova tra qualche minuto.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Ora puoi accedere con il tuo nuovo account</translation>
+<translation id="1535200361681091160">Inserisci l'indirizzo email</translation>
 <translation id="1544981664986460902">Il client ha specificato un argomento non valido.</translation>
 <translation id="1575848116712334589">Ciad</translation>
 <translation id="1630237004390596779">Invia di nuovo il codice tra <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Isole Cook</translation>
 <translation id="1870056762032541323">Codice errato. Riprova.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Buongiorno <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Elimina account</translation>
+<translation id="1912929493041975510">La password deve contenere almeno 6 caratteri</translation>
+<translation id="1933044638365301516">Accedi con <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Inserisci il codice a 6 cifre che abbiamo inviato al numero <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Seguire le istruzioni inviate all'indirizzo email <ph name="PH_1" /> per recuperare la password.</translation>
+<translation id="1999379687946415948"><ph name="IDV_CODE_PLACE_HOLDER" /> è il tuo codice per <ph name="APP_NAME" />.</translation>
+<translation id="2033662766890821456">Invia di nuovo il codice</translation>
 <translation id="2035855087334775326">Ungheria</translation>
 <translation id="2040904406955887821">Suriname</translation>
 <translation id="2046207054419739276">Stati Uniti</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Una password efficace è composta da almeno 6 caratteri e contiene una combinazione di lettere e numeri.</translation>
 <translation id="2074008538308369451">Termini di servizio</translation>
 <translation id="2089802663554186342">Sessione terminata</translation>
 <translation id="2108717231438756650">Regno Unito</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Capo Verde</translation>
 <translation id="2301396996587599046">Macedonia</translation>
 <translation id="2310948428656960769">Accesso eseguito</translation>
+<translation id="2321152797538991921">La password deve contenere un carattere non alfanumerico</translation>
 <translation id="2324942959480650701">Ospite</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">Il browser in uso non supporta l'archiviazione web. Prova con un altro browser.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">Si è verificato un problema durante l'autenticazione della richiesta. Torna all'URL che ti ha reindirizzato a questa pagina per riavviare il processo di autenticazione.</translation>
 <translation id="3216149523061905579">Dominìca</translation>
 <translation id="3223688630903046698">Nuova password</translation>
+<translation id="3245143966477136343">La password deve contenere un carattere minuscolo</translation>
 <translation id="3250864391349648273">Gabon</translation>
 <translation id="3259479674319858599">Hai già utilizzato <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Accedi con <ph name="IDP_DISPLAY_NAME" /> per continuare.</translation>
 <translation id="3275852444431525182">Nuova Zelanda</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Seguire le istruzioni inviate a <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> per recuperare la password</translation>
 <translation id="4588392627302012849">Accedi con l'indirizzo email</translation>
 <translation id="4595119411041064617">Se tocchi "<ph name="PH_1" />", è possibile che venga inviato un SMS. Potrebbero essere applicate le tariffe per l'invio dei messaggi e per il traffico dati.</translation>
+<translation id="4603232692404395592">La password può contenere al massimo <ph name="MAX_PASSWORD_LENGTH" /> caratteri</translation>
 <translation id="4632709875751031323">Russia</translation>
 <translation id="4644169548516814280">L'indirizzo email è già utilizzato da un altro account</translation>
 <translation id="4692014002063276828">Polonia</translation>
@@ -277,7 +281,7 @@
 <translation id="5606731250220630939">Norvegia</translation>
 <translation id="5611074838440670731">Questo numero di telefono è stato usato troppe volte</translation>
 <translation id="5630396263271753991">Eritrea</translation>
-<translation id="5636713964613741614">Maurizio</translation>
+<translation id="5636713964613741614">Mauritius</translation>
 <translation id="5642254620426025006">Si è verificato un errore. Riprova.</translation>
 <translation id="5649486931917149784">Password</translation>
 <translation id="5664080586064341046">Saint Kitts</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Verifica che vi sia ancora spazio disponibile nella Posta in arrivo o che non vi siano altri problemi legati alle impostazioni della Posta in arrivo.</translation>
 <translation id="6135589730599211649">Il client ha specificato un intervallo non valido.</translation>
 <translation id="6143147250106939258">La quota per questa operazione è stata superata. Riprova più tardi.</translation>
+<translation id="615787395595800956">Requisiti per la password mancanti:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Algeria</translation>
 <translation id="6213969168046789596">Hai effettuato troppi tentativi con una password errata. Riprova tra qualche minuto.</translation>
 <translation id="6216759405419177713">Isola Norfolk</translation>
-<translation id="6245066275978703471">Numero di telefono verificato automaticamente</translation>
-<translation id="6269083314054226194">Errore di rete. Controlla la connessione a Internet.</translation>
-<translation id="6295157125625453859">Verifica eseguita.</translation>
+<translation id="6238170540438416559">Se tocchi "<ph name="PH_1" />", accetti le nostre <ph name="PP" />. È possibile che venga inviato un SMS. Potrebbero essere applicate le tariffe per l'invio dei messaggi e per il traffico dati.</translation>
+<translation id="6265373887273416711">Verifica il numero di telefono</translation>
+<translation id="6283536862756552051">Per modificare la password, devi prima inserire la password corrente.</translation>
+<translation id="6299890279889400823">Indietro</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Continua</translation>
+<translation id="6355621963154078138">La password deve contenere un carattere numerico</translation>
 <translation id="6359400968059656782">Ora puoi accedere con la nuova password</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Lussemburgo</translation>
@@ -420,6 +427,7 @@
 <translation id="7790301903034097323">Scegli password</translation>
 <translation id="7796914496604415892">Rilevato nuovo dispositivo o browser</translation>
 <translation id="786166109137986817">Accedi a <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">La password deve contenere un carattere maiuscolo</translation>
 <translation id="7868540442111212282">Repubblica Ceca</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Accedi con GitHub</translation>
@@ -493,13 +501,15 @@
 <translation id="8916080112145514151">Se vuoi ancora collegare il tuo account <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, apri il link sullo stesso dispositivo sul quale hai iniziato a eseguire l'accesso. Altrimenti, tocca Continua per accedere su questo dispositivo.</translation>
 <translation id="8920674952994839257">Riprova</translation>
 <translation id="8939353296336237380">Inizialmente intendevi collegare l'account <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> al tuo account email, ma hai aperto il link su un altro dispositivo sul quale non hai eseguito l'accesso.</translation>
-<translation id="8971555482255213064">Invia di nuovo il codice tra 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">Se tocchi <ph name="BTN" />, accetti le <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Fine</translation>
 <translation id="8984161590699631096">Marocco</translation>
 <translation id="8994098794339484800">Se non riconosci questo dispositivo, è possibile che qualcuno stia cercando di accedere al tuo account. Ti consigliamo di <ph name="START_LINK" />modificare immediatamente la password<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesh</translation>
 <translation id="9022632332691561239">Telefono</translation>
 <translation id="9028063588419847334">Finlandia</translation>
 <translation id="9078135685219203661">Emirati Arabi Uniti</translation>
+<translation id="9085311482535098646">La password deve contenere almeno <ph name="MIN_PASSWORD_LENGTH" /> caratteri</translation>
 <translation id="9121203582272050974">L'email è stata verificata e modificata</translation>
 <translation id="9156150178611681179">Password</translation>
 <translation id="9168877696443530714">Repubblica Centrafricana</translation>

--- a/translations/iw.xtb
+++ b/translations/iw.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">איי קוק</translation>
 <translation id="1870056762032541323">הקוד שגוי. נסה שוב.</translation>
 <translation id="1898579907513173256">מקאו</translation>
-<translation id="1929332760123475919"><ph name="P_START" />שלום <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">מחיקת חשבון</translation>
+<translation id="1912929493041975510">אורך הסיסמה צריך להיות 6 תווים לפחות</translation>
+<translation id="1933044638365301516">כניסה באמצעות <ph name="STRING" /></translation>
 <translation id="1987722456379605552">שלחנו קוד בן 6 ספרות למספר <ph name="START_LINK" />‎<ph name="PHONE_NUMBER" /><ph name="END_LINK" />. מה הקוד?</translation>
 <translation id="2016421613709283485">כדי לשחזר את הסיסמה, עליך לפעול לפי ההוראות ששלחנו לכתובת <ph name="PH_1" />.</translation>
 <translation id="2035855087334775326">הונגריה</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">ארצות הברית</translation>
 <translation id="2049229571938383319">סנט ברתלמי</translation>
 <translation id="2058731785647385204">מונסראט</translation>
-<translation id="2070709910567585968">סיסמה חזקה היא סיסמה באורך 6 תווים לפחות שמכילה אותיות ומספרים</translation>
 <translation id="2074008538308369451">תנאים והגבלות</translation>
 <translation id="2089802663554186342">הסשן הסתיים</translation>
 <translation id="2108717231438756650">בריטניה</translation>
@@ -263,7 +262,7 @@
 <translation id="5528189843379142883">גינאה המשוונית</translation>
 <translation id="5529036554155743092">אוסטרליה</translation>
 <translation id="5537884323453943551">טרינידד/טובגו</translation>
-<translation id="5543493820882105191">הזן את שמך</translation>
+<translation id="5543493820882105191">יש להזין את שמך</translation>
 <translation id="55439745111619380">האי אסנשן</translation>
 <translation id="5569341882117077010">אירעה שגיאת רשת</translation>
 <translation id="5581239183924693195">כניסה באמצעות <ph name="IDP_DISPLAY_NAME" /></translation>
@@ -311,9 +310,10 @@
 <translation id="6192657410634245771">אלג'יריה</translation>
 <translation id="6213969168046789596">הזנת סיסמה שגויה יותר מדי פעמים. אפשר יהיה לנסות שוב בעוד כמה דקות.</translation>
 <translation id="6216759405419177713">האי נורפולק</translation>
-<translation id="6245066275978703471">מספר הטלפון אומת באופן אוטומטי</translation>
-<translation id="6269083314054226194">אירעה שגיאת רשת. יש לבדוק את החיבור לאינטרנט.</translation>
-<translation id="6295157125625453859">אומת.</translation>
+<translation id="6238170540438416559">הקשה על "<ph name="PH_1" />", תפורש כהסכמתך ל<ph name="PP" />. ייתכן שתישלח הודעת SMS. ייתכנו חיובים בגין שליחת הודעות ושימוש בנתונים.</translation>
+<translation id="6265373887273416711">אמת את מספר הטלפון</translation>
+<translation id="6283536862756552051">כדי לשנות את הסיסמה, עליך להזין את הסיסמה הנוכחית.</translation>
+<translation id="6299890279889400823">הקודם</translation>
 <translation id="6316446940976157217">הודו</translation>
 <translation id="6327723482938582895">בנין</translation>
 <translation id="6338643731889005578">המשך</translation>
@@ -409,7 +409,7 @@
 <translation id="7615083347713899917">קירגיזסטן</translation>
 <translation id="7643408533407091568">כבר השתמשת בכתובת <ph name="EMAIL_ADDR" />.
         כדי להיכנס. עליך להזין את הסיסמה לחשבון המשויך אליה.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך תו אחד (<ph name="PH_1" />) לפחות שמכילה אותיות ומספרים}two{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך <ph name="PH_1" /> תווים לפחות שמכילה אותיות ומספרים}many{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך <ph name="PH_1" /> תווים לפחות שמכילה אותיות ומספרים}other{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך <ph name="PH_1" /> תווים לפחות שמכילה אותיות ומספרים}}</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך תו אחד (<ph name="PH_1" />) לפחות שמכילה אותיות ומספרים}one{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך <ph name="PH_1" /> תווים לפחות שמכילה אותיות ומספרים}two{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך <ph name="PH_1" /> תווים לפחות שמכילה אותיות ומספרים}other{הסיסמה חלשה מדי. סיסמה חזקה היא סיסמה באורך <ph name="PH_1" /> תווים לפחות שמכילה אותיות ומספרים}}</translation>
 <translation id="7699755204074920022">זימבבווה</translation>
 <translation id="7746977132739352062">הבקשה לא אומתה עקב אסימון OAuth חסר, לא חוקי או שתוקפו פג.</translation>
 <translation id="7782885946428624225">אירעה בעיה באימות של מספר הטלפון</translation>

--- a/translations/ja.xtb
+++ b/translations/ja.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">この IP アドレスから多くのアカウント リクエストが送信されています。しばらくしてからもう一度お試しください。</translation>
 <translation id="1483249363694224399">スリランカ</translation>
 <translation id="1507995441600689506">新しいアカウントでログインできるようになりました</translation>
+<translation id="1535200361681091160">メールアドレスを入力</translation>
 <translation id="1544981664986460902">クライアントが無効な引数を指定しました。</translation>
 <translation id="1575848116712334589">チャド</translation>
 <translation id="1630237004390596779"><ph name="STRING" />後にコードを再送信</translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">クック諸島</translation>
 <translation id="1870056762032541323">コードが間違っています。もう一度お試しください。</translation>
 <translation id="1898579907513173256">マカオ</translation>
-<translation id="1929332760123475919"><ph name="P_START" /><ph name="DISPLAY_NAME" /> 様<ph name="P_END" /></translation>
-<translation id="1966996824429980990">アカウントの削除</translation>
+<translation id="1912929493041975510">パスワードは 6 文字以上にしてください</translation>
+<translation id="1933044638365301516"><ph name="STRING" /> でログイン</translation>
 <translation id="1987722456379605552"><ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /> に送信された 6 桁のコードを入力してください</translation>
-<translation id="2016421613709283485"><ph name="PH_1" /> に送信された手順に沿ってパスワードを復元してください</translation>
+<translation id="1999379687946415948"><ph name="APP_NAME" /> のコードは「<ph name="IDV_CODE_PLACE_HOLDER" />」です。</translation>
+<translation id="2033662766890821456">コードを再送信</translation>
 <translation id="2035855087334775326">ハンガリー</translation>
 <translation id="2040904406955887821">スリナム</translation>
 <translation id="2046207054419739276">米国</translation>
 <translation id="2049229571938383319">サン バルテルミー島</translation>
 <translation id="2058731785647385204">モントセラト島</translation>
-<translation id="2070709910567585968">6 文字以上で、文字と数字を組み合わせた安全なパスワードを設定してください</translation>
 <translation id="2074008538308369451">利用規約</translation>
 <translation id="2089802663554186342">セッションが終了しました</translation>
 <translation id="2108717231438756650">英国</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">カボベルデ</translation>
 <translation id="2301396996587599046">マケドニア</translation>
 <translation id="2310948428656960769">ログインしました</translation>
+<translation id="2321152797538991921">パスワードには英数字以外の文字を含める必要があります</translation>
 <translation id="2324942959480650701">ゲスト</translation>
 <translation id="2331781584136059536">ガーナ</translation>
 <translation id="2338909515537249568">お使いのブラウザは Web Storage に対応していません。他のブラウザでもう一度お試しください。</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">リクエストの認証時に問題が発生しました。このページにリダイレクトした URL に再度アクセスし、認証プロセスをもう一度行ってください。</translation>
 <translation id="3216149523061905579">ドミニカ国</translation>
 <translation id="3223688630903046698">新しいパスワード</translation>
+<translation id="3245143966477136343">パスワードには小文字を含める必要があります</translation>
 <translation id="3250864391349648273">ガボン</translation>
 <translation id="3259479674319858599"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> をすでに使用しています。<ph name="IDP_DISPLAY_NAME" /> でログインして続行してください。</translation>
 <translation id="3275852444431525182">ニュージーランド</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> に送信された手順に沿ってパスワードを復元します</translation>
 <translation id="4588392627302012849">メールでログイン</translation>
 <translation id="4595119411041064617">[<ph name="PH_1" />] をタップすると、SMS が送信されます。データ通信料がかかることがあります。</translation>
+<translation id="4603232692404395592">パスワードは <ph name="MAX_PASSWORD_LENGTH" /> 文字以内で指定してください</translation>
 <translation id="4632709875751031323">ロシア</translation>
 <translation id="4644169548516814280">このメールアドレスは他のアカウントによってすでに使用されています</translation>
 <translation id="4692014002063276828">ポーランド</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">受信トレイの容量不足や、設定関連のその他の問題がないか確認する。</translation>
 <translation id="6135589730599211649">クライアントが無効な範囲を指定しました。</translation>
 <translation id="6143147250106939258">このオペレーションの割り当てを超過しています。しばらくしてからもう一度実行してください。</translation>
+<translation id="615787395595800956">パスワードの要件を満たしていません:</translation>
 <translation id="6189573836664806798">パラグアイ</translation>
 <translation id="6192657410634245771">アルジェリア</translation>
 <translation id="6213969168046789596">正しくないパスワードを何度も入力しています。しばらくしてからもう一度お試しください。</translation>
 <translation id="6216759405419177713">ノーフォーク島</translation>
-<translation id="6245066275978703471">電話番号は自動的に確認されました</translation>
-<translation id="6269083314054226194">ネットワーク エラー。インターネット接続を確認してください。</translation>
-<translation id="6295157125625453859">確認済み</translation>
+<translation id="6238170540438416559">[<ph name="PH_1" />] をタップすると、<ph name="PP" /> に同意したことになり、SMS が送信されます。データ通信料がかかることがあります。</translation>
+<translation id="6265373887273416711">電話番号を確認</translation>
+<translation id="6283536862756552051">パスワードを変更するには、まず現在のパスワードを入力する必要があります。</translation>
+<translation id="6299890279889400823">戻る</translation>
 <translation id="6316446940976157217">インド</translation>
 <translation id="6327723482938582895">ベナン</translation>
 <translation id="6338643731889005578">続行</translation>
+<translation id="6355621963154078138">パスワードには数字を含める必要があります</translation>
 <translation id="6359400968059656782">新しいパスワードでログインできるようになりました</translation>
 <translation id="6363241121027868570">アルバ</translation>
 <translation id="6377222208046638522">ルクセンブルグ</translation>
@@ -419,6 +426,7 @@
 <translation id="7790301903034097323">パスワードを設定</translation>
 <translation id="7796914496604415892">新しいデバイスまたはブラウザが検出されました</translation>
 <translation id="786166109137986817"><ph name="DISPLAY_NAME" /> にログイン</translation>
+<translation id="7863575218808091551">パスワードには大文字を含める必要があります</translation>
 <translation id="7868540442111212282">チェコ共和国</translation>
 <translation id="7874584525604421364">ツバル</translation>
 <translation id="7926046652648626866">GitHub でログイン</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151"><ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> アカウントを接続する場合は、ログインを開始したデバイスでリンクを開いてください。元のプロバイダに接続しない場合は、このデバイスで [続行] をタップしてログインしてください。</translation>
 <translation id="8920674952994839257">再試行</translation>
 <translation id="8939353296336237380">元々は <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> をメール アカウントに接続しようとしましたが、このプロバイダにログインしていないデバイスでリンクが開かれました。</translation>
-<translation id="8971555482255213064">0:<ph name="PH_1" /> 秒後にコードを再送信します</translation>
+<translation id="8955469172512804617">[<ph name="BTN" />] をタップすると、<ph name="PP" /> に同意したことになります。</translation>
+<translation id="8980953965669178372">完了</translation>
 <translation id="8984161590699631096">モロッコ</translation>
 <translation id="8994098794339484800">このデバイスに心当たりがない場合は、他のユーザーがアカウントにアクセスしようとしている可能性があります。<ph name="START_LINK" />今すぐパスワードを変更する<ph name="END_LINK" />ことをおすすめします。</translation>
 <translation id="900153878296575829">バングラデシュ</translation>
 <translation id="9022632332691561239">電話番号</translation>
 <translation id="9028063588419847334">フィンランド</translation>
 <translation id="9078135685219203661">アラブ首長国連邦</translation>
+<translation id="9085311482535098646">パスワードは <ph name="MIN_PASSWORD_LENGTH" /> 文字以上で指定してください</translation>
 <translation id="9121203582272050974">メールアドレスの確認と変更が完了しました</translation>
 <translation id="9156150178611681179">パスワード</translation>
 <translation id="9168877696443530714">中央アフリカ共和国</translation>

--- a/translations/ko.xtb
+++ b/translations/ko.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">IP 주소에서 계정 요청이 너무 많이 발생하고 있습니다. 잠시 후에 다시 시도해 주세요.</translation>
 <translation id="1483249363694224399">스리랑카</translation>
 <translation id="1507995441600689506">이제 새 계정으로 로그인할 수 있습니다.</translation>
+<translation id="1535200361681091160">이메일 입력</translation>
 <translation id="1544981664986460902">클라이언트가 잘못된 인수를 지정했습니다.</translation>
 <translation id="1575848116712334589">차드</translation>
 <translation id="1630237004390596779"><ph name="STRING" /> 후에 코드 재전송</translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">쿡 제도</translation>
 <translation id="1870056762032541323">코드가 잘못되었습니다. 다시 시도하세요.</translation>
 <translation id="1898579907513173256">마카오</translation>
-<translation id="1929332760123475919"><ph name="P_START" /><ph name="DISPLAY_NAME" />님, 안녕하세요.<ph name="P_END" /></translation>
-<translation id="1966996824429980990">계정 삭제</translation>
+<translation id="1912929493041975510">비밀번호는 6자 이상이어야 합니다.</translation>
+<translation id="1933044638365301516"><ph name="STRING" />(으)로 로그인</translation>
 <translation id="1987722456379605552"><ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" />(으)로 전송된 6자리 코드를 입력하세요.</translation>
-<translation id="2016421613709283485"><ph name="PH_1" />(으)로 발송된 이메일의 안내에 따라 비밀번호를 복구하세요.</translation>
+<translation id="1999379687946415948"><ph name="APP_NAME" /> 코드는 <ph name="IDV_CODE_PLACE_HOLDER" />입니다.</translation>
+<translation id="2033662766890821456">코드 재전송</translation>
 <translation id="2035855087334775326">헝가리</translation>
 <translation id="2040904406955887821">수리남</translation>
 <translation id="2046207054419739276">미국</translation>
 <translation id="2049229571938383319">생바르텔레미</translation>
 <translation id="2058731785647385204">몬트세랫</translation>
-<translation id="2070709910567585968">안전한 비밀번호는 6자 이상이어야 하고 문자와 숫자가 조합되어야 합니다.</translation>
 <translation id="2074008538308369451">서비스 약관</translation>
 <translation id="2089802663554186342">세션 종료됨</translation>
 <translation id="2108717231438756650">영국</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">카보 베르데</translation>
 <translation id="2301396996587599046">마케도니아</translation>
 <translation id="2310948428656960769">로그인 완료</translation>
+<translation id="2321152797538991921">비밀번호에 영숫자 문자가 아닌 문자가 포함되어야 합니다.</translation>
 <translation id="2324942959480650701">비회원</translation>
 <translation id="2331781584136059536">가나</translation>
 <translation id="2338909515537249568">사용하는 브라우저가 웹 저장소를 지원하지 않습니다. 다른 브라우저에서 다시 시도해 주세요.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">요청을 인증하는 중에 문제가 발생했습니다. 이 페이지로 리디렉션된 URL을 다시 방문하여 인증 프로세스를 다시 시작하세요.</translation>
 <translation id="3216149523061905579">도미니카</translation>
 <translation id="3223688630903046698">새 비밀번호</translation>
+<translation id="3245143966477136343">비밀번호에 소문자가 포함되어야 합니다.</translation>
 <translation id="3250864391349648273">가봉</translation>
 <translation id="3259479674319858599"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />을(를) 이미 사용하고 있습니다. 계속하려면 <ph name="IDP_DISPLAY_NAME" />(으)로 로그인하세요.</translation>
 <translation id="3275852444431525182">뉴질랜드</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />(으)로 발송된 안내에 따라 비밀번호를 복구하세요.</translation>
 <translation id="4588392627302012849">이메일로 로그인</translation>
 <translation id="4595119411041064617">'<ph name="PH_1" />' 버튼을 탭하면 SMS가 발송될 수 있으며, 메시지 및 데이터 요금이 부과될 수 있습니다.</translation>
+<translation id="4603232692404395592">비밀번호는 <ph name="MAX_PASSWORD_LENGTH" />자(영문 기준) 이하여야 합니다.</translation>
 <translation id="4632709875751031323">러시아</translation>
 <translation id="4644169548516814280">이미 다른 계정에서 사용 중인 이메일 주소입니다.</translation>
 <translation id="4692014002063276828">폴란드</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">받은편지함 용량이 다 찼거나 받은편지함 설정과 관련된 문제가 있는 것이 아닌지 확인합니다.</translation>
 <translation id="6135589730599211649">클라이언트가 잘못된 범위로 지정되었습니다.</translation>
 <translation id="6143147250106939258">이 작업의 할당량을 초과했습니다. 나중에 다시 시도하세요.</translation>
+<translation id="615787395595800956">누락된 비밀번호 요구사항:</translation>
 <translation id="6189573836664806798">파라과이</translation>
 <translation id="6192657410634245771">알제리</translation>
 <translation id="6213969168046789596">비밀번호 입력 오류 횟수를 초과했습니다. 잠시 후에 다시 시도해 주세요.</translation>
 <translation id="6216759405419177713">노퍽 섬</translation>
-<translation id="6245066275978703471">전화번호가 자동으로 확인되었습니다.</translation>
-<translation id="6269083314054226194">네트워크 오류가 발생했습니다. 인터넷 연결을 확인하세요.</translation>
-<translation id="6295157125625453859">인증되었습니다.</translation>
+<translation id="6238170540438416559">‘<ph name="PH_1" />’ 버튼을 탭하면 <ph name="PP" />에 동의하는 것으로 간주됩니다. SMS가 발송될 수 있으며, 메시지 및 데이터 요금이 부과될 수 있습니다.</translation>
+<translation id="6265373887273416711">전화번호 인증</translation>
+<translation id="6283536862756552051">비밀번호를 변경하려면 먼저 현재 비밀번호를 입력해야 합니다.</translation>
+<translation id="6299890279889400823">뒤로</translation>
 <translation id="6316446940976157217">인도</translation>
 <translation id="6327723482938582895">베냉</translation>
 <translation id="6338643731889005578">계속</translation>
+<translation id="6355621963154078138">비밀번호에 숫자가 포함되어야 합니다.</translation>
 <translation id="6359400968059656782">이제 새 비밀번호로 로그인 할 수 있습니다.</translation>
 <translation id="6363241121027868570">아루바</translation>
 <translation id="6377222208046638522">룩셈부르크</translation>
@@ -420,6 +427,7 @@
 <translation id="7790301903034097323">비밀번호 선택</translation>
 <translation id="7796914496604415892">새 기기 또는 브라우저 감지됨</translation>
 <translation id="786166109137986817"><ph name="DISPLAY_NAME" />에 로그인</translation>
+<translation id="7863575218808091551">비밀번호에 대문자가 포함되어야 합니다.</translation>
 <translation id="7868540442111212282">체코 공화국</translation>
 <translation id="7874584525604421364">투발루</translation>
 <translation id="7926046652648626866">GitHub로 로그인</translation>
@@ -493,13 +501,15 @@
 <translation id="8916080112145514151">그래도 <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> 계정에 연결하려면 로그인했던 기기에서 링크를 여시기 바랍니다. 아니면, 계속을 탭하여 이 기기에서 로그인하세요.</translation>
 <translation id="8920674952994839257">재시도</translation>
 <translation id="8939353296336237380">원래 이메일 계정에 <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />을(를) 연결하려고 했지만 로그인되지 않은 다른 기기에서 링크를 열었습니다.</translation>
-<translation id="8971555482255213064">0:<ph name="PH_1" /> 후에 코드 재전송</translation>
+<translation id="8955469172512804617"><ph name="BTN" />을(를) 탭하면 <ph name="PP" />에 동의하는 것으로 간주됩니다.</translation>
+<translation id="8980953965669178372">완료</translation>
 <translation id="8984161590699631096">모로코</translation>
 <translation id="8994098794339484800">모르는 기기라면 누군가 계정 액세스를 시도하려는 것일 수 있습니다. <ph name="START_LINK" />지금 비밀번호를 변경<ph name="END_LINK" />하는 것이 좋습니다.</translation>
 <translation id="900153878296575829">방글라데시</translation>
 <translation id="9022632332691561239">전화</translation>
 <translation id="9028063588419847334">핀란드</translation>
 <translation id="9078135685219203661">아랍에미리트</translation>
+<translation id="9085311482535098646">비밀번호는 <ph name="MIN_PASSWORD_LENGTH" />자(영문 기준) 이상이어야 합니다.</translation>
 <translation id="9121203582272050974">이메일 인증 및 변경됨</translation>
 <translation id="9156150178611681179">비밀번호</translation>
 <translation id="9168877696443530714">중앙아프리카 공화국</translation>

--- a/translations/lt.xtb
+++ b/translations/lt.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Kuko Salos</translation>
 <translation id="1870056762032541323">Klaidingas kodas. Bandykite dar kartą.</translation>
 <translation id="1898579907513173256">Makao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Sveiki, <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Ištrinti paskyrą</translation>
+<translation id="1912929493041975510">Slaptažodį turi sudaryti mažiausiai 6 simboliai</translation>
+<translation id="1933044638365301516">Prisijungti per „<ph name="STRING" />“</translation>
 <translation id="1987722456379605552">Įveskite 6 skaitmenų kodą, išsiųstą numeriu <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Vadovaudamiesi el. pašto adresu <ph name="PH_1" /> išsiųstais nurodymais atkurkite slaptažodį.</translation>
 <translation id="2035855087334775326">Vengrija</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Jungtinės Amerikos Valstijos</translation>
 <translation id="2049229571938383319">Šv. Baltramiejaus sala</translation>
 <translation id="2058731785647385204">Montseratas</translation>
-<translation id="2070709910567585968">Sudėtingą slaptažodį sudaro bent 6 simboliai ir raidžių bei skaičių derinys</translation>
 <translation id="2074008538308369451">Paslaugų teikimo sąlygos</translation>
 <translation id="2089802663554186342">Sesija baigėsi</translation>
 <translation id="2108717231438756650">Jungtinė Karalystė</translation>
@@ -311,9 +310,10 @@
 <translation id="6192657410634245771">Alžyras</translation>
 <translation id="6213969168046789596">Įvedėte netinkamą slaptažodį per daug kartų. Po kelių minučių bandykite dar kartą.</translation>
 <translation id="6216759405419177713">Norfolko Sala</translation>
-<translation id="6245066275978703471">Telefono numeris patvirtintas automatiškai</translation>
-<translation id="6269083314054226194">Tinklo klaida: patikrinkite interneto ryšį.</translation>
-<translation id="6295157125625453859">Patvirtinta.</translation>
+<translation id="6238170540438416559">Paliesdami „<ph name="PH_1" />“ nurodote, kad sutinkate su <ph name="PP" />. Gali būti išsiųstas SMS pranešimas, taip pat – taikomi pranešimų ir duomenų įkainiai.</translation>
+<translation id="6265373887273416711">Patvirtinti telefono numerį</translation>
+<translation id="6283536862756552051">Norėdami pakeisti slaptažodį, pirmiausia turite įvesti dabartinį.</translation>
+<translation id="6299890279889400823">Atgal</translation>
 <translation id="6316446940976157217">Indija</translation>
 <translation id="6327723482938582895">Beninas</translation>
 <translation id="6338643731889005578">Tęsti</translation>

--- a/translations/lv.xtb
+++ b/translations/lv.xtb
@@ -45,16 +45,15 @@
 <translation id="1799407952500261728">Kuka Salas</translation>
 <translation id="1870056762032541323">Nepareizs kods. Mēģiniet vēlreiz.</translation>
 <translation id="1898579907513173256">Makao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Labdien, <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Konta dzēšana</translation>
-<translation id="1987722456379605552">Ievadīt 6 ciparu kodu, kas tika nosūtīts uz šādu tālruņa numuru: <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
+<translation id="1912929493041975510">Parolei ir jābūt vismaz sešas rakstzīmes garai</translation>
+<translation id="1933044638365301516">Pierakstīties ar <ph name="STRING" /></translation>
+<translation id="1987722456379605552">Ievadīt 6 ciparu kodu, kas tika nosūtīts uz šādu tālruņa numuru: <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Izpildiet uz e-pasta adresi <ph name="PH_1" /> nosūtītos norādījumus, lai atgūtu paroli.</translation>
 <translation id="2035855087334775326">Ungārija</translation>
 <translation id="2040904406955887821">Surinama</translation>
 <translation id="2046207054419739276">Amerikas Savienotās Valstis</translation>
 <translation id="2049229571938383319">Senbartelmī</translation>
 <translation id="2058731785647385204">Montserrata</translation>
-<translation id="2070709910567585968">Drošām parolēm ir vismaz 6 rakstzīmes, un tajās ir burtu un ciparu kombinācija</translation>
 <translation id="2074008538308369451">Pakalpojumu sniegšanas noteikumi</translation>
 <translation id="2089802663554186342">Sesija ir beigusies</translation>
 <translation id="2108717231438756650">Apvienotā Karaliste</translation>
@@ -178,7 +177,7 @@
 <translation id="3898029444496274961">Pierakstīties</translation>
 <translation id="3905423743526704083">Austrumtimora</translation>
 <translation id="3908950705971364393">Džibutija</translation>
-<translation id="3954166521214262397">6 ciparu kods</translation>
+<translation id="3954166521214262397">6 ciparu kods</translation>
 <translation id="3987987513436822097">Komoru Salas</translation>
 <translation id="4009306200855295525">Valsts</translation>
 <translation id="4021489444336102711">Verificēt</translation>
@@ -295,9 +294,9 @@
 <translation id="5985902459796151462">Dominikāna</translation>
 <translation id="5987586156626209007">Džērsija</translation>
 <translation id="5989709845715452405">Paroles atgūšana</translation>
-<translation id="5995596766674622541">Ievadiet 6 ciparu kodu, kas nosūtīts uz šādu tālruņa numuru: <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
+<translation id="5995596766674622541">Ievadiet 6 ciparu kodu, kas nosūtīts uz šādu tālruņa numuru: <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="6006148985615990975">Ruanda</translation>
-<translation id="6032262985756512833">Ievadiet <ph name="STRING" /> ciparu kodu, ko nosūtījām uz šādu tālruņa numuru:</translation>
+<translation id="6032262985756512833">Ievadiet <ph name="STRING" /> ciparu kodu, ko nosūtījām uz šādu tālruņa numuru:</translation>
 <translation id="6044396095102058216">Šis tālruņa numurs ir izmantots pārāk daudz reižu</translation>
 <translation id="6083089720215618333">Norādītā e-pasta adrese neatbilst pašreizējai pierakstīšanās sesijai.</translation>
 <translation id="6091051069256411999">Twitter</translation>
@@ -311,9 +310,10 @@
 <translation id="6192657410634245771">Alžīrija</translation>
 <translation id="6213969168046789596">Esat pārāk daudz reižu ievadījis nepareizu paroli. Lūdzu, mēģiniet vēlreiz pēc dažām minūtēm.</translation>
 <translation id="6216759405419177713">Norfolkas Sala</translation>
-<translation id="6245066275978703471">Tālruņa numurs tika automātiski verificēts</translation>
-<translation id="6269083314054226194">Tīkla kļūda. Pārbaudiet interneta savienojumu.</translation>
-<translation id="6295157125625453859">Verificēts.</translation>
+<translation id="6238170540438416559">Pieskaroties pogai “<ph name="PH_1" />”, jūs norādāt, ka piekrītat šādam dokumentam: <ph name="PP" />. Var tikt nosūtīta īsziņa. Var tikt piemērota maksa par ziņojumiem un datu pārsūtīšanu.</translation>
+<translation id="6265373887273416711">Verificēt tālruņa numuru</translation>
+<translation id="6283536862756552051">Lai mainītu paroli, vispirms ir jāievada pašreizējā parole.</translation>
+<translation id="6299890279889400823">Atpakaļ</translation>
 <translation id="6316446940976157217">Indija</translation>
 <translation id="6327723482938582895">Benina</translation>
 <translation id="6338643731889005578">Turpināt</translation>
@@ -409,7 +409,7 @@
 <translation id="7615083347713899917">Kirgizstāna</translation>
 <translation id="7643408533407091568">Esat jau izmantojis e-pasta adresi <ph name="EMAIL_ADDR" />,
         lai pierakstītos. Ievadiet šī konta paroli.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmi un burtu un ciparu kombināciju}zero{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmes un burtu un ciparu kombināciju}one{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmi un burtu un ciparu kombināciju}other{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmes un burtu un ciparu kombināciju}}</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmi un burtu un ciparu kombināciju}zero{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmes un burtu un ciparu kombināciju}one{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmi un burtu un ciparu kombināciju}other{Parole nav pietiekami droša. Izmantojiet vismaz <ph name="PH_1" /> rakstzīmes un burtu un ciparu kombināciju}}</translation>
 <translation id="7699755204074920022">Zimbabve</translation>
 <translation id="7746977132739352062">Pieprasījums nav autentificēts, jo trūkst OAuth pilnvaras, tā ir nederīga vai beidzies tās termiņš.</translation>
 <translation id="7782885946428624225">Verificējot jūsu tālruņa numuru, radās problēma</translation>

--- a/translations/nl.xtb
+++ b/translations/nl.xtb
@@ -31,10 +31,11 @@
 <translation id="1479035434297790822">Er komen te veel accountaanvragen van uw IP-adres. Probeer het over enkele minuten opnieuw.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">U kunt nu inloggen met uw nieuwe account</translation>
+<translation id="1535200361681091160">Voer uw e-mailadres in</translation>
 <translation id="1544981664986460902">De client heeft een ongeldig argument opgegeven.</translation>
 <translation id="1575848116712334589">Tsjaad</translation>
-<translation id="1630237004390596779">Code opnieuw verzenden over <ph name="STRING" /></translation>
-<translation id="1653501608290591291">Wit-Rusland</translation>
+<translation id="1630237004390596779">Code opnieuw sturen over <ph name="STRING" /></translation>
+<translation id="1653501608290591291">Belarus</translation>
 <translation id="1667376103923043653">Dit e-mailadres komt niet overeen met een bestaand account.</translation>
 <translation id="173576986138855124">Als u op '<ph name="PH_1" />' tikt, wordt er mogelijk een sms verzonden. Er kunnen sms- en datakosten in rekening worden gebracht.</translation>
 <translation id="1739056958326110545">Sint-Helena</translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Cookeilanden</translation>
 <translation id="1870056762032541323">Onjuiste code. Probeer het opnieuw.</translation>
 <translation id="1898579907513173256">Macau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hallo <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Account verwijderen</translation>
+<translation id="1912929493041975510">Het wachtwoord moet minimaal 6 tekens lang zijn</translation>
+<translation id="1933044638365301516">Inloggen met <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Voer de zescijferige code in die we hebben verzonden naar <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Volg de instructies die we naar <ph name="PH_1" /> hebben verzonden om uw wachtwoord te herstellen.</translation>
+<translation id="1999379687946415948">Uw code voor <ph name="APP_NAME" /> is <ph name="IDV_CODE_PLACE_HOLDER" />.</translation>
+<translation id="2033662766890821456">Code opnieuw sturen</translation>
 <translation id="2035855087334775326">Hongarije</translation>
 <translation id="2040904406955887821">Suriname</translation>
 <translation id="2046207054419739276">Verenigde Staten</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Sterke wachtwoorden bevatten ten minste zes tekens en een combinatie van letters en cijfers</translation>
 <translation id="2074008538308369451">Servicevoorwaarden</translation>
 <translation id="2089802663554186342">Sessie beëindigd</translation>
 <translation id="2108717231438756650">Verenigd Koninkrijk</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Kaapverdië</translation>
 <translation id="2301396996587599046">Macedonië</translation>
 <translation id="2310948428656960769">Ingelogd</translation>
+<translation id="2321152797538991921">Het wachtwoord moet een niet-alfanumeriek teken bevatten</translation>
 <translation id="2324942959480650701">Gast</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">De browser die u gebruikt, ondersteunt webopslag niet. Probeer het opnieuw in een andere browser.</translation>
@@ -113,7 +115,7 @@
 <translation id="2741235824871026219">Verifiëren</translation>
 <translation id="2752984808025184019">Zuid-Afrika</translation>
 <translation id="2760636260031093254">Voer uw e-mailadres in om verder te gaan</translation>
-<translation id="276938411216176478">Het gebruikersaccount is uitgeschakeld door een beheerder.</translation>
+<translation id="276938411216176478">Het gebruikersaccount is uitgezet door een beheerder.</translation>
 <translation id="2782685789517131804">Er is een inlogmail met aanvullende instructies verzonden naar <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Controleer uw inbox om het inlogproces te voltooien.</translation>
 <translation id="2824267666257947103">Voer uw wachtwoord in</translation>
 <translation id="2828509010894808185">Account maken</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">Er is een probleem opgetreden bij het verifiëren van uw verzoek. Ga naar de URL die u naar deze pagina heeft omgeleid en start het verificatieproces opnieuw.</translation>
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">Nieuw wachtwoord</translation>
+<translation id="3245143966477136343">Het wachtwoord moet kleine letters bevatten</translation>
 <translation id="3250864391349648273">Gabon</translation>
 <translation id="3259479674319858599">U heeft <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> al gebruikt. Log in met <ph name="IDP_DISPLAY_NAME" /> om verder te gaan.</translation>
 <translation id="3275852444431525182">Nieuw-Zeeland</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Volg de instructies die naar <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> zijn verzonden om uw wachtwoord te herstellen</translation>
 <translation id="4588392627302012849">Inloggen met e-mailadres</translation>
 <translation id="4595119411041064617">Als u op '<ph name="PH_1" />' tikt, ontvangt u mogelijk een sms. Er kunnen sms- en datakosten in rekening worden gebracht.</translation>
+<translation id="4603232692404395592">Het wachtwoord mag maximaal <ph name="MAX_PASSWORD_LENGTH" /> tekens bevatten</translation>
 <translation id="4632709875751031323">Rusland</translation>
 <translation id="4644169548516814280">Dit e-mailadres wordt al gebruikt door een ander account</translation>
 <translation id="4692014002063276828">Polen</translation>
@@ -229,7 +233,7 @@
 <translation id="4852256440857413490">Onjuiste code. Probeer het opnieuw.</translation>
 <translation id="4866990546854875813">De aan dit inlogverzoek gekoppelde sessie is vervallen of gewist.</translation>
 <translation id="4871106926303956169">Turks- en Caicoseilanden</translation>
-<translation id="4877597386645466815">Code opnieuw verzenden over <ph name="TIME_REMAINING" /></translation>
+<translation id="4877597386645466815">Code opnieuw sturen over <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
 <ph name="P_START" />Uw account in <ph name="APP_NAME" /> is geüpdatet met het telefoonnummer <ph name="SECOND_FACTOR" /> voor verificatie in 2 stappen.<ph name="P_END" />
 <ph name="P_START" />Heeft u dit telefoonnummer niet toegevoegd voor verificatie in 2 stappen? Klik dan op de onderstaande link om het te verwijderen.<ph name="P_END" />
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Controleer of er voldoende ruimte in uw inbox is en of er geen andere problemen met inboxinstellingen zijn.</translation>
 <translation id="6135589730599211649">De client heeft een ongeldig bereik opgegeven.</translation>
 <translation id="6143147250106939258">Het quotum voor deze bewerking is overschreden. Probeer het later opnieuw.</translation>
+<translation id="615787395595800956">Ontbrekende wachtwoordvereisten:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Algerije</translation>
 <translation id="6213969168046789596">U heeft te vaak een fout wachtwoord ingevoerd. Probeer het over enkele minuten opnieuw.</translation>
 <translation id="6216759405419177713">Norfolkeiland</translation>
-<translation id="6245066275978703471">Telefoonnummer is automatisch geverifieerd</translation>
-<translation id="6269083314054226194">Er is een netwerkfout opgetreden. Controleer uw internetverbinding.</translation>
-<translation id="6295157125625453859">Geverifieerd</translation>
+<translation id="6238170540438416559">Als u op '<ph name="PH_1" />' tikt, geeft u aan dat u ons <ph name="PP" /> accepteert. Mogelijk ontvangt u een sms. Er kunnen sms- en datakosten in rekening worden gebracht.</translation>
+<translation id="6265373887273416711">Uw telefoonnummer verifiëren</translation>
+<translation id="6283536862756552051">Om uw wachtwoord te veranderen, moet u eerst uw huidige wachtwoord invoeren.</translation>
+<translation id="6299890279889400823">Terug</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Doorgaan</translation>
+<translation id="6355621963154078138">Het wachtwoord moet een numeriek teken bevatten</translation>
 <translation id="6359400968059656782">U kunt nu inloggen met uw nieuwe wachtwoord</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxemburg</translation>
@@ -419,6 +426,7 @@
 <translation id="7790301903034097323">Wachtwoord kiezen</translation>
 <translation id="7796914496604415892">Nieuw apparaat of nieuwe browser gedetecteerd</translation>
 <translation id="786166109137986817">Inloggen bij <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">Het wachtwoord moet hoofdletters bevatten</translation>
 <translation id="7868540442111212282">Tsjechië</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Inloggen met GitHub</translation>
@@ -452,7 +460,7 @@
 <translation id="8347635771101835254">Uruguay</translation>
 <translation id="8356629306226578917">Egypte</translation>
 <translation id="8361109291694366329">Marshalleilanden</translation>
-<translation id="8371947480506692029">Sint-Maarten</translation>
+<translation id="8371947480506692029">Sint Maarten</translation>
 <translation id="8395242001819210481">Antigua en Barbuda</translation>
 <translation id="8399150401520737446">Noordelijke Marianen</translation>
 <translation id="8414177484126578295">Falklandeilanden [Islas Malvinas]</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151">Als u uw <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />-account nog steeds wilt koppelen, opent u de link op het apparaat waarop u het inlogproces bent gestart. Tik anders op Doorgaan om in te loggen op dit apparaat.</translation>
 <translation id="8920674952994839257">Opnieuw proberen</translation>
 <translation id="8939353296336237380">U wilde aanvankelijk <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> aan uw e-mailaccount koppelen, maar u heeft de link geopend op een ander apparaat, waarop u niet ingelogd bent.</translation>
-<translation id="8971555482255213064">Code opnieuw verzenden over 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">Door op <ph name="BTN" /> te tikken, geeft u aan dat u akkoord gaat met het <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Klaar</translation>
 <translation id="8984161590699631096">Marokko</translation>
 <translation id="8994098794339484800">Als u dit apparaat niet herkent, probeert iemand anders mogelijk toegang tot uw account te krijgen. We raden u aan om <ph name="START_LINK" />uw wachtwoord onmiddellijk te wijzigen<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesh</translation>
 <translation id="9022632332691561239">Telefoon</translation>
 <translation id="9028063588419847334">Finland</translation>
 <translation id="9078135685219203661">Verenigde Arabische Emiraten</translation>
+<translation id="9085311482535098646">Het wachtwoord moet minstens <ph name="MIN_PASSWORD_LENGTH" /> tekens bevatten</translation>
 <translation id="9121203582272050974">Uw e-mailadres is geverifieerd en gewijzigd</translation>
 <translation id="9156150178611681179">Wachtwoord</translation>
 <translation id="9168877696443530714">Centraal-Afrikaanse Republiek</translation>

--- a/translations/no.xtb
+++ b/translations/no.xtb
@@ -28,7 +28,7 @@
 <translation id="144766329299583285">Hvis du ikke ba om å endre påloggingsadressen din, er det mulig at noen prøver å få tilgang til kontoen din. Du bør <ph name="START_LINK" />endre passordet ditt umiddelbart<ph name="END_LINK" />.</translation>
 <translation id="1449981769524156676">Heardøya og McDonaldøyene</translation>
 <translation id="1451880131543823984"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> har ikke autorisasjon til å se den forespurte siden.</translation>
-<translation id="1479035434297790822">Det kommer for mange kontoforespørsler fra IP-adressen din. Prøv igjen om noen minutter.</translation>
+<translation id="1479035434297790822">Det kommer for mange kontoforespørsler fra IP-adressen din. Prøv på nytt om noen minutter.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Nå kan du logge på med den nye kontoen din</translation>
 <translation id="1544981664986460902">Klienten oppga et ugyldig argument.</translation>
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Cookøyene</translation>
 <translation id="1870056762032541323">Feil kode. Prøv på nytt.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hei, <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Slett kontoen</translation>
+<translation id="1912929493041975510">Passordet må bestå av minst seks tegn</translation>
+<translation id="1933044638365301516">Logg på med <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Oppgi den 6-sifrede koden vi har sendt til <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Følg veiledningen som er sendt til <ph name="PH_1" />, for å gjenopprette passordet ditt.</translation>
 <translation id="2035855087334775326">Ungarn</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">USA</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Sterke passord består av minst seks tegn og en blanding av bokstaver og tall</translation>
 <translation id="2074008538308369451">Vilkår for bruk</translation>
 <translation id="2089802663554186342">Økten er utløpt</translation>
 <translation id="2108717231438756650">Storbritannia</translation>
@@ -76,7 +75,7 @@
 <translation id="2310948428656960769">Pålogget!</translation>
 <translation id="2324942959480650701">Gjest</translation>
 <translation id="2331781584136059536">Ghana</translation>
-<translation id="2338909515537249568">Nettleseren du bruker, støtter ikke nettlagring. Prøv igjen i en annen nettleser.</translation>
+<translation id="2338909515537249568">Nettleseren du bruker, støtter ikke nettlagring. Prøv på nytt i en annen nettleser.</translation>
 <translation id="2342152898808240937">Forespørselen ble avbrutt av klienten.</translation>
 <translation id="2356282732642724501"><ph name="START_PARAGRAPH" />Det oppsto et problem med å tilbakestille påloggingsadressen din.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Be administratoren din om hjelp hvis du prøver igjen og fortsatt ikke får tilbakestilt e-postadressen.<ph name="END_PARAGRAPH" /></translation>
 <translation id="2375419764963116430">Bahrain</translation>
@@ -89,12 +88,12 @@
 <translation id="2460064915291012298">Seychellene</translation>
 <translation id="2490672522100125425"><ph name="START_STRONG" /><ph name="FACTOR_ID" /> <ph name="PHONE_NUMBER" /><ph name="END_STRONG" /> ble fjernet som andre autentiseringstrinn.</translation>
 <translation id="2494962141967044042">Kunne ikke oppgradere den anonyme brukeren. Den ikke-anonyme legitimasjonen er allerede tilknyttet en annen brukerkonto.</translation>
-<translation id="2541179214468543429">Du har angitt feil passord for mange ganger. Prøv igjen om noen minutter.</translation>
+<translation id="2541179214468543429">Du har angitt feil passord for mange ganger. Prøv på nytt om noen minutter.</translation>
 <translation id="2561560038714758184">Sikkerhet</translation>
 <translation id="2561835578785502516">Forespørselen om å tilbakestille passordet ditt har utløpt, eller så er linken allerede brukt</translation>
 <translation id="2562498793334241360">Nå kan du logge på med den nye e-postadressen, <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="2581514546525533462">Landskoden som er oppgitt, støttes ikke.</translation>
-<translation id="2600950452451016107">Kontrollér at du ikke har skrevet e-postadressen din feil.</translation>
+<translation id="2600950452451016107">Kontroller at du ikke har skrevet e-postadressen din feil.</translation>
 <translation id="2610891451939662786">Twitter</translation>
 <translation id="2612036261782356367">Kambodsja</translation>
 <translation id="2614081868476050089">Tjenesten er ikke tilgjengelig.</translation>
@@ -109,7 +108,7 @@
 <translation id="2668496398414877352">Kosovo</translation>
 <translation id="2674823936234616183">Usbekistan</translation>
 <translation id="2696162410887720551">Åland</translation>
-<translation id="2725769874498146298">Påloggingsøkten din har utløpt. Prøv igjen.</translation>
+<translation id="2725769874498146298">Påloggingsøkten din har utløpt. Prøv på nytt.</translation>
 <translation id="2741235824871026219">Bekreft</translation>
 <translation id="2752984808025184019">Sør-Afrika</translation>
 <translation id="2760636260031093254">Oppgi e-postadressen din for å fortsette</translation>
@@ -307,16 +306,17 @@
 <translation id="61182948399263957">
 <ph name="P_START" />Logg på <ph name="APP_NAME" /> &lt;/p&gt;&lt;/p&gt;
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
-<translation id="6132202686885223981">Kontrollér at innboksen din ikke er full, og se etter andre problemer knyttet til innboksinnstillingene.</translation>
+<translation id="6132202686885223981">Kontroller at innboksen din ikke er full, og se etter andre problemer knyttet til innboksinnstillingene.</translation>
 <translation id="6135589730599211649">Klienten oppga et ugyldig område.</translation>
 <translation id="6143147250106939258">Kvoten for denne operasjonen er overskredet. Prøv på nytt senere.</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Algerie</translation>
-<translation id="6213969168046789596">Du har angitt feil passord for mange ganger. Prøv igjen om noen minutter.</translation>
+<translation id="6213969168046789596">Du har angitt feil passord for mange ganger. Prøv på nytt om noen minutter.</translation>
 <translation id="6216759405419177713">Norfolkøya</translation>
-<translation id="6245066275978703471">Telefonnummeret ble bekreftet automatisk</translation>
-<translation id="6269083314054226194">Nettverksfeil. Sjekk internettilkoblingen din.</translation>
-<translation id="6295157125625453859">Bekreftet.</translation>
+<translation id="6238170540438416559">Hvis du trykker på «<ph name="PH_1" />», godtar du <ph name="PP" /> våre. Du kan bli tilsendt en SMS. Kostnader for meldinger og datatrafikk kan påløpe.</translation>
+<translation id="6265373887273416711">Bekreft telefonnummeret ditt</translation>
+<translation id="6283536862756552051">For å endre passordet ditt må du først oppgi det eksisterende passordet.</translation>
+<translation id="6299890279889400823">Tilbake</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Fortsett</translation>

--- a/translations/pl.xtb
+++ b/translations/pl.xtb
@@ -28,15 +28,16 @@
 <translation id="144766329299583285">Jeżeli prośba o zmianę e-maila używanego do logowania nie została wysłana przez Ciebie, to możliwe, że ktoś próbuje się dostać na Twoje konto. <ph name="START_LINK" />Jak najszybciej zmień hasło<ph name="END_LINK" /></translation>
 <translation id="1449981769524156676">Wyspy Heard i McDonalda</translation>
 <translation id="1451880131543823984">Użytkownik <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> nie ma uprawnień do wyświetlenia wybranej strony.</translation>
-<translation id="1479035434297790822">Z tego adresu IP wysłano zbyt wiele próśb o utworzenie konta. Spróbuj ponownie za kilka minut.</translation>
+<translation id="1479035434297790822">Z tego adresu IP wysłano zbyt wiele próśb o utworzenie konta. Spróbuj ponownie za kilka minut.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Możesz się teraz zalogować na nowe konto</translation>
+<translation id="1535200361681091160">Wpisz adres e-mail</translation>
 <translation id="1544981664986460902">Klient podał nieprawidłowy argument.</translation>
 <translation id="1575848116712334589">Czad</translation>
 <translation id="1630237004390596779">Wyślij kod ponownie za <ph name="STRING" /></translation>
 <translation id="1653501608290591291">Białoruś</translation>
 <translation id="1667376103923043653">Nie istnieje konto, do którego pasuje ten adres e-mail.</translation>
-<translation id="173576986138855124">Gdy klikniesz „<ph name="PH_1" />”, może zostać wysłany SMS. Może to skutkować pobraniem opłaty za przesłanie wiadomości i danych.</translation>
+<translation id="173576986138855124">Gdy klikniesz „<ph name="PH_1" />”, może zostać wysłany SMS. Może to skutkować pobraniem opłaty za przesłanie wiadomości i danych.</translation>
 <translation id="1739056958326110545">Wyspa Świętej Heleny</translation>
 <translation id="1743026758446868773">Barbados</translation>
 <translation id="1772888465204630090">Klikając Dalej, wyrażasz zgodę na <ph name="START_LINK" />Warunki usługi<ph name="END_LINK" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Wyspy Cooka</translation>
 <translation id="1870056762032541323">Nieprawidłowy kod. Spróbuj jeszcze raz.</translation>
 <translation id="1898579907513173256">Makau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Cześć <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Usuwanie konta</translation>
+<translation id="1912929493041975510">Hasło musi składać się z co najmniej 6 znaków</translation>
+<translation id="1933044638365301516">Zaloguj się przez: <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Wpisz sześciocyfrowy kod, który wysłaliśmy pod numer <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Aby odzyskać hasło, wykonaj instrukcje, które wysłaliśmy Ci na adres <ph name="PH_1" />.</translation>
+<translation id="1999379687946415948">Twój kod do aplikacji <ph name="APP_NAME" /> to <ph name="IDV_CODE_PLACE_HOLDER" />.</translation>
+<translation id="2033662766890821456">Wyślij kod ponownie</translation>
 <translation id="2035855087334775326">Węgry</translation>
 <translation id="2040904406955887821">Surinam</translation>
 <translation id="2046207054419739276">Stany Zjednoczone</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Silne hasło ma co najmniej 6 znaków i jest kombinacją liter oraz cyfr.</translation>
 <translation id="2074008538308369451">Warunki korzystania z usługi</translation>
 <translation id="2089802663554186342">Sesja została zakończona</translation>
 <translation id="2108717231438756650">Wielka Brytania</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Zielony Przylądek</translation>
 <translation id="2301396996587599046">Macedonia</translation>
 <translation id="2310948428656960769">Zalogowano</translation>
+<translation id="2321152797538991921">Hasło musi zawierać co najmniej 1 znak niealfanumeryczny</translation>
 <translation id="2324942959480650701">Gość</translation>
 <translation id="2331781584136059536">Ghana</translation>
 <translation id="2338909515537249568">Twoja przeglądarka nie obsługuje pamięci podręcznej. Spróbuj ponownie z inną przeglądarką.</translation>
@@ -118,7 +120,7 @@
 <translation id="2824267666257947103">Wpisz hasło</translation>
 <translation id="2828509010894808185">Tworzenie konta</translation>
 <translation id="2834770837848769530">Afganistan</translation>
-<translation id="2884525438023347369">Klikając <ph name="BTN" />, potwierdzasz że znane Ci są <ph name="TOS" /> i akceptujesz je.</translation>
+<translation id="2884525438023347369">Klikając <ph name="BTN" />, potwierdzasz że znane Ci są <ph name="TOS" /> i akceptujesz je.</translation>
 <translation id="2909392332969582158">Kanada</translation>
 <translation id="2911018261311455240">Dania</translation>
 <translation id="2949732021187449522">Upłynął termin realizacji żądania.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">Podczas uwierzytelniania żądania wystąpił problem. Otwórz jeszcze raz URL, z którego nastąpiło przekierowanie na tę stronę, by zacząć proces uwierzytelniania od początku.</translation>
 <translation id="3216149523061905579">Dominika</translation>
 <translation id="3223688630903046698">Nowe hasło</translation>
+<translation id="3245143966477136343">Hasło musi zawierać co najmniej 1 małą literę</translation>
 <translation id="3250864391349648273">Gabon</translation>
 <translation id="3259479674319858599">Adres <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> został już przez Ciebie użyty. Aby kontynuować, zaloguj się przez: <ph name="IDP_DISPLAY_NAME" />.</translation>
 <translation id="3275852444431525182">Nowa Zelandia</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Aby odzyskać hasło, wykonaj instrukcje wysłane na adres <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /></translation>
 <translation id="4588392627302012849">Zaloguj się za pomocą e-maila</translation>
 <translation id="4595119411041064617">Gdy klikniesz „<ph name="PH_1" />”, może zostać wysłany SMS. Może to skutkować pobraniem opłaty za przesłanie wiadomości i danych.</translation>
+<translation id="4603232692404395592">Maksymalna liczba znaków w haśle to <ph name="MAX_PASSWORD_LENGTH" /></translation>
 <translation id="4632709875751031323">Rosja</translation>
 <translation id="4644169548516814280">Tego adresu e-mail używa już inne konto</translation>
 <translation id="4692014002063276828">Polska</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Sprawdź, czy nie kończy się miejsce w skrzynce odbiorczej oraz czy nie ma innych problemów z ustawieniami skrzynki.</translation>
 <translation id="6135589730599211649">Klient podał nieprawidłowy zakres.</translation>
 <translation id="6143147250106939258">Limit dla tej operacji został przekroczony. Spróbuj jeszcze raz później.</translation>
+<translation id="615787395595800956">Niespełnione wymogi dotyczące hasła:</translation>
 <translation id="6189573836664806798">Paragwaj</translation>
 <translation id="6192657410634245771">Algieria</translation>
 <translation id="6213969168046789596">Zbyt wiele razy podano niepoprawne hasło. Spróbuj jeszcze raz za kilka minut.</translation>
 <translation id="6216759405419177713">Wyspa Norfolk</translation>
-<translation id="6245066275978703471">Numer telefonu został automatycznie zweryfikowany</translation>
-<translation id="6269083314054226194">Błąd sieci. Sprawdź połączenie z internetem.</translation>
-<translation id="6295157125625453859">Zweryfikowano.</translation>
+<translation id="6238170540438416559">Klikając „<ph name="PH_1" />”, potwierdzasz, że akceptujesz ten dokument: <ph name="PP" />. Może zostać wysłany SMS. Może to skutkować pobraniem opłat za przesłanie wiadomości i danych.</translation>
+<translation id="6265373887273416711">Zweryfikuj swój numer telefonu</translation>
+<translation id="6283536862756552051">Aby zmienić hasło, musisz najpierw wpisać to, którego używasz obecnie.</translation>
+<translation id="6299890279889400823">Wstecz</translation>
 <translation id="6316446940976157217">Indie</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Dalej</translation>
+<translation id="6355621963154078138">Hasło musi zawierać co najmniej 1 cyfrę</translation>
 <translation id="6359400968059656782">Teraz możesz się zalogować z użyciem nowego hasła</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luksemburg</translation>
@@ -402,7 +409,7 @@
 <translation id="7359542696390093035">Nie masz uprawnień</translation>
 <translation id="743266754881673808">Google</translation>
 <translation id="744894552966168763">Nieprawidłowy link z e-maila</translation>
-<translation id="7477065998516229434">Warunki korzystania z usługi</translation>
+<translation id="7477065998516229434">Warunki korzystania z usługi</translation>
 <translation id="7493245640904888019">Gibraltar</translation>
 <translation id="7510939244824757986">Tanzania</translation>
 <translation id="7526532581122816497">Połączone konto</translation>
@@ -412,13 +419,14 @@
 <translation id="7595933825828475368">E-mail nie dotarł?</translation>
 <translation id="7615083347713899917">Kirgistan</translation>
 <translation id="7643408533407091568">Adres <ph name="EMAIL_ADDR" /> został już przez Ciebie użyty do logowania. Wpisz hasło tego konta.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znak i być kombinacją liter i cyfr.}few{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znaki i być kombinacją liter i cyfr.}many{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znaków i być kombinacją liter i cyfr.}other{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znaku i być kombinacją liter i cyfr}}</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znak i być kombinacją liter i cyfr.}few{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znaki i być kombinacją liter i cyfr.}many{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znaków i być kombinacją liter i cyfr.}other{Hasło jest za słabe. Powinno mieć przynajmniej <ph name="PH_1" /> znaku i być kombinacją liter i cyfr}}</translation>
 <translation id="7699755204074920022">Zimbabwe</translation>
 <translation id="7746977132739352062">Żądanie nie zostało uwierzytelnione, ponieważ brakuje tokena OAuth, jest on nieprawidłowy lub wygasł.</translation>
 <translation id="7778245738233381641">Podaj sześciocyfrowy kod weryfikacyjny, który wysłaliśmy Ci SMS-em.</translation>
 <translation id="7790301903034097323">Wybierz hasło</translation>
 <translation id="7796914496604415892">Wykryto nowe urządzenie lub nową przeglądarkę</translation>
 <translation id="786166109137986817">Zaloguj się do <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">Hasło musi zawierać co najmniej 1 wielką literę</translation>
 <translation id="7868540442111212282">Czechy</translation>
 <translation id="7874584525604421364">Tuwalu</translation>
 <translation id="7926046652648626866">Zaloguj się przez GitHuba</translation>
@@ -426,7 +434,7 @@
 <translation id="7956645158976161232">Libia</translation>
 <translation id="8017277252219866084">Kenia</translation>
 <translation id="8028653067082554952">Spowoduje to nieodwracalne usunięcie wszystkich danych powiązanych z Twoim kontem. Czy na pewno chcesz usunąć konto?</translation>
-<translation id="8033786138248870436">Gdy klikniesz Zweryfikuj, może zostać wysłany SMS, przez co operator może pobrać opłatę za przesyłanie wiadomości i danych.</translation>
+<translation id="8033786138248870436">Gdy klikniesz Zweryfikuj, może zostać wysłany SMS, przez co operator może pobrać opłatę za przesyłanie wiadomości i danych.</translation>
 <translation id="8047183472745080590">Boliwia</translation>
 <translation id="8047565947836609247">Portoryko</translation>
 <translation id="8055755007915250245">Czy odłączyć konto?</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151">Jeśli nadal chcesz połączyć swoje konto w serwisie <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, otwórz link na tym samym urządzeniu, na którym zaczęty został proces logowania. Aby zalogować się na obecnie używanym urządzeniu, wybierz „Dalej”.</translation>
 <translation id="8920674952994839257">Ponów</translation>
 <translation id="8939353296336237380">Podjęto próbę połączenia konta w serwisie <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> z adresem e-mail, ale link został otwarty na innym urządzeniu, na którym użytkownik nie był zalogowany.</translation>
-<translation id="8971555482255213064">Kod można ponownie wysłać za 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">Klikając <ph name="BTN" />, potwierdzasz że znana Ci jest <ph name="PP" /> i wyrażasz na nią zgodę.</translation>
+<translation id="8980953965669178372">Gotowe</translation>
 <translation id="8984161590699631096">Maroko</translation>
 <translation id="8994098794339484800">Jeżeli nie rozpoznajesz tego urządzenia, to możliwe, że ktoś próbował uzyskać dostęp do Twojego konta. Rozważ <ph name="START_LINK" />natychmiastową zmianę hasła<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesz</translation>
 <translation id="9022632332691561239">Telefon</translation>
 <translation id="9028063588419847334">Finlandia</translation>
 <translation id="9078135685219203661">Zjednoczone Emiraty Arabskie</translation>
+<translation id="9085311482535098646">Minimalna liczba znaków w haśle to <ph name="MIN_PASSWORD_LENGTH" /></translation>
 <translation id="9121203582272050974">Twój adres e-mail został potwierdzony i zmieniony</translation>
 <translation id="9156150178611681179">Hasło</translation>
 <translation id="9168877696443530714">Republika Środkowej Afryki</translation>

--- a/translations/pt-BR.xtb
+++ b/translations/pt-BR.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">Seu endereço IP está emitindo muitas solicitações de contas. Tente novamente em alguns minutos.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Faça login com a sua nova conta</translation>
+<translation id="1535200361681091160">Digite seu e-mail</translation>
 <translation id="1544981664986460902">O cliente especificou um argumento inválido.</translation>
 <translation id="1575848116712334589">Chade</translation>
 <translation id="1630237004390596779">Reenviar o código em <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Ilhas Cook</translation>
 <translation id="1870056762032541323">Código incorreto. Tente novamente.</translation>
 <translation id="1898579907513173256">Macau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Olá, <ph name="DISPLAY_NAME" /><ph name="P_END" /></translation>
-<translation id="1966996824429980990">Excluir conta</translation>
+<translation id="1912929493041975510">A senha precisa ter pelo menos seis caracteres</translation>
+<translation id="1933044638365301516">Fazer login com o <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Insira o código de 6 dígitos enviado para <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">Siga as instruções enviadas para <ph name="PH_1" /> para recuperar sua senha.</translation>
+<translation id="1999379687946415948"><ph name="IDV_CODE_PLACE_HOLDER" /> é seu código para <ph name="APP_NAME" />.</translation>
+<translation id="2033662766890821456">Reenviar código</translation>
 <translation id="2035855087334775326">Hungria</translation>
 <translation id="2040904406955887821">Suriname</translation>
 <translation id="2046207054419739276">Estados Unidos</translation>
 <translation id="2049229571938383319">São Bartolomeu</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Senhas fortes têm pelo menos 6 caracteres e uma combinação de letras e números</translation>
 <translation id="2074008538308369451">Termos de Serviço</translation>
 <translation id="2089802663554186342">Sessão encerrada</translation>
 <translation id="2108717231438756650">Reino Unido</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Cabo Verde</translation>
 <translation id="2301396996587599046">Macedônia</translation>
 <translation id="2310948428656960769">Conectado!</translation>
+<translation id="2321152797538991921">A senha precisa ter um caractere não alfanumérico</translation>
 <translation id="2324942959480650701">Convidado</translation>
 <translation id="2331781584136059536">Gana</translation>
 <translation id="2338909515537249568">O navegador usado não é compatível com o armazenamento na Web. Tente novamente em outro navegador.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">Houve um problema ao autenticar sua solicitação. Acesse novamente o URL que redirecionou você para esta página e reinicie o processo de autenticação.</translation>
 <translation id="3216149523061905579">Dominica</translation>
 <translation id="3223688630903046698">Nova senha</translation>
+<translation id="3245143966477136343">A senha precisa ter uma letra minúscula</translation>
 <translation id="3250864391349648273">Gabão</translation>
 <translation id="3259479674319858599">Você já usou o e-mail <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Faça login com o <ph name="IDP_DISPLAY_NAME" /> para continuar.</translation>
 <translation id="3275852444431525182">Nova Zelândia</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Siga as instruções enviadas para <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> para recuperar sua senha</translation>
 <translation id="4588392627302012849">Fazer login com o e-mail</translation>
 <translation id="4595119411041064617">Se você tocar em "<ph name="PH_1" />", um SMS poderá ser enviado e tarifas de mensagens e de dados serão cobradas.</translation>
+<translation id="4603232692404395592">A senha pode ter no máximo <ph name="MAX_PASSWORD_LENGTH" /> caracteres</translation>
 <translation id="4632709875751031323">Rússia</translation>
 <translation id="4644169548516814280">O endereço de e-mail já está sendo usado por outra conta</translation>
 <translation id="4692014002063276828">Polônia</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Verifique se você ainda tem espaço na sua caixa de entrada, além de outros problemas relacionados à configuração.</translation>
 <translation id="6135589730599211649">O cliente especificou um intervalo inválido.</translation>
 <translation id="6143147250106939258">A cota desta operação foi excedida. Tente novamente mais tarde.</translation>
+<translation id="615787395595800956">Requisitos de senha em falta:</translation>
 <translation id="6189573836664806798">Paraguai</translation>
 <translation id="6192657410634245771">Argélia</translation>
 <translation id="6213969168046789596">Você digitou a senha incorretamente várias vezes. Tente novamente em alguns minutos.</translation>
 <translation id="6216759405419177713">Ilha Norfolk</translation>
-<translation id="6245066275978703471">O número de telefone foi verificado automaticamente</translation>
-<translation id="6269083314054226194">Erro de rede, confira sua conexão de Internet.</translation>
-<translation id="6295157125625453859">Verificado.</translation>
+<translation id="6238170540438416559">Ao tocar em “<ph name="PH_1" />”, você concorda com nossa <ph name="PP" />. Um SMS poderá ser enviado e tarifas de mensagens e de dados poderão ser cobradas.</translation>
+<translation id="6265373887273416711">Confirmar seu número de telefone</translation>
+<translation id="6283536862756552051">Para alterar sua senha, primeiro insira sua senha atual.</translation>
+<translation id="6299890279889400823">Voltar</translation>
 <translation id="6316446940976157217">Índia</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Continuar</translation>
+<translation id="6355621963154078138">A senha precisa ter um caractere numérico</translation>
 <translation id="6359400968059656782">Faça login com a sua nova senha</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Luxemburgo</translation>
@@ -419,13 +426,14 @@
 <translation id="7790301903034097323">Escolha a senha</translation>
 <translation id="7796914496604415892">Novo dispositivo ou navegador detectado</translation>
 <translation id="786166109137986817">Fazer login no locatário <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">A senha precisa ter uma letra maiúscula</translation>
 <translation id="7868540442111212282">República Tcheca</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Fazer login com o GitHub</translation>
 <translation id="792838323404934335">Groenlândia</translation>
 <translation id="7956645158976161232">Líbia</translation>
 <translation id="8017277252219866084">Quênia</translation>
-<translation id="8028653067082554952">Esta ação apagará todos os dados associados à sua conta e não poderá ser desfeita. Você quer mesmo excluir sua conta?</translation>
+<translation id="8028653067082554952">Esta ação vai apagar todos os dados associados à sua conta e não poderá ser desfeita. Você quer mesmo excluir sua conta?</translation>
 <translation id="8033786138248870436">Talvez você receba um SMS quando tocar em "Verificar". Taxas de mensagens e dados podem ser aplicáveis.</translation>
 <translation id="8047183472745080590">Bolívia</translation>
 <translation id="8047565947836609247">Porto Rico</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151">Se você ainda quiser conectar sua conta do <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, abra o link no mesmo dispositivo em que você iniciou o login. Caso contrário, toque em Continuar para fazer login neste dispositivo.</translation>
 <translation id="8920674952994839257">Tentar novamente</translation>
 <translation id="8939353296336237380">Inicialmente, você quis conectar o <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> à sua conta de e-mail, mas abriu o link em um dispositivo diferente, em que você não está conectado.</translation>
-<translation id="8971555482255213064">Reenviar código em 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">Ao tocar em "<ph name="BTN" />", você indica que está de acordo com a <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Concluído</translation>
 <translation id="8984161590699631096">Marrocos</translation>
 <translation id="8994098794339484800">Se você não reconhece este dispositivo, alguém pode estar tentando acessar sua conta. Considere <ph name="START_LINK" />alterar sua senha agora mesmo<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladesh</translation>
 <translation id="9022632332691561239">Smartphone</translation>
 <translation id="9028063588419847334">Finlândia</translation>
 <translation id="9078135685219203661">Emirados Árabes Unidos</translation>
+<translation id="9085311482535098646">A senha precisa ter pelo menos <ph name="MIN_PASSWORD_LENGTH" /> caracteres</translation>
 <translation id="9121203582272050974">Seu e-mail foi verificado e alterado</translation>
 <translation id="9156150178611681179">Senha</translation>
 <translation id="9168877696443530714">República Centro-Africana</translation>

--- a/translations/pt-PT.xtb
+++ b/translations/pt-PT.xtb
@@ -19,7 +19,7 @@
 <translation id="1297168472480293352">Guatemala</translation>
 <translation id="1307255433239736397"><ph name="START_PARAGRAPH" />Ocorreu um erro ao remover o seu segundo fator.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Experimente removê-lo novamente. Se isso não funcionar, contacte o apoio técnico para obter assistência.<ph name="END_PARAGRAPH" /></translation>
 <translation id="1310034618729602982">Experimente atualizar o seu email novamente</translation>
-<translation id="1312824004897469797">Ocorreu um erro de rede. Tente novamente mais tarde.</translation>
+<translation id="1312824004897469797">Ocorreu um erro de rede. Tente mais tarde.</translation>
 <translation id="1315809131562953678">Introduza um número de telefone válido</translation>
 <translation id="1335716056288807013">Ao tocar em Validar, indica que aceita os <ph name="START_LINK_1" />Termos de Utilização<ph name="END_LINK" /> e a <ph name="START_LINK_2" />Política de Privacidade<ph name="END_LINK" />. Pode gerar o envio de uma SMS. Podem aplicar-se tarifas de dados e de mensagens.</translation>
 <translation id="137210131544215127">Introduza a palavra-passe</translation>
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Ilhas Cook</translation>
 <translation id="1870056762032541323">Código errado. Tente novamente.</translation>
 <translation id="1898579907513173256">Macau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Olá, <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Eliminar conta</translation>
+<translation id="1912929493041975510">A palavra-passe tem de ter, pelo menos, 6 caracteres</translation>
+<translation id="1933044638365301516">Iniciar sessão com <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Introduza o código de 6 dígitos que enviámos para <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Siga as instruções enviadas para <ph name="PH_1" /> para recuperar a palavra-passe.</translation>
 <translation id="2035855087334775326">Hungria</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Estados Unidos</translation>
 <translation id="2049229571938383319">São Bartolomeu</translation>
 <translation id="2058731785647385204">Monserrate</translation>
-<translation id="2070709910567585968">Para criar uma palavra-passe forte é necessário utilizar, no mínimo, 6 caracteres e uma combinação de letras e de números</translation>
 <translation id="2074008538308369451">Termos de Utilização</translation>
 <translation id="2089802663554186342">Sessão terminada</translation>
 <translation id="2108717231438756650">Reino Unido</translation>
@@ -306,14 +305,15 @@
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="6132202686885223981">Certifique-se de que a sua caixa de entrada não está a ficar sem espaço disponível nem está com outros problemas relacionados com as definições da caixa de entrada.</translation>
 <translation id="6135589730599211649">O cliente especificou uma alteração inválida.</translation>
-<translation id="6143147250106939258">A quota para esta operação foi excedida. Tente novamente mais tarde.</translation>
+<translation id="6143147250106939258">A quota para esta operação foi excedida. Tente mais tarde.</translation>
 <translation id="6189573836664806798">Paraguai</translation>
 <translation id="6192657410634245771">Argélia</translation>
 <translation id="6213969168046789596">Introduziu uma palavra-passe errada demasiadas vezes. Tente novamente dentro de alguns minutos.</translation>
 <translation id="6216759405419177713">Ilha Norfolk</translation>
-<translation id="6245066275978703471">Número de telefone verificado automaticamente</translation>
-<translation id="6269083314054226194">Erro de rede. Verifique a sua ligação à Internet.</translation>
-<translation id="6295157125625453859">Validado!</translation>
+<translation id="6238170540438416559">Ao tocar em "<ph name="PH_1" />", indica que aceita a nossa <ph name="PP" />. Pode gerar o envio de uma SMS. Podem aplicar-se tarifas de mensagens e dados.</translation>
+<translation id="6265373887273416711">Validar o número de telefone</translation>
+<translation id="6283536862756552051">Para alterar a palavra-passe, primeiro tem de introduzir a palavra-passe atual.</translation>
+<translation id="6299890279889400823">Anterior</translation>
 <translation id="6316446940976157217">Índia</translation>
 <translation id="6327723482938582895">Benim</translation>
 <translation id="6338643731889005578">Continuar</translation>
@@ -382,7 +382,7 @@
 <translation id="7192078949090526171">São Marino</translation>
 <translation id="7197455001919474950">Chipre</translation>
 <translation id="7198563013006562060">Ilhas Salomão</translation>
-<translation id="7207660930894629055">Pretende continuar com <ph name="USER_EMAIL" />?</translation>
+<translation id="7207660930894629055">Quer continuar com <ph name="USER_EMAIL" />?</translation>
 <translation id="720983450833499456">Para continuar a iniciar sessão com <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> neste dispositivo, tem de recuperar a palavra-passe.</translation>
 <translation id="7223410082658239002">Maldivas</translation>
 <translation id="7254028881697834212">São Tomé e Príncipe</translation>
@@ -410,21 +410,21 @@
 <translation id="7643408533407091568">Já utilizou <ph name="EMAIL_ADDR" /> para iniciar sessão. Introduza a palavra-passe da conta em questão.</translation>
 <translation id="7652546345268886994">{plural_var,plural, =1{A palavra-passe não é suficientemente forte. Utilize, pelo menos, <ph name="PH_1" /> caráter e uma combinação de letras e números}other{A palavra-passe não é suficientemente forte. Utilize, pelo menos, <ph name="PH_1" /> caracteres e uma combinação de letras e números}}</translation>
 <translation id="7699755204074920022">Zimbabué</translation>
-<translation id="7746977132739352062">Pedido não autenticado devido a token OAuth em falta, inválido ou expirado.</translation>
+<translation id="7746977132739352062">Pedido não autenticado devido o token OAuth em falta, inválido ou expirado.</translation>
 <translation id="7782885946428624225">Ocorreu um problema ao validar o número de telefone</translation>
 <translation id="7796914496604415892">Novo dispositivo ou navegador detetado</translation>
 <translation id="786166109137986817">Iniciar sessão em <ph name="DISPLAY_NAME" /></translation>
-<translation id="7868540442111212282">República Checa</translation>
+<translation id="7868540442111212282">Chéquia</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">Iniciar sessão com o GitHub</translation>
 <translation id="792838323404934335">Gronelândia</translation>
 <translation id="7956645158976161232">Líbia</translation>
 <translation id="8017277252219866084">Quénia</translation>
-<translation id="8028653067082554952">Esta ação apaga todos os dados associados à sua conta e não pode ser anulada. Tem a certeza de que pretende eliminar a sua conta?</translation>
+<translation id="8028653067082554952">Esta ação apaga todos os dados associados à sua conta e não pode ser anulada. Tem a certeza de que quer eliminar a sua conta?</translation>
 <translation id="8033786138248870436">Ao tocar em Validar, pode gerar o envio de uma SMS. Podem aplicar-se tarifas de dados e de mensagens.</translation>
 <translation id="8047183472745080590">Bolívia</translation>
 <translation id="8047565947836609247">Porto Rico</translation>
-<translation id="8055755007915250245">Pretende desassociar a conta?</translation>
+<translation id="8055755007915250245">Quer desassociar a conta?</translation>
 <translation id="8063505483150915580">Ilha do Natal</translation>
 <translation id="8077378925683571933">
 <ph name="P_START" />Obrigado,<ph name="P_END" />
@@ -493,7 +493,7 @@
 <translation id="9156150178611681179">Palavra-passe</translation>
 <translation id="9168877696443530714">República Centro-Africana</translation>
 <translation id="9186194643192393179">Curaçau</translation>
-<translation id="9193130710600355008">Bloqueámos todos os pedidos deste dispositivo devido a atividade invulgar. Tente novamente mais tarde.</translation>
+<translation id="9193130710600355008">Bloqueámos todos os pedidos deste dispositivo devido a atividade invulgar. Tente mais tarde.</translation>
 <translation id="919456844206936371">Tunísia</translation>
 <translation id="9209678713072395487">Palavra-passe alterada</translation>
 <translation id="954276184636809129">Grécia</translation>

--- a/translations/ro.xtb
+++ b/translations/ro.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Insulele Cook</translation>
 <translation id="1870056762032541323">Cod greșit. Încercați din nou.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Bună ziua, <ph name="DISPLAY_NAME" />.<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Ștergeți contul</translation>
+<translation id="1912929493041975510">Parola trebuie să conțină cel puțin 6 caractere.</translation>
+<translation id="1933044638365301516">Conectați-vă cu <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Introduceți codul din 6 cifre pe care l-am trimis la <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Urmați instrucțiunile trimise la <ph name="PH_1" /> pentru a vă recupera parola.</translation>
 <translation id="2035855087334775326">Ungaria</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Statele Unite</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Parolele puternice au cel puțin 6 caractere și conțin o combinație de litere și cifre</translation>
 <translation id="2074008538308369451">Termeni și condiții</translation>
 <translation id="2089802663554186342">S-a încheiat sesiunea</translation>
 <translation id="2108717231438756650">Regatul Unit</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Algeria</translation>
 <translation id="6213969168046789596">Ați introdus de prea multe ori o parolă greșită. Încercați din nou peste câteva minute.</translation>
 <translation id="6216759405419177713">Insula Norfolk</translation>
-<translation id="6245066275978703471">Numărul de telefon este verificat automat</translation>
-<translation id="6269083314054226194">Eroare de rețea, verificați conexiunea la internet.</translation>
-<translation id="6295157125625453859">Confirmat!</translation>
+<translation id="6238170540438416559">Dacă atingeți „<ph name="PH_1" />”, sunteți de acord cu <ph name="PP" />. Poate fi trimis un SMS. Se pot aplica tarife pentru mesaje și date.</translation>
+<translation id="6265373887273416711">Confirmați numărul de telefon</translation>
+<translation id="6283536862756552051">Pentru a vă schimba parola, trebuie să introduceți parola actuală.</translation>
+<translation id="6299890279889400823">Înapoi</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Continuați</translation>

--- a/translations/ru.xtb
+++ b/translations/ru.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">С вашего IP-адреса поступает слишком много запросов на создание аккаунта. Повторите попытку через несколько минут.</translation>
 <translation id="1483249363694224399">Шри-Ланка</translation>
 <translation id="1507995441600689506">Теперь вы можете входить в систему через новый аккаунт</translation>
+<translation id="1535200361681091160">Введите свой адрес электронной почты</translation>
 <translation id="1544981664986460902">Указан недопустимый аргумент.</translation>
 <translation id="1575848116712334589">Чад</translation>
 <translation id="1630237004390596779">Код можно будет запросить ещё раз через <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Острова Кука</translation>
 <translation id="1870056762032541323">Неверный код. Повторите попытку.</translation>
 <translation id="1898579907513173256">Макао</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Здравствуйте, <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Удаление аккаунта</translation>
+<translation id="1912929493041975510">Пароль должен содержать не менее 6 символов.</translation>
+<translation id="1933044638365301516">Войти через аккаунт <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Введите 6-значный код, отправленный на номер <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">На адрес <ph name="PH_1" /> отправлено письмо с инструкциями по сбросу пароля.</translation>
+<translation id="1999379687946415948">Ваш код для входа в приложение "<ph name="APP_NAME" />": <ph name="IDV_CODE_PLACE_HOLDER" />.</translation>
+<translation id="2033662766890821456">Отправить код ещё раз</translation>
 <translation id="2035855087334775326">Венгрия</translation>
 <translation id="2040904406955887821">Суринам</translation>
 <translation id="2046207054419739276">Соединенные Штаты Америки</translation>
 <translation id="2049229571938383319">Сен-Бартелеми</translation>
 <translation id="2058731785647385204">Монтсеррат</translation>
-<translation id="2070709910567585968">Пароль должен состоять из букв и цифр и содержать не меньше 6 символов.</translation>
 <translation id="2074008538308369451">Условия использования</translation>
 <translation id="2089802663554186342">Сеанс завершен</translation>
 <translation id="2108717231438756650">Великобритания</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Кабо-Верде</translation>
 <translation id="2301396996587599046">Македония</translation>
 <translation id="2310948428656960769">Вход выполнен</translation>
+<translation id="2321152797538991921">В пароле должен быть символ, не являющийся буквой или цифрой</translation>
 <translation id="2324942959480650701">Гость</translation>
 <translation id="2331781584136059536">Гана</translation>
 <translation id="2338909515537249568">Ваш браузер не поддерживает веб-хранилище. Повторите попытку в другом браузере.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">Во время аутентификации запроса произошла ошибка. Чтобы возобновить процесс, снова перейдите по URL, который перенаправляет на эту страницу.</translation>
 <translation id="3216149523061905579">Доминика</translation>
 <translation id="3223688630903046698">Новый пароль</translation>
+<translation id="3245143966477136343">В пароле должна быть строчная буква</translation>
 <translation id="3250864391349648273">Габон</translation>
 <translation id="3259479674319858599">Вы уже использовали адрес <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Войдите через аккаунт <ph name="IDP_DISPLAY_NAME" />.</translation>
 <translation id="3275852444431525182">Новая Зеландия</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">На адрес <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> отправлено письмо с инструкциями по восстановлению пароля.</translation>
 <translation id="4588392627302012849">Войти по адресу электронной почты</translation>
 <translation id="4595119411041064617">Нажимая кнопку "<ph name="PH_1" />", вы соглашаетесь получить SMS. За его отправку и обмен данными может взиматься плата.</translation>
+<translation id="4603232692404395592">Максимальное числов символов в пароле: <ph name="MAX_PASSWORD_LENGTH" /></translation>
 <translation id="4632709875751031323">Россия</translation>
 <translation id="4644169548516814280">Этот адрес электронной почты уже используется в другом аккаунте.</translation>
 <translation id="4692014002063276828">Польша</translation>
@@ -229,7 +233,7 @@
 <translation id="4852256440857413490">Неверный код. Повторите попытку.</translation>
 <translation id="4866990546854875813">Время сеанса, связанного с этим запросом входа, истекло, или сеанс был завершен.</translation>
 <translation id="4871106926303956169">Острова Теркс и Кайкос</translation>
-<translation id="4877597386645466815">Отправить код ещё раз можно будет через <ph name="TIME_REMAINING" /></translation>
+<translation id="4877597386645466815">Отправить код ещё раз можно будет через <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
 <ph name="P_START" />Для вашего аккаунта в приложении "<ph name="APP_NAME" />" добавлен номер телефона <ph name="SECOND_FACTOR" /> для двухэтапной аутентификации.<ph name="P_END" />
 <ph name="P_START" />Если вы не добавляли этот номер телефона для двухэтапной аутентификации, нажмите на ссылку ниже, чтобы удалить его.<ph name="P_END" /> <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
@@ -300,7 +304,7 @@
 <translation id="5989709845715452405">Восстановление пароля</translation>
 <translation id="5995596766674622541">Введите 6-значный код, отправленный на номер <ph name="START_LINK" />&amp;lrm;<ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="6006148985615990975">Руанда</translation>
-<translation id="6032262985756512833">Укажите код из <ph name="STRING" /> цифр, который мы отправили на номер</translation>
+<translation id="6032262985756512833">Укажите код из <ph name="STRING" /> цифр, который мы отправили на номер</translation>
 <translation id="6044396095102058216">Этот номер телефона использовался слишком много раз.</translation>
 <translation id="6083089720215618333">Указанный адрес электронной почты не совпадает с адресом, который использовался для входа.</translation>
 <translation id="6091051069256411999">Twitter</translation>
@@ -310,16 +314,19 @@
 <translation id="6132202686885223981">Проверьте настройки папки со входящими сообщениям и убедитесь, что в ней достаточно места.</translation>
 <translation id="6135589730599211649">Указан недопустимый диапазон.</translation>
 <translation id="6143147250106939258">Превышена квота для этой операции. Повторите попытку позже.</translation>
+<translation id="615787395595800956">Требования, которым не отвечает ваш пароль:</translation>
 <translation id="6189573836664806798">Парагвай</translation>
 <translation id="6192657410634245771">Алжир</translation>
 <translation id="6213969168046789596">Вы неправильно ввели пароль слишком много раз. Прежде чем повторить попытку, подождите несколько минут.</translation>
 <translation id="6216759405419177713">Остров Норфолк</translation>
-<translation id="6245066275978703471">Номер телефона был подтвержден автоматически</translation>
-<translation id="6269083314054226194">Ошибка сети. Проверьте подключение к Интернету.</translation>
-<translation id="6295157125625453859">Проверка выполнена.</translation>
+<translation id="6238170540438416559">Нажимая кнопку "<ph name="PH_1" />", вы принимаете <ph name="PP" /> и соглашаетесь получить SMS. За его отправку и обмен данными может взиматься плата.</translation>
+<translation id="6265373887273416711">Подтвердить номер телефона</translation>
+<translation id="6283536862756552051">Сначала нужно ввести текущий пароль.</translation>
+<translation id="6299890279889400823">Назад</translation>
 <translation id="6316446940976157217">Индия</translation>
 <translation id="6327723482938582895">Бенин</translation>
 <translation id="6338643731889005578">Продолжить</translation>
+<translation id="6355621963154078138">В пароле должна быть цифра</translation>
 <translation id="6359400968059656782">Теперь вы можете войти в аккаунт, используя новый пароль</translation>
 <translation id="6363241121027868570">Аруба</translation>
 <translation id="6377222208046638522">Люксембург</translation>
@@ -411,13 +418,14 @@
 <translation id="7595933825828475368">Не получили письмо?</translation>
 <translation id="7615083347713899917">Киргизия</translation>
 <translation id="7643408533407091568">Вы уже использовали адрес <ph name="EMAIL_ADDR" />. Введите пароль для этого аккаунта.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символа.}one{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символа.}few{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символов.}many{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символов.}other{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символа.}}</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символа.}one{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символа.}few{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символов.}many{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символов.}other{Пароль должен состоять из букв и цифр и содержать не меньше <ph name="PH_1" /> символа.}}</translation>
 <translation id="7699755204074920022">Зимбабве</translation>
 <translation id="7746977132739352062">Запрос не аутентифицирован, поскольку токен OAuth отсутствует, недействителен или устарел.</translation>
-<translation id="7778245738233381641">Код подтверждения должен состоять из 6 цифр.</translation>
+<translation id="7778245738233381641">Код подтверждения должен состоять из 6 цифр.</translation>
 <translation id="7790301903034097323">Выберите пароль</translation>
 <translation id="7796914496604415892">Зарегистрирован вход с нового устройства или браузера</translation>
 <translation id="786166109137986817">Войдите в аккаунт в приложении <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">В пароле должна быть прописная буква</translation>
 <translation id="7868540442111212282">Чехия</translation>
 <translation id="7874584525604421364">Тувалу</translation>
 <translation id="7926046652648626866">Войти через аккаунт GitHub</translation>
@@ -491,13 +499,15 @@
 <translation id="8916080112145514151">Чтобы пройти авторизацию на текущем компьютере, телефоне или планшете, нажмите "Продолжить". Если вы все-таки хотите связать аккаунт сервиса <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> со своим адресом электронной почты, откройте ссылку на устройстве, на котором начали процесс входа.</translation>
 <translation id="8920674952994839257">Повторить</translation>
 <translation id="8939353296336237380">Вы пытались связать аккаунт сервиса <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> со своим адресом электронной почты, однако перешли по ссылке на устройстве, на котором у вас не выполнен вход.</translation>
-<translation id="8971555482255213064">Отправить код ещё раз можно будет через 0:<ph name="PH_1" />.</translation>
+<translation id="8955469172512804617">Нажимая кнопку "<ph name="BTN" />", вы принимаете <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Готово</translation>
 <translation id="8984161590699631096">Марокко</translation>
 <translation id="8994098794339484800">Если вам не знакомо это устройство, возможно, кто-то пытается получить доступ к вашему аккаунту. Рекомендуем <ph name="START_LINK" />изменить пароль прямо сейчас<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Бангладеш</translation>
 <translation id="9022632332691561239">Телефон</translation>
 <translation id="9028063588419847334">Финляндия</translation>
 <translation id="9078135685219203661">Объединенные Арабские Эмираты</translation>
+<translation id="9085311482535098646">Минимальное число символов в пароле: <ph name="MIN_PASSWORD_LENGTH" /></translation>
 <translation id="9121203582272050974">Адрес электронной почты подтвержден и изменен</translation>
 <translation id="9156150178611681179">Пароль</translation>
 <translation id="9168877696443530714">Центрально-Африканская Республика</translation>

--- a/translations/sk.xtb
+++ b/translations/sk.xtb
@@ -2,51 +2,51 @@
 <translation id="1003362845472634045">Prihlasovací e‑mail bol odoslaný</translation>
 <translation id="10081113082271688">Nesprávny overovací kód</translation>
 <translation id="1024070574104100559">Svätý Vincent a Grenadíny</translation>
-<translation id="1080228854514607739">Tento e‑mailový odkaz je neplatný. Môže k tomu dôjsť vtedy, ak platnosť odkazu vypršala alebo ste sa prostredníctvom tohto e‑mailového odkazu už prihlásili. Reštartujte proces prihlásenia.</translation>
+<translation id="1080228854514607739">Tento e‑mailový odkaz je neplatný. Môže k tomu dôjsť vtedy, ak platnosť odkazu vypršala alebo ste sa prostredníctvom tohto e‑mailového odkazu už prihlásili. Reštartujte proces prihlásenia.</translation>
 <translation id="1088824719285122027">Toto telefónne číslo bolo použité príliš veľakrát</translation>
 <translation id="1111168792069656940">ui_flow</translation>
 <translation id="1130401182255828006">Lotyšsko</translation>
 <translation id="1133565039750742069">Uložiť</translation>
 <translation id="1139115784936170936">Singapur</translation>
-<translation id="1163494479861953195">Znova sa prihláste a vykonajte túto operáciu</translation>
+<translation id="1163494479861953195">Znova sa prihláste a vykonajte túto operáciu</translation>
 <translation id="1163771673786684213">Filipíny</translation>
 <translation id="1170304454812139475">Rumunsko</translation>
-<translation id="1194565221977667376">Južná Georgia a Južné Sandwichove ostrovy</translation>
+<translation id="1194565221977667376">Južná Georgia a Južné Sandwichove ostrovy</translation>
 <translation id="1233977465587641672">Neobnoviteľná strata alebo poškodenie údajov.</translation>
 <translation id="1244846213930750436">Taliansko</translation>
 <translation id="1268266284642694018">Libanon</translation>
 <translation id="1294742657282291237">Guyana</translation>
 <translation id="1297168472480293352">Guatemala</translation>
-<translation id="1307255433239736397"><ph name="START_PARAGRAPH" />Pri odstraňovaní druhého prvku sa vyskytla chyba.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Skúste ho odstrániť znova. Ak to nepomôže, požiadajte o pomoc podporu.<ph name="END_PARAGRAPH" /></translation>
+<translation id="1307255433239736397"><ph name="START_PARAGRAPH" />Pri odstraňovaní druhého prvku sa vyskytla chyba.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Skúste ho odstrániť znova. Ak to nepomôže, požiadajte o pomoc podporu.<ph name="END_PARAGRAPH" /></translation>
 <translation id="1310034618729602982">Skúste e‑mailovú adresu aktualizovať znova</translation>
 <translation id="1312824004897469797">Vyskytla sa chyba siete. Skúste to neskôr.</translation>
 <translation id="1315809131562953678">Zadajte platné telefónne číslo</translation>
-<translation id="1335716056288807013">Klepnutím na tlačidlo Overiť vyjadrujete súhlas so <ph name="START_LINK_1" />zmluvnými podmienkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />pravidlami ochrany súkromia<ph name="END_LINK" />. Môže byť odoslaná SMS a môžu sa účtovať poplatky za správy a dáta.</translation>
+<translation id="1335716056288807013">Klepnutím na tlačidlo Overiť vyjadrujete súhlas so <ph name="START_LINK_1" />zmluvnými podmienkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />pravidlami ochrany súkromia<ph name="END_LINK" />. Môže byť odoslaná SMS a môžu sa účtovať poplatky za správy a dáta.</translation>
 <translation id="137210131544215127">Zadajte svoje heslo</translation>
 <translation id="1393433815796487579">Hotovo</translation>
 <translation id="1412449974349991050">Haiti</translation>
-<translation id="144766329299583285">Ak ste nepožiadali o zmenu prihlasovacieho e-mailu, je možné, že sa niekto pokúša získať prístup do vášho účtu a mali by ste si <ph name="START_LINK" />ihneď zmeniť heslo<ph name="END_LINK" />.</translation>
-<translation id="1449981769524156676">Heardov ostrov a Macdonaldove ostrovy</translation>
+<translation id="144766329299583285">Ak ste nepožiadali o zmenu prihlasovacieho e-mailu, je možné, že sa niekto pokúša získať prístup do vášho účtu a mali by ste si <ph name="START_LINK" />ihneď zmeniť heslo<ph name="END_LINK" />.</translation>
+<translation id="1449981769524156676">Heardov ostrov a Macdonaldove ostrovy</translation>
 <translation id="1451880131543823984"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> nemá autorizáciu na zobrazenie požadovanej stránky.</translation>
-<translation id="1479035434297790822">Z vašej adresy IP prichádza príliš veľa žiadostí o účet. Skúste to znova o pár minút.</translation>
+<translation id="1479035434297790822">Z vašej adresy IP prichádza príliš veľa žiadostí o účet. Skúste to znova o pár minút.</translation>
 <translation id="1483249363694224399">Srí Lanka</translation>
 <translation id="1507995441600689506">Teraz sa môžete prihlásiť pomocou nového účtu</translation>
 <translation id="1544981664986460902">Klient zadal neplatný argument.</translation>
 <translation id="1575848116712334589">Čad</translation>
-<translation id="1630237004390596779">Znova odoslať kód o <ph name="STRING" /></translation>
+<translation id="1630237004390596779">Znova odoslať kód o <ph name="STRING" /></translation>
 <translation id="1653501608290591291">Bielorusko</translation>
-<translation id="1667376103923043653">Daná e-mailová adresa sa nezhoduje s existujúcim účtom.</translation>
-<translation id="173576986138855124">Klepnutím na tlačidlo <ph name="PH_1" /> možno odoslať SMS. Môžu sa účtovať poplatky za správy a dáta.</translation>
+<translation id="1667376103923043653">Daná e-mailová adresa sa nezhoduje s existujúcim účtom.</translation>
+<translation id="173576986138855124">Klepnutím na tlačidlo <ph name="PH_1" /> možno odoslať SMS. Môžu sa účtovať poplatky za správy a dáta.</translation>
 <translation id="1739056958326110545">Svätá Helena</translation>
 <translation id="1743026758446868773">Barbados</translation>
 <translation id="1772888465204630090">Klepnutím na Pokračovať vyjadrujete súhlas so <ph name="START_LINK" />zmluvnými podmienkami<ph name="END_LINK" /></translation>
 <translation id="177937029926612729">Arménsko</translation>
-<translation id="179194004476893686">Bosna a Hercegovina</translation>
+<translation id="179194004476893686">Bosna a Hercegovina</translation>
 <translation id="1799407952500261728">Cookove ostrovy</translation>
 <translation id="1870056762032541323">Nesprávny kód. Skúste to znova.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Dobrý deň, <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Odstrániť účet</translation>
+<translation id="1912929493041975510">Heslo musí obsahovať aspoň šesť znakov</translation>
+<translation id="1933044638365301516">Prihlásiť sa cez <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Zadajte 6-ciferný kód, ktorý sme odoslali na číslo <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Obnovte si heslo podľa pokynov odoslaných na adresu <ph name="PH_1" />.</translation>
 <translation id="2035855087334775326">Maďarsko</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Spojené štáty</translation>
 <translation id="2049229571938383319">Svätý Bartolomej</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Silné heslá majú aspoň 6 znakov a kombinujú písmená a čísla</translation>
 <translation id="2074008538308369451">Zmluvné podmienky</translation>
 <translation id="2089802663554186342">Relácia sa skončila</translation>
 <translation id="2108717231438756650">Spojené kráľovstvo</translation>
@@ -76,9 +75,9 @@
 <translation id="2310948428656960769">Prihlásili ste sa.</translation>
 <translation id="2324942959480650701">Hosť</translation>
 <translation id="2331781584136059536">Ghana</translation>
-<translation id="2338909515537249568">Prehliadač, ktorý používate, nepodporuje webové úložisko. Skúste to znova v inom prehliadači.</translation>
+<translation id="2338909515537249568">Prehliadač, ktorý používate, nepodporuje webové úložisko. Skúste to znova v inom prehliadači.</translation>
 <translation id="2342152898808240937">Klient žiadosť zrušil.</translation>
-<translation id="2356282732642724501"><ph name="START_PARAGRAPH" />Pri zmene prihlasovacieho e-mailu naspäť vznikol problém.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Ak sa vám nepodarí obnoviť e-mail ani pri opätovnom pokuse, skúste požiadať o pomoc svojho správcu.<ph name="END_PARAGRAPH" /></translation>
+<translation id="2356282732642724501"><ph name="START_PARAGRAPH" />Pri zmene prihlasovacieho e-mailu naspäť vznikol problém.<ph name="END_PARAGRAPH" /><ph name="START_PARAGRAPH" />Ak sa vám nepodarí obnoviť e-mail ani pri opätovnom pokuse, skúste požiadať o pomoc svojho správcu.<ph name="END_PARAGRAPH" /></translation>
 <translation id="2375419764963116430">Bahrajn</translation>
 <translation id="2392247362473363900">Interná chyba servera.</translation>
 <translation id="2405828009195143258">Irán</translation>
@@ -88,16 +87,16 @@
 <translation id="2451742558284013472">Monako</translation>
 <translation id="2460064915291012298">Seychely</translation>
 <translation id="2490672522100125425">Telefónne číslo <ph name="START_STRONG" /><ph name="FACTOR_ID" /> <ph name="PHONE_NUMBER" /><ph name="END_STRONG" /> bolo ako prvok druhého kroku overenia odstránené.</translation>
-<translation id="2494962141967044042">Nepodarilo sa inovovať aktuálneho anonymného používateľa. Neanonymné poverenie je už priradené k inému používateľskému účtu.</translation>
-<translation id="2541179214468543429">Zadali ste nesprávne heslo príliš veľakrát. Skúste to znova o pár minút.</translation>
+<translation id="2494962141967044042">Nepodarilo sa inovovať aktuálneho anonymného používateľa. Neanonymné poverenie je už priradené k inému používateľskému účtu.</translation>
+<translation id="2541179214468543429">Zadali ste nesprávne heslo príliš veľakrát. Skúste to znova o pár minút.</translation>
 <translation id="2561560038714758184">Zabezpečenie</translation>
-<translation id="2561835578785502516">Platnosť vašej žiadosti o obnovu hesla vypršala alebo už bol odkaz použitý</translation>
+<translation id="2561835578785502516">Platnosť vašej žiadosti o obnovu hesla vypršala alebo už bol odkaz použitý</translation>
 <translation id="2562498793334241360">Teraz sa môžete prihlásiť pomocou novej e‑mailovej adresy <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="2581514546525533462">Zadaný kód krajiny nie je podporovaný.</translation>
 <translation id="2600950452451016107">Skontrolujte, či ste správne napísali svoju e‑mailovú adresu.</translation>
 <translation id="2610891451939662786">Twitter</translation>
 <translation id="2612036261782356367">Kambodža</translation>
-<translation id="2614081868476050089">Služba nie je k dispozícii.</translation>
+<translation id="2614081868476050089">Služba nie je k dispozícii.</translation>
 <translation id="2616650714309312732">Portugalsko</translation>
 <translation id="2619590123270932385">Francúzska Guyana</translation>
 <translation id="2621854044487969847">Britské Panenské ostrovy</translation>
@@ -114,7 +113,7 @@
 <translation id="2752984808025184019">Južná Afrika</translation>
 <translation id="2760636260031093254">Zadajte svoju e-mailovú adresu, aby ste mohli pokračovať</translation>
 <translation id="276938411216176478">Správca deaktivoval tento používateľský účet.</translation>
-<translation id="2782685789517131804">Prihlasovací e‑mail s dodatočnými pokynmi bol odoslaný na adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Na dokončenie prihlásenia skontrolujte svoj e‑mail.</translation>
+<translation id="2782685789517131804">Prihlasovací e‑mail s dodatočnými pokynmi bol odoslaný na adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Na dokončenie prihlásenia skontrolujte svoj e‑mail.</translation>
 <translation id="2828509010894808185">Vytvorenie účtu</translation>
 <translation id="2834770837848769530">Afganistan</translation>
 <translation id="2884525438023347369">Klepnutím na tlačidlo <ph name="BTN" /> vyjadrujete súhlas so zmluvnými podmienkami <ph name="TOS" />.</translation>
@@ -133,7 +132,7 @@
 <translation id="3147551458884186429">Indonézia</translation>
 <translation id="3154748063569624719">Pôvodne ste sa chceli prihlásiť pomocou e-mailu <ph name="PENDING_EMAIL" /></translation>
 <translation id="3164676761565983157">Venezuela</translation>
-<translation id="3170526549630869494">Máte problémy s prihlásením?</translation>
+<translation id="3170526549630869494">Máte problémy s prihlásením?</translation>
 <translation id="3204914819635733576">Overte, že ste to vy</translation>
 <translation id="3215050409577090361">Vyskytol sa problém pri overovaní vašej žiadosti. Vráťte sa na webovú adresu, ktorá vás presmerovala na túto stránku, aby sa proces overovania začal odznova.</translation>
 <translation id="3216149523061905579">Dominika</translation>
@@ -147,7 +146,7 @@
 <translation id="3372254675985592547">Kuba</translation>
 <translation id="3394519231857398207">Francúzsko</translation>
 <translation id="3398534025670554188">Čína</translation>
-<translation id="3409391354412142307">Už ste použili adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Svoj účet <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> môžete prepojiť s adresou <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> tým, že sa prihlásite pomocou e‑mailového odkazu uvedeného nižšie.</translation>
+<translation id="3409391354412142307">Už ste použili adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />. Svoj účet <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> môžete prepojiť s adresou <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> tým, že sa prihlásite pomocou e‑mailového odkazu uvedeného nižšie.</translation>
 <translation id="3413300222170818119">Zambia</translation>
 <translation id="3429213469114503705">Vatikán</translation>
 <translation id="3434621886769337032">Gambia</translation>
@@ -158,7 +157,7 @@
 <translation id="3521753471343796628">Irak</translation>
 <translation id="354888504916863713">Vietnam</translation>
 <translation id="3550380781997195832">Táto e-mailová adresa nie je správna</translation>
-<translation id="3552446912357282301">V súvislosti s autorizáciou sa obráťte na adresu <ph name="START_STRONG" /><ph name="ADMIN_EMAIL" /><ph name="END_STRONG" />.</translation>
+<translation id="3552446912357282301">V súvislosti s autorizáciou sa obráťte na adresu <ph name="START_STRONG" /><ph name="ADMIN_EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="3561568594856945084">Mayotte</translation>
 <translation id="3591063723610544836">Prihlásenie</translation>
 <translation id="3593480381831738519">Obnovte svoje heslo</translation>
@@ -166,10 +165,10 @@
 <translation id="3605933028246642593">Nepál</translation>
 <translation id="3608140835232496799">Tokelau</translation>
 <translation id="3620185428620643248">Vybraté poverenie poskytovateľa služieb overenia totožnosti nie je podporované.</translation>
-<translation id="3658306886462996856">Pre daný e‑mail nie je k dispozícii žiadny poskytovateľ prihlásenia. Skúste iný e‑mail.</translation>
-<translation id="3695180913983403205">Zadajte meno a priezvisko.</translation>
+<translation id="3658306886462996856">Pre daný e‑mail nie je k dispozícii žiadny poskytovateľ prihlásenia. Skúste iný e‑mail.</translation>
+<translation id="3695180913983403205">Zadajte meno a priezvisko.</translation>
 <translation id="3700097473356216716">Kolumbia</translation>
-<translation id="3703067902498234034">Klepnutím na ULOŽIŤ vyjadrujete súhlas s dokumentom </translation>
+<translation id="3703067902498234034">Klepnutím na ULOŽIŤ vyjadrujete súhlas s dokumentom </translation>
 <translation id="3736041829854387744">Burundi</translation>
 <translation id="3755663127769565780">Mauritánia</translation>
 <translation id="3813801701232240278">Twitter</translation>
@@ -187,21 +186,21 @@
 <translation id="4022450612826261789">Kosovo</translation>
 <translation id="4025579119565425333">Vyskúšajte tieto bežné riešenia:</translation>
 <translation id="4056653682525186486">Prihlásiť sa cez <ph name="XXX" /></translation>
-<translation id="4064888056475403511">Skúste otvoriť odkaz pomocou toho istého zariadenia, v ktorom ste začali proces prihlásenia.</translation>
+<translation id="4064888056475403511">Skúste otvoriť odkaz pomocou toho istého zariadenia, v ktorom ste začali proces prihlásenia.</translation>
 <translation id="4066104405592701692">Estónsko</translation>
 <translation id="4147949012570877154">Odstrániť</translation>
 <translation id="4163133799286985193">Argentína</translation>
-<translation id="4166504762096983411">Pokračovaním vyjadrujete súhlas so <ph name="START_LINK_1" />zmluvnými podmienkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />pravidlami ochrany súkromia<ph name="END_LINK" />.</translation>
+<translation id="4166504762096983411">Pokračovaním vyjadrujete súhlas so <ph name="START_LINK_1" />zmluvnými podmienkami<ph name="END_LINK" /> a <ph name="START_LINK_2" />pravidlami ochrany súkromia<ph name="END_LINK" />.</translation>
 <translation id="420554669252656972">Zadajte novú e-mailovú adresu</translation>
 <translation id="4210333062216604630">Odpojiť</translation>
 <translation id="4242716276491763916">Guinea</translation>
 <translation id="4248546264350694306">Švajčiarsko</translation>
 <translation id="4266056491449352939">Andorra</translation>
-<translation id="4322167048992801895">Máte problémy s dostávaním e‑mailov?</translation>
+<translation id="4322167048992801895">Máte problémy s dostávaním e‑mailov?</translation>
 <translation id="4329551945958214898">Japonsko</translation>
 <translation id="4331763189922924781">Čierna Hora</translation>
 <translation id="4372962701784304822">Mozambik</translation>
-<translation id="4377158577300329881">Táto e-mailová adresa sa nezhoduje s existujúcim účtom</translation>
+<translation id="4377158577300329881">Táto e-mailová adresa sa nezhoduje s existujúcim účtom</translation>
 <translation id="4386334763822785837">Turecko</translation>
 <translation id="4413304190485210039">Tadžikistan</translation>
 <translation id="4432634970196611353">Laos</translation>
@@ -210,11 +209,11 @@
 <translation id="4498504413765490964">Honduras</translation>
 <translation id="450385255996536115">Časový limit operácie uplynul.</translation>
 <translation id="4515732781724470190">Niger</translation>
-<translation id="4521614244485847733">Táto e-mailová adresa sa nezhoduje s existujúcim účtom</translation>
+<translation id="4521614244485847733">Táto e-mailová adresa sa nezhoduje s existujúcim účtom</translation>
 <translation id="4556476996891737119">Jordánsko</translation>
 <translation id="4571870355114729513">Obnovte svoje heslo podľa pokynov odoslaných na adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /></translation>
 <translation id="4588392627302012849">Prihlásiť sa e-mailom</translation>
-<translation id="4595119411041064617">Klepnutím na tlačidlo <ph name="PH_1" /> možno odoslať SMS. Môžu sa účtovať poplatky za správy a dáta.</translation>
+<translation id="4595119411041064617">Klepnutím na tlačidlo <ph name="PH_1" /> možno odoslať SMS. Môžu sa účtovať poplatky za správy a dáta.</translation>
 <translation id="4632709875751031323">Rusko</translation>
 <translation id="4644169548516814280">Túto e-mailovú adresu už používa iný účet</translation>
 <translation id="4692014002063276828">Poľsko</translation>
@@ -226,11 +225,11 @@
 <translation id="4775051289386800916">Nikaragua</translation>
 <translation id="4783400389150493171">Burkina Faso</translation>
 <translation id="4852256440857413490">Nesprávny kód. Skúste to znova.</translation>
-<translation id="4866990546854875813">Relácia spojená s touto žiadosťou o prihlásenie bola vymazaná alebo jej platnosť vypršala.</translation>
-<translation id="4871106926303956169">Turks a Caicos</translation>
-<translation id="4877597386645466815">Znova odoslať kód o <ph name="TIME_REMAINING" /></translation>
+<translation id="4866990546854875813">Relácia spojená s touto žiadosťou o prihlásenie bola vymazaná alebo jej platnosť vypršala.</translation>
+<translation id="4871106926303956169">Turks a Caicos</translation>
+<translation id="4877597386645466815">Znova odoslať kód o <ph name="TIME_REMAINING" /></translation>
 <translation id="4900116391137165411">
-<ph name="P_START" />Váš účet v aplikácii <ph name="APP_NAME" /> bol aktualizovaný. Pribudlo v ňom telefónne číslo <ph name="SECOND_FACTOR" /> na účely dvojstupňového overenia.<ph name="P_END" />
+<ph name="P_START" />Váš účet v aplikácii <ph name="APP_NAME" /> bol aktualizovaný. Pribudlo v ňom telefónne číslo <ph name="SECOND_FACTOR" /> na účely dvojstupňového overenia.<ph name="P_END" />
 <ph name="P_START" />Ak ste toto telefónne číslo na účely dvojstupňového overenia nepridali vy, odstráňte ho kliknutím na odkaz nižšie.<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="4923375331439013137">Druhý prvok sa nepodarilo odstrániť</translation>
@@ -240,15 +239,15 @@
 <translation id="4991626049082973728">Srbsko</translation>
 <translation id="4991892293325936102">Belize</translation>
 <translation id="5042136001778337830"><ph name="START_PARAGRAPH" />pre účet <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /><ph name="END_PARAGRAPH" /></translation>
-<translation id="5059105734231232362">Aby tento proces mohol úspešne prepojiť váš účet <ph name="IDP_DISPLAY_NAME" /> s týmto e‑mailom, musíte odkaz otvoriť v tom istom zariadení alebo prehliadači.</translation>
+<translation id="5059105734231232362">Aby tento proces mohol úspešne prepojiť váš účet <ph name="IDP_DISPLAY_NAME" /> s týmto e‑mailom, musíte odkaz otvoriť v tom istom zariadení alebo prehliadači.</translation>
 <translation id="5080084639513001393">Švédsko</translation>
 <translation id="5080899604429810481">Svätý Martin (fr.)</translation>
-<translation id="5115661695221894994"><ph name="START_PARAGRAPH" />Platnosť vašej žiadosti o overenie a aktualizáciu e‑mailovej adresy vypršala alebo bol odkaz už použitý.<ph name="END_PARAGRAPH" /></translation>
+<translation id="5115661695221894994"><ph name="START_PARAGRAPH" />Platnosť vašej žiadosti o overenie a aktualizáciu e‑mailovej adresy vypršala alebo bol odkaz už použitý.<ph name="END_PARAGRAPH" /></translation>
 <translation id="5143657419516597442">Svätá Lucia</translation>
 <translation id="521218078240459724">@string/app_name</translation>
 <translation id="5241732101105320538">Skontrolujte si e-mail</translation>
 <translation id="5255830932650472373">Nové heslo</translation>
-<translation id="5301108536112812420">Platnosť vašej žiadosti o overenie e-mailu vypršala alebo už bol odkaz použitý</translation>
+<translation id="5301108536112812420">Platnosť vašej žiadosti o overenie e-mailu vypršala alebo už bol odkaz použitý</translation>
 <translation id="5323041129469627535">Omán</translation>
 <translation id="5326139833547026317">Karibské Holandsko</translation>
 <translation id="5347459868860672391">Aktualizovaná e-mailová adresa</translation>
@@ -265,7 +264,7 @@
 <translation id="5524360735013196510">Holandsko</translation>
 <translation id="5528189843379142883">Rovníková Guinea</translation>
 <translation id="5529036554155743092">Austrália</translation>
-<translation id="5537884323453943551">Trinidad a Tobago</translation>
+<translation id="5537884323453943551">Trinidad a Tobago</translation>
 <translation id="5543493820882105191">Zadajte svoje meno</translation>
 <translation id="55439745111619380">Ascension</translation>
 <translation id="5569341882117077010">Vyskytla sa sieťová chyba</translation>
@@ -279,7 +278,7 @@
 <translation id="5636713964613741614">Maurícius</translation>
 <translation id="5642254620426025006">Vyskytol sa problém. Skúste to znova.</translation>
 <translation id="5649486931917149784">Heslo</translation>
-<translation id="5664080586064341046">Svätý Krištof a Nevis</translation>
+<translation id="5664080586064341046">Svätý Krištof a Nevis</translation>
 <translation id="5668881954117611594">Späť</translation>
 <translation id="5699028034244995851">Zadajte svoju e-mailovú adresu, aby ste mohli pokračovať</translation>
 <translation id="5701178667798108817">Overenie telefónneho čísla</translation>
@@ -290,7 +289,7 @@
 <translation id="5829301468800336085">Prihlasovanie…</translation>
 <translation id="5840765100196379855">Panama</translation>
 <translation id="5840803301882074743">Tonga</translation>
-<translation id="5850752921356750845">Wallis a Futuna</translation>
+<translation id="5850752921356750845">Wallis a Futuna</translation>
 <translation id="5853516492584814656">Nepodarilo sa aktualizovať vašu e-mailovú adresu</translation>
 <translation id="5905720181746284549">Na prihlásenie ste už použili e-mailovú adresu <ph name="STRING" />. Zadajte heslo pre daný účet.</translation>
 <translation id="5921101578434778028">Anguila</translation>
@@ -307,16 +306,17 @@
 <translation id="61182948399263957">
 <ph name="P_START" />Prihláste sa do aplikácie <ph name="APP_NAME" /> &lt;/p&gt;&lt;/p&gt;
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
-<translation id="6132202686885223981">Skontrolujte, či máte dostatok miesta v doručenej pošte alebo iné problémy súvisiace s nastaveniami doručenej pošty.</translation>
+<translation id="6132202686885223981">Skontrolujte, či máte dostatok miesta v doručenej pošte alebo iné problémy súvisiace s nastaveniami doručenej pošty.</translation>
 <translation id="6135589730599211649">Klient zadal neplatný rozsah.</translation>
 <translation id="6143147250106939258">Bola prekročená kvóta tejto operácie. Skúste to neskôr.</translation>
 <translation id="6189573836664806798">Paraguaj</translation>
 <translation id="6192657410634245771">Alžírsko</translation>
-<translation id="6213969168046789596">Príliš veľakrát ste zadali nesprávne heslo. Skúste to znova o pár minút.</translation>
+<translation id="6213969168046789596">Príliš veľakrát ste zadali nesprávne heslo. Skúste to znova o pár minút.</translation>
 <translation id="6216759405419177713">Norfolk</translation>
-<translation id="6245066275978703471">Telefónne číslo bolo automaticky overené</translation>
-<translation id="6269083314054226194">Chyba siete. Skontrolujte internetové pripojenie.</translation>
-<translation id="6295157125625453859">Overené.</translation>
+<translation id="6238170540438416559">Klepnutím na tlačidlo <ph name="PH_1" /> vyjadrujete súhlas s dokumentom <ph name="PP" />. Môže byť odoslaná SMS a môžu sa účtovať poplatky za správy a dáta.</translation>
+<translation id="6265373887273416711">Overiť telefónne číslo</translation>
+<translation id="6283536862756552051">Ak chcete zmeniť heslo, musíte najskôr zadať aktuálne heslo.</translation>
+<translation id="6299890279889400823">Späť</translation>
 <translation id="6316446940976157217">India</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Pokračovať</translation>
@@ -329,7 +329,7 @@
 <translation id="6470057025778734988">Už sa nebudete môcť prihlásiť svojím účtom</translation>
 <translation id="6472297146424049005">Skontrolujte internetové pripojenie.</translation>
 <translation id="6483116480230343278">Prebieha registrácia...</translation>
-<translation id="6494734506607758748">Ak chcete zmeniť e-mailovú adresu prepojenú s vaším účtom, budete sa musieť znova prihlásiť.</translation>
+<translation id="6494734506607758748">Ak chcete zmeniť e-mailovú adresu prepojenú s vaším účtom, budete sa musieť znova prihlásiť.</translation>
 <translation id="6508909904815637928">Vanuatu</translation>
 <translation id="6520863029476703422">Americká Samoa</translation>
 <translation id="6527597037551425211">Brazília</translation>
@@ -353,9 +353,9 @@
 <translation id="6740430702644152657">Albánsko</translation>
 <translation id="6765051113469046531">Vaša prihlasovacia e-mailová adresa bola zmenená späť na <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />.</translation>
 <translation id="6769550797775698634">Kamerun</translation>
-<translation id="6775190982418995854">Svalbard a Jan Mayen</translation>
+<translation id="6775190982418995854">Svalbard a Jan Mayen</translation>
 <translation id="6775835872637240659">Ukrajina</translation>
-<translation id="6779584651193963121">Ak sa uvedenými krokmi problém nevyriešil, e‑mail môžete znovu odoslať. Upozorňujeme, že opätovné odoslanie deaktivuje odkaz v staršom e‑maile.</translation>
+<translation id="6779584651193963121">Ak sa uvedenými krokmi problém nevyriešil, e‑mail môžete znovu odoslať. Upozorňujeme, že opätovné odoslanie deaktivuje odkaz v staršom e‑maile.</translation>
 <translation id="6782010235320729294">Turkménsko</translation>
 <translation id="6821607741326790458">Jamajka</translation>
 <translation id="6834335872619414720">GitHub</translation>
@@ -366,13 +366,13 @@
 <translation id="6921505896641453739">E-mail</translation>
 <translation id="6929813273561975780">Ďalej</translation>
 <translation id="6951302238647056860">Tento kód už nie je platný</translation>
-<translation id="6961220857430789248">Prihlasovací e‑mail s ďalšími pokynmi bol odoslaný na adresu <ph name="STRING" />. Pozrite si poštu a dokončite prihlásenie.</translation>
+<translation id="6961220857430789248">Prihlasovací e‑mail s ďalšími pokynmi bol odoslaný na adresu <ph name="STRING" />. Pozrite si poštu a dokončite prihlásenie.</translation>
 <translation id="6984204927251307445">Potvrdenie e-mailovej adresy</translation>
 <translation id="6996552808101270965">Ďalšie informácie</translation>
-<translation id="6999773882165218263">Krstné meno a priezvisko</translation>
+<translation id="6999773882165218263">Krstné meno a priezvisko</translation>
 <translation id="7012506961150923116">Grenada</translation>
 <translation id="7024571478138322659">Západná Sahara</translation>
-<translation id="7025117765722694556">Kým je systém v aktuálnom stave, žiadosť nemožno vykonať.</translation>
+<translation id="7025117765722694556">Kým je systém v aktuálnom stave, žiadosť nemožno vykonať.</translation>
 <translation id="7062299334696934251">Vyskytla sa neznáma chyba.</translation>
 <translation id="7064251114893721966">Adresu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> ste už použili na prihlásenie. Zadajte heslo pre daný účet.</translation>
 <translation id="7085136866191400000">Prihlasovací e‑mail bol odoslaný</translation>
@@ -385,14 +385,14 @@
 <translation id="7192078949090526171">San Maríno</translation>
 <translation id="7197455001919474950">Cyprus</translation>
 <translation id="7198563013006562060">Šalamúnove ostrovy</translation>
-<translation id="7207660930894629055">Chcete pokračovať s e-mailom <ph name="USER_EMAIL" />?</translation>
-<translation id="720983450833499456">Ak chcete pokračovať v prihlásení do účtu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> v tomto zariadení, musíte si obnoviť heslo.</translation>
+<translation id="7207660930894629055">Chcete pokračovať s e-mailom <ph name="USER_EMAIL" />?</translation>
+<translation id="720983450833499456">Ak chcete pokračovať v prihlásení do účtu <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> v tomto zariadení, musíte si obnoviť heslo.</translation>
 <translation id="7223410082658239002">Maldivy</translation>
-<translation id="7254028881697834212">Svätý Tomáš a Princov ostrov</translation>
+<translation id="7254028881697834212">Svätý Tomáš a Princov ostrov</translation>
 <translation id="7268827299582726485">Potvrdením svojej e‑mailovej adresy dokončite prihlásenie</translation>
 <translation id="7272145663101316762">Slovinsko</translation>
 <translation id="7280309713358692490">Južná Kórea</translation>
-<translation id="7283725113395426048">Konflikt súbežnosti operácií, napríklad čítania, úpravy a zápisu.</translation>
+<translation id="7283725113395426048">Konflikt súbežnosti operácií, napríklad čítania, úpravy a zápisu.</translation>
 <translation id="7290147808482957603">Na serveri nie je implementovaná táto metóda rozhrania API.</translation>
 <translation id="7291567990403335374">Lesotho</translation>
 <translation id="7291656724505689727">Prihlásiť sa telefónom</translation>
@@ -405,17 +405,17 @@
 <translation id="7493245640904888019">Gibraltár</translation>
 <translation id="7510939244824757986">Tanzánia</translation>
 <translation id="7526532581122816497">Prepojený účet</translation>
-<translation id="7560587702704358921">Saint Pierre a Miquelon</translation>
+<translation id="7560587702704358921">Saint Pierre a Miquelon</translation>
 <translation id="7569285452790032317">Somálsko</translation>
 <translation id="7592224526951017144">Nemecko</translation>
-<translation id="7595933825828475368">Máte problémy s dostávaním e‑mailov?</translation>
+<translation id="7595933825828475368">Máte problémy s dostávaním e‑mailov?</translation>
 <translation id="7615083347713899917">Kirgizsko</translation>
 <translation id="7643408533407091568">Na prihlásenie ste už použili adresu <ph name="EMAIL_ADDR" />.
         Zadajte svoje heslo pre daný účet.</translation>
-<translation id="7652546345268886994">{plural_var,plural, =1{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znak a kombináciu písmen a čísel}few{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znaky a kombináciu písmen a čísel}many{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znaku a kombináciu písmen a čísel}other{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znakov a kombináciu písmen a čísel}}</translation>
+<translation id="7652546345268886994">{plural_var,plural, =1{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znak a kombináciu písmen a čísel}few{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znaky a kombináciu písmen a čísel}many{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znaku a kombináciu písmen a čísel}other{Heslo nie je dostatočne silné. Použite aspoň <ph name="PH_1" /> znakov a kombináciu písmen a čísel}}</translation>
 <translation id="7699755204074920022">Zimbabwe</translation>
 <translation id="7746977132739352062">Žiadosť nebola overená, pretože token OAuth chýba, je neplatný alebo jeho platnosť vypršala.</translation>
-<translation id="7782885946428624225">Vyskytol sa problém s overením vášho telefónneho čísla</translation>
+<translation id="7782885946428624225">Vyskytol sa problém s overením vášho telefónneho čísla</translation>
 <translation id="7796914496604415892">Bolo rozpoznané nové zariadenie alebo prehliadač</translation>
 <translation id="786166109137986817">Prihlásiť sa do aplikácie <ph name="DISPLAY_NAME" /></translation>
 <translation id="7868540442111212282">Česko</translation>
@@ -424,8 +424,8 @@
 <translation id="792838323404934335">Grónsko</translation>
 <translation id="7956645158976161232">Líbya</translation>
 <translation id="8017277252219866084">Keňa</translation>
-<translation id="8028653067082554952">Týmto sa vymažú všetky dáta súvisiace s vaším účtom a túto akciu nie je možné vrátiť späť. Naozaj chcete odstrániť svoj účet?</translation>
-<translation id="8033786138248870436">Klepnutím na Overiť možno odoslať SMS. Môžu sa účtovať poplatky za dáta a správy.</translation>
+<translation id="8028653067082554952">Týmto sa vymažú všetky dáta súvisiace s vaším účtom a túto akciu nie je možné vrátiť späť. Naozaj chcete odstrániť svoj účet?</translation>
+<translation id="8033786138248870436">Klepnutím na Overiť možno odoslať SMS. Môžu sa účtovať poplatky za dáta a správy.</translation>
 <translation id="8047183472745080590">Bolívia</translation>
 <translation id="8047565947836609247">Portoriko</translation>
 <translation id="8055755007915250245">Chcete odpojiť účet?</translation>
@@ -447,7 +447,7 @@
 <translation id="8356629306226578917">Egypt</translation>
 <translation id="8361109291694366329">Marshallove ostrovy</translation>
 <translation id="8371947480506692029">Svätý Martin (hol.)</translation>
-<translation id="8395242001819210481">Antigua a Barbuda</translation>
+<translation id="8395242001819210481">Antigua a Barbuda</translation>
 <translation id="8399150401520737446">Severné Mariány</translation>
 <translation id="8414177484126578295">Falklandy</translation>
 <translation id="8420860857100049136">Peru</translation>
@@ -463,7 +463,7 @@
 <translation id="8534746304953308378">Togo</translation>
 <translation id="8572093925387077451">Už máte účet</translation>
 <translation id="8585285847459057945">Váš prihlasovací e-mail pre aplikáciu <ph name="APP_NAME" /> sa zmenil</translation>
-<translation id="8585655327529919573">Nechajte si na tento e-mail poslať pokyny s vysvetlením, ako obnoviť svoje heslo.</translation>
+<translation id="8585655327529919573">Nechajte si na tento e-mail poslať pokyny s vysvetlením, ako obnoviť svoje heslo.</translation>
 <translation id="8652838224332661203">Nauru</translation>
 <translation id="8657280305228520442">Brunej</translation>
 <translation id="8657544769531875987">Čile</translation>
@@ -483,26 +483,26 @@
 <translation id="8869797682387766327">Ostrov Man</translation>
 <translation id="8893950153780006385">Malajzia</translation>
 <translation id="8895840173743975193">Kokosové ostrovy</translation>
-<translation id="8916080112145514151">Ak stále chcete prepojiť svoj účet v službe <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, otvorte odkaz v tom istom zariadení, v ktorom ste sa začali prihlasovať. V opačnom prípade klepnite na tlačidlo Pokračovať a prihláste sa v tomto zariadení.</translation>
+<translation id="8916080112145514151">Ak stále chcete prepojiť svoj účet v službe <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />, otvorte odkaz v tom istom zariadení, v ktorom ste sa začali prihlasovať. V opačnom prípade klepnite na tlačidlo Pokračovať a prihláste sa v tomto zariadení.</translation>
 <translation id="8920674952994839257">Skúsiť znova</translation>
-<translation id="8939353296336237380">Pôvodne ste chceli prepojiť svoj účet v službe <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> so svojím e‑mailovým účtom, ale odkaz ste otvorili v inom zariadení, v ktorom nie ste prihlásený/-á.</translation>
-<translation id="8971555482255213064">Kód sa znova odošle o 0:<ph name="PH_1" /></translation>
+<translation id="8939353296336237380">Pôvodne ste chceli prepojiť svoj účet v službe <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> so svojím e‑mailovým účtom, ale odkaz ste otvorili v inom zariadení, v ktorom nie ste prihlásený/-á.</translation>
+<translation id="8971555482255213064">Kód sa znova odošle o 0:<ph name="PH_1" /></translation>
 <translation id="8984161590699631096">Maroko</translation>
-<translation id="8994098794339484800">Ak toto zariadenie nepoznáte, je možné, že sa niekto snaží získať prístup k vášmu účtu. Mali by ste si <ph name="START_LINK" />ihneď zmeniť heslo<ph name="END_LINK" />.</translation>
+<translation id="8994098794339484800">Ak toto zariadenie nepoznáte, je možné, že sa niekto snaží získať prístup k vášmu účtu. Mali by ste si <ph name="START_LINK" />ihneď zmeniť heslo<ph name="END_LINK" />.</translation>
 <translation id="900153878296575829">Bangladéš</translation>
 <translation id="9022632332691561239">Telefón</translation>
 <translation id="9028063588419847334">Fínsko</translation>
 <translation id="9078135685219203661">Spojené arabské emiráty</translation>
-<translation id="9121203582272050974">E‑mailová adresa bola overená a zmenená</translation>
+<translation id="9121203582272050974">E‑mailová adresa bola overená a zmenená</translation>
 <translation id="9156150178611681179">Heslo</translation>
 <translation id="9168877696443530714">Stredoafrická republika</translation>
 <translation id="9186194643192393179">Curaçao</translation>
-<translation id="9193130710600355008">Pre nezvyčajnú aktivitu sme zablokovali všetky žiadosti z tohto zariadenia. Skúste to neskôr.</translation>
+<translation id="9193130710600355008">Pre nezvyčajnú aktivitu sme zablokovali všetky žiadosti z tohto zariadenia. Skúste to neskôr.</translation>
 <translation id="919456844206936371">Tunisko</translation>
 <translation id="9209678713072395487">Heslo bolo zmenené</translation>
 <translation id="954276184636809129">Grécko</translation>
 <translation id="959388308828818789">Druhý prvok bol odstránený</translation>
 <translation id="965930633376049617">Angola</translation>
 <translation id="988087302893519488">Kuvajt</translation>
-<translation id="994914101700264849">Zadaný e-mail a heslo sa nezhodujú.</translation>
+<translation id="994914101700264849">Zadaný e-mail a heslo sa nezhodujú.</translation>
 </translationbundle>

--- a/translations/sl.xtb
+++ b/translations/sl.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Cookovi otoki</translation>
 <translation id="1870056762032541323">Napačna koda. Poskusite znova.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Pozdravljeni, <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Brisanje računa</translation>
+<translation id="1912929493041975510">Geslo mora vsebovati najmanj 6 znakov.</translation>
+<translation id="1933044638365301516">Prijava z računom za <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Vnesite 6-mestno kodo, ki smo jo poslali na številko <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Če želite obnoviti geslo, upoštevajte navodila, poslana na naslov <ph name="PH_1" />.</translation>
 <translation id="2035855087334775326">Madžarska</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Združene države</translation>
 <translation id="2049229571938383319">Saint Barthelemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Zapletena gesla imajo vsaj 6 znakov in so sestavljena iz kombinacije črk ter številk</translation>
 <translation id="2074008538308369451">Pogoji storitve</translation>
 <translation id="2089802663554186342">Seja se je končala</translation>
 <translation id="2108717231438756650">Združeno kraljestvo</translation>
@@ -311,9 +310,10 @@
 <translation id="6192657410634245771">Alžirija</translation>
 <translation id="6213969168046789596">Prevečkrat ste vnesli nepravilno geslo. Poskusite znova čez nekaj minut.</translation>
 <translation id="6216759405419177713">Norfolški otok</translation>
-<translation id="6245066275978703471">Telefonska številka je bila samodejno preverjena</translation>
-<translation id="6269083314054226194">Napaka v omrežju. Preverite internetno povezavo.</translation>
-<translation id="6295157125625453859">Preverjeno.</translation>
+<translation id="6238170540438416559">Če se dotaknete možnosti »<ph name="PH_1" />«, potrjujete, da se strinjate z dokumentom <ph name="PP" />. Morda bo poslano sporočilo SMS. Pošiljanje sporočila in prenos podatkov boste morda morali plačati.</translation>
+<translation id="6265373887273416711">Preverjanje telefonske številke</translation>
+<translation id="6283536862756552051">Če želite spremeniti geslo, morate najprej vnesti trenutno geslo.</translation>
+<translation id="6299890279889400823">Nazaj</translation>
 <translation id="6316446940976157217">Indija</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Naprej</translation>

--- a/translations/sr.xtb
+++ b/translations/sr.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Кукова Острва</translation>
 <translation id="1870056762032541323">Кôд није тачан. Пробајте поново.</translation>
 <translation id="1898579907513173256">Макао</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Здраво <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Избриши налог</translation>
+<translation id="1912929493041975510">Лозинка мора да има најмање 6 знакова</translation>
+<translation id="1933044638365301516">Пријавите се помоћу <ph name="STRING" />-а</translation>
 <translation id="1987722456379605552">Унесите 6-цифрени кôд који смо послали на <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Пратите упутства која су вам послана на <ph name="PH_1" /> да бисте повратили лозинку.</translation>
 <translation id="2035855087334775326">Мађарска</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Сједињене Америчке Државе</translation>
 <translation id="2049229571938383319">Свети Бартоломеј</translation>
 <translation id="2058731785647385204">Монсерат</translation>
-<translation id="2070709910567585968">Јаке лозинке имају бар 6 знакова, уз комбинацију слова и бројева</translation>
 <translation id="2074008538308369451">Услови коришћења услуге</translation>
 <translation id="2089802663554186342">Сесија је завршена</translation>
 <translation id="2108717231438756650">Уједињено Краљевство</translation>
@@ -277,7 +276,7 @@
 <translation id="5611074838440670731">Овај број телефона је употребљен превише пута</translation>
 <translation id="5630396263271753991">Еритреја</translation>
 <translation id="5636713964613741614">Маурицијус</translation>
-<translation id="5642254620426025006">Нешто није у реду. Пробајте поново.</translation>
+<translation id="5642254620426025006">Дошло је до грешке. Пробајте поново.</translation>
 <translation id="5649486931917149784">Лозинка</translation>
 <translation id="5664080586064341046">Сент Китс</translation>
 <translation id="5668881954117611594">Назад</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Алжир</translation>
 <translation id="6213969168046789596">Превише пута сте унели нетачну лозинку. Пробајте поново за пар минута.</translation>
 <translation id="6216759405419177713">Острво Норфолк</translation>
-<translation id="6245066275978703471">Број телефона је аутоматски верификован</translation>
-<translation id="6269083314054226194">Дошло је до мрежне грешке, проверите интернет везу.</translation>
-<translation id="6295157125625453859">Потврђено је!</translation>
+<translation id="6238170540438416559">Ако додирнете „<ph name="PH_1" />“, потврђујете да прихватате документ <ph name="PP" />. Можда ћете послати SMS. Могу да вам буду наплаћени трошкови слања поруке и преноса података.</translation>
+<translation id="6265373887273416711">Верификујте број телефона</translation>
+<translation id="6283536862756552051">Да бисте променили лозинку, треба да унесете тренутну лозинку.</translation>
+<translation id="6299890279889400823">Назад</translation>
 <translation id="6316446940976157217">Индија</translation>
 <translation id="6327723482938582895">Бенин</translation>
 <translation id="6338643731889005578">Настави</translation>

--- a/translations/sv.xtb
+++ b/translations/sv.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Cooköarna</translation>
 <translation id="1870056762032541323">Fel kod. Försök igen.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Hej <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Radera konto</translation>
+<translation id="1912929493041975510">Lösenordet måste vara minst sex tecken långt</translation>
+<translation id="1933044638365301516">Logga in med <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Ange den sexsiffriga koden vi skickade till <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Följ anvisningarna som har skickats till <ph name="PH_1" /> för att återställa ditt lösenord.</translation>
 <translation id="2035855087334775326">Ungern</translation>
@@ -54,10 +54,9 @@
 <translation id="2046207054419739276">USA</translation>
 <translation id="2049229571938383319">Saint-Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Starka lösenord består av minst 6 tecken och en blandning av bokstäver och siffror</translation>
 <translation id="2074008538308369451">Användarvillkor</translation>
 <translation id="2089802663554186342">Sessionen är avslutad</translation>
-<translation id="2108717231438756650">Storbritannien</translation>
+<translation id="2108717231438756650">Förenade kungariket</translation>
 <translation id="2120419640334291526">Caymanöarna</translation>
 <translation id="2124070231227334770">Moldavien</translation>
 <translation id="2124843735553988177">Godkänn de behörigheter som krävs för att logga in via leverantören</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Algeriet</translation>
 <translation id="6213969168046789596">Du har angett fel lösenord för många gånger. Försök igen om några minuter.</translation>
 <translation id="6216759405419177713">Norfolkön</translation>
-<translation id="6245066275978703471">Telefonnumret verifierades automatiskt</translation>
-<translation id="6269083314054226194">Nätverksfel, kontrollera din internetanslutning.</translation>
-<translation id="6295157125625453859">Verifierat!</translation>
+<translation id="6238170540438416559">Genom att trycka på <ph name="PH_1" /> godkänner du vår <ph name="PP" />. Ett sms kan skickas. Meddelande- och dataavgifter kan tillkomma.</translation>
+<translation id="6265373887273416711">Verifiera ditt telefonnummer</translation>
+<translation id="6283536862756552051">Du måste först ange ditt aktuella lösenord för att kunna ändra lösenordet.</translation>
+<translation id="6299890279889400823">Föregående</translation>
 <translation id="6316446940976157217">Indien</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Fortsätt</translation>
@@ -457,7 +457,7 @@
 <translation id="847294590390666986">Taiwan</translation>
 <translation id="8477554788963470892">Sierra Leone</translation>
 <translation id="8498398269542501379">Kontrollera om meddelandet hamnade bland skräpposten eller filtrerades.</translation>
-<translation id="8505200776212389923">Verifierar …</translation>
+<translation id="8505200776212389923">Verifierar …</translation>
 <translation id="8505941919386646914">Martinique</translation>
 <translation id="8534746304953308378">Togo</translation>
 <translation id="8572093925387077451">Du har redan ett konto</translation>

--- a/translations/th.xtb
+++ b/translations/th.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">มีคำขอสร้างบัญชีจากที่อยู่ IP ของคุณมากเกินไป โปรดรอสักครู่แล้วลองอีกครั้ง</translation>
 <translation id="1483249363694224399">ศรีลังกา</translation>
 <translation id="1507995441600689506">ตอนนี้คุณสามารถลงชื่อเข้าใช้ด้วยบัญชีใหม่ได้แล้ว</translation>
+<translation id="1535200361681091160">ป้อนอีเมลของคุณ</translation>
 <translation id="1544981664986460902">ไคลเอ็นต์ระบุอาร์กิวเมนต์ไม่ถูกต้อง</translation>
 <translation id="1575848116712334589">ชาด</translation>
 <translation id="1630237004390596779">ส่งรหัสอีกครั้งใน <ph name="STRING" /></translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">หมู่เกาะคุก</translation>
 <translation id="1870056762032541323">รหัสไม่ถูกต้อง โปรดลองอีกครั้ง</translation>
 <translation id="1898579907513173256">มาเก๊า</translation>
-<translation id="1929332760123475919"><ph name="P_START" />สวัสดีคุณ <ph name="DISPLAY_NAME" /><ph name="P_END" /></translation>
-<translation id="1966996824429980990">ลบบัญชี</translation>
+<translation id="1912929493041975510">รหัสผ่านต้องมีความยาวอย่างน้อย 6 อักขระ</translation>
+<translation id="1933044638365301516">ลงชื่อเข้าใช้ด้วย <ph name="STRING" /></translation>
 <translation id="1987722456379605552">ป้อนรหัส 6 หลักที่เราส่งไปยัง <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
-<translation id="2016421613709283485">ทำตามวิธีการที่ส่งไปยัง <ph name="PH_1" /> เพื่อกู้คืนรหัสผ่านของคุณ</translation>
+<translation id="1999379687946415948">รหัสสำหรับ <ph name="APP_NAME" /> คือ <ph name="IDV_CODE_PLACE_HOLDER" /></translation>
+<translation id="2033662766890821456">ส่งรหัสอีกครั้ง</translation>
 <translation id="2035855087334775326">ฮังการี</translation>
 <translation id="2040904406955887821">ซูรินาเม</translation>
 <translation id="2046207054419739276">สหรัฐอเมริกา</translation>
 <translation id="2049229571938383319">แซ็งบาร์เตเลมี</translation>
 <translation id="2058731785647385204">มอนต์เซอร์รัต</translation>
-<translation id="2070709910567585968">รหัสผ่านที่รัดกุมต้องมีความยาวอย่างน้อย 6 อักขระและประกอบด้วยตัวอักษรปนกับตัวเลข</translation>
 <translation id="2074008538308369451">ข้อกำหนดในการให้บริการ</translation>
 <translation id="2089802663554186342">สิ้นสุดเซสชันแล้ว</translation>
 <translation id="2108717231438756650">สหราชอาณาจักร</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">เคปเวิร์ด</translation>
 <translation id="2301396996587599046">มาซิโดเนีย</translation>
 <translation id="2310948428656960769">ลงชื่อเข้าใช้แล้ว</translation>
+<translation id="2321152797538991921">รหัสผ่านต้องมีอักขระที่ไม่ใช่ตัวอักษรและตัวเลขคละกัน</translation>
 <translation id="2324942959480650701">ผู้เข้าร่วม</translation>
 <translation id="2331781584136059536">กานา</translation>
 <translation id="2338909515537249568">เบราว์เซอร์ที่คุณใช้อยู่ไม่รองรับพื้นที่เก็บข้อมูลเว็บ โปรดใช้เบราว์เซอร์อื่นแล้วลองอีกครั้ง</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">ระบบพบปัญหาขณะตรวจสอบคำขอของคุณ โปรดไปที่ URL ที่เปลี่ยนเส้นทางคุณมาที่หน้านี้เพื่อเริ่มกระบวนการตรวจสอบสิทธิ์ใหม่อีกครั้ง</translation>
 <translation id="3216149523061905579">โดมินิกัน</translation>
 <translation id="3223688630903046698">รหัสผ่านใหม่</translation>
+<translation id="3245143966477136343">รหัสผ่านต้องมีอักขระตัวพิมพ์เล็ก</translation>
 <translation id="3250864391349648273">กาบอง</translation>
 <translation id="3259479674319858599">คุณใช้ <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> อยู่แล้ว ลงชื่อเข้าใช้ด้วย <ph name="IDP_DISPLAY_NAME" /> เพื่อดำเนินการต่อ</translation>
 <translation id="3275852444431525182">นิวซีแลนด์</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">ทำตามวิธีการที่ส่งไปยัง <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> เพื่อกู้คืนรหัสผ่านของคุณ</translation>
 <translation id="4588392627302012849">ลงชื่อเข้าใช้ด้วยอีเมล</translation>
 <translation id="4595119411041064617">เมื่อคุณแตะ “<ph name="PH_1" />” ระบบจะส่ง SMS ให้คุณ อาจมีค่าบริการรับส่งข้อความและค่าบริการอินเทอร์เน็ต</translation>
+<translation id="4603232692404395592">รหัสผ่านต้องมีอักขระไม่เกิน <ph name="MAX_PASSWORD_LENGTH" /> ตัว</translation>
 <translation id="4632709875751031323">รัสเซีย</translation>
 <translation id="4644169548516814280">มีบัญชีอื่นใช้ที่อยู่อีเมลนี้อยู่แล้ว</translation>
 <translation id="4692014002063276828">โปแลนด์</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">ตรวจสอบว่ายังมีพื้นที่เหลือในกล่องจดหมายหรือไม่มีปัญหาอื่นๆ ที่เกี่ยวกับการตั้งค่ากล่องจดหมาย</translation>
 <translation id="6135589730599211649">ไคลเอ็นต์ระบุช่วงไม่ถูกต้อง</translation>
 <translation id="6143147250106939258">โควต้าสำหรับการดำเนินการนี้เกินขีดจำกัดแล้ว ลองอีกครั้งในภายหลัง</translation>
+<translation id="615787395595800956">ไม่เป็นไปตามข้อกำหนดของรหัสผ่าน:</translation>
 <translation id="6189573836664806798">ปารากวัย</translation>
 <translation id="6192657410634245771">แอลจีเรีย</translation>
 <translation id="6213969168046789596">คุณป้อนรหัสผ่านไม่ถูกต้องหลายครั้งเกินไป โปรดรอสักครู่แล้วลองอีกครั้ง</translation>
 <translation id="6216759405419177713">เกาะนอร์ฟอล์ก</translation>
-<translation id="6245066275978703471">ยืนยันหมายเลขโทรศัพท์โดยอัตโนมัติแล้ว</translation>
-<translation id="6269083314054226194">เกิดข้อผิดพลาดของเครือข่าย โปรดตรวจสอบการเชื่อมต่ออินเทอร์เน็ต</translation>
-<translation id="6295157125625453859">ยืนยันแล้ว</translation>
+<translation id="6238170540438416559">การแตะ “<ph name="PH_1" />” แสดงว่าคุณยอมรับ <ph name="PP" /> ระบบจะส่ง SMS ให้คุณ อาจมีค่าบริการรับส่งข้อความและค่าบริการอินเทอร์เน็ต</translation>
+<translation id="6265373887273416711">ยืนยันหมายเลขโทรศัพท์</translation>
+<translation id="6283536862756552051">คุณต้องป้อนรหัสผ่านปัจจุบันของคุณก่อนจึงจะเปลี่ยนรหัสผ่านได้</translation>
+<translation id="6299890279889400823">ย้อนกลับ</translation>
 <translation id="6316446940976157217">อินเดีย</translation>
 <translation id="6327723482938582895">เบนิน</translation>
 <translation id="6338643731889005578">ต่อไป</translation>
+<translation id="6355621963154078138">รหัสผ่านต้องมีอักขระที่เป็นตัวเลข</translation>
 <translation id="6359400968059656782">ตอนนี้คุณสามารถลงชื่อเข้าใช้ด้วยรหัสผ่านใหม่ได้แล้ว</translation>
 <translation id="6363241121027868570">อารูบา</translation>
 <translation id="6377222208046638522">ลักเซมเบิร์ก</translation>
@@ -419,6 +426,7 @@
 <translation id="7790301903034097323">ตั้งรหัสผ่าน</translation>
 <translation id="7796914496604415892">พบการใช้อุปกรณ์หรือเบราว์เซอร์ใหม่</translation>
 <translation id="786166109137986817">ลงชื่อเข้าใช้ <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">รหัสผ่านต้องมีอักขระตัวพิมพ์ใหญ่</translation>
 <translation id="7868540442111212282">สาธารณรัฐเช็ก</translation>
 <translation id="7874584525604421364">ตูวาลู</translation>
 <translation id="7926046652648626866">ลงชื่อเข้าใช้ด้วย GitHub</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151">หากคุณยังต้องการเชื่อมต่อบัญชี <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> ให้เปิดลิงก์บนอุปกรณ์ที่เริ่มลงชื่อเข้าใช้ หรือแตะ "ต่อไป" เพื่อลงชื่อเข้าใช้บนอุปกรณ์นี้</translation>
 <translation id="8920674952994839257">ลองใหม่</translation>
 <translation id="8939353296336237380">แต่เดิมคุณตั้งใจที่จะเชื่อมต่อ <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> ไปยังบัญชีอีเมล แต่คุณได้เปิดลิงก์บนอุปกรณ์อื่นที่ไม่ได้ลงชื่อเข้าใช้</translation>
-<translation id="8971555482255213064">ส่งรหัสอีกครั้งใน 0:<ph name="PH_1" /></translation>
+<translation id="8955469172512804617">การแตะ<ph name="BTN" />แสดงว่าคุณยอมรับ<ph name="PP" /></translation>
+<translation id="8980953965669178372">เสร็จสิ้น</translation>
 <translation id="8984161590699631096">โมร็อกโก</translation>
 <translation id="8994098794339484800">หากคุณไม่รู้จักอุปกรณ์นี้ อาจเป็นไปได้ว่ามีผู้อื่นพยายามเข้าถึงบัญชีของคุณ ลอง<ph name="START_LINK" />เปลี่ยนรหัสผ่านทันที<ph name="END_LINK" /></translation>
 <translation id="900153878296575829">บังกลาเทศ</translation>
 <translation id="9022632332691561239">โทรศัพท์</translation>
 <translation id="9028063588419847334">ฟินแลนด์</translation>
 <translation id="9078135685219203661">สหรัฐอาหรับเอมิเรตส์</translation>
+<translation id="9085311482535098646">รหัสผ่านต้องมีอักขระอย่างน้อย <ph name="MIN_PASSWORD_LENGTH" /> ตัว</translation>
 <translation id="9121203582272050974">อีเมลของคุณได้รับการยืนยันและเปลี่ยนแปลงแล้ว</translation>
 <translation id="9156150178611681179">รหัสผ่าน</translation>
 <translation id="9168877696443530714">สาธารณรัฐแอฟริกากลาง</translation>

--- a/translations/tr.xtb
+++ b/translations/tr.xtb
@@ -31,10 +31,11 @@
 <translation id="1479035434297790822">IP adresinizden çok fazla sayıda hesap isteği geliyor. Birkaç dakika içinde tekrar deneyin.</translation>
 <translation id="1483249363694224399">Sri Lanka</translation>
 <translation id="1507995441600689506">Artık yeni hesabınızla oturum açabilirsiniz</translation>
+<translation id="1535200361681091160">E-postanızı girin</translation>
 <translation id="1544981664986460902">İstemci, geçersiz bağımsız değişken belirtti.</translation>
 <translation id="1575848116712334589">Çad</translation>
 <translation id="1630237004390596779"><ph name="STRING" /> içinde kodu yeniden gönder</translation>
-<translation id="1653501608290591291">Beyaz Rusya</translation>
+<translation id="1653501608290591291">Belarus</translation>
 <translation id="1667376103923043653">Bu e-posta adresi mevcut bir hesapla eşleşmiyor.</translation>
 <translation id="173576986138855124">"<ph name="PH_1" />" öğesine dokunarak SMS gönderilebilir. Mesaj ve veri ücretleri uygulanabilir.</translation>
 <translation id="1739056958326110545">Saint Helena</translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">Cook Adaları</translation>
 <translation id="1870056762032541323">Yanlış kod. Tekrar deneyin.</translation>
 <translation id="1898579907513173256">Makau</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Merhaba <ph name="DISPLAY_NAME" />,<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Hesabı silin</translation>
+<translation id="1912929493041975510">Şifre en az 6 karakter uzunluğunda olmalıdır</translation>
+<translation id="1933044638365301516"><ph name="STRING" /> ile oturum aç</translation>
 <translation id="1987722456379605552"><ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /> numaralı telefona gönderdiğimiz 6 haneli kodu girin</translation>
-<translation id="2016421613709283485">Şifrenizi kurtarmak için <ph name="PH_1" /> adresine gönderilen talimatları uygulayın.</translation>
+<translation id="1999379687946415948"><ph name="APP_NAME" /> için kodunuz: <ph name="IDV_CODE_PLACE_HOLDER" /></translation>
+<translation id="2033662766890821456">Kodu yeniden gönder</translation>
 <translation id="2035855087334775326">Macaristan</translation>
 <translation id="2040904406955887821">Surinam</translation>
 <translation id="2046207054419739276">Amerika Birleşik Devletleri</translation>
 <translation id="2049229571938383319">Saint Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Güçlü şifreler en az 6 karakterden oluşur ve hem harf hem de rakam içerir</translation>
 <translation id="2074008538308369451">Hizmet Şartları</translation>
 <translation id="2089802663554186342">Oturum sona erdi</translation>
 <translation id="2108717231438756650">Birleşik Krallık</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">Yeşil Burun Adaları</translation>
 <translation id="2301396996587599046">Makedonya</translation>
 <translation id="2310948428656960769">Oturum açıldı!</translation>
+<translation id="2321152797538991921">Şifre, alfanümerik olmayan bir karakter içermelidir</translation>
 <translation id="2324942959480650701">Misafir</translation>
 <translation id="2331781584136059536">Gana</translation>
 <translation id="2338909515537249568">Kullandığınız tarayıcı Web Depolamasını desteklemiyor. Lütfen farklı bir tarayıcıda tekrar deneyin.</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">İsteğinizin kimliği doğrulanırken bir sorun oluştu. Kimlik doğrulama sürecini yeniden başlatmak için lütfen sizi bu sayfaya yönlendiren URL'yi ziyaret edin.</translation>
 <translation id="3216149523061905579">Dominik</translation>
 <translation id="3223688630903046698">Yeni şifre</translation>
+<translation id="3245143966477136343">Şifre, küçük harfli karakter içermelidir</translation>
 <translation id="3250864391349648273">Gabon</translation>
 <translation id="3259479674319858599"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> adresini daha önce kullandınız. Devam etmek için <ph name="IDP_DISPLAY_NAME" /> ile oturum açın.</translation>
 <translation id="3275852444431525182">Yeni Zelanda</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">Şifrenizi kurtarmak için <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> adresine gönderilen talimatları uygulayın</translation>
 <translation id="4588392627302012849">E-posta ile oturum aç</translation>
 <translation id="4595119411041064617">"<ph name="PH_1" />" öğesine dokunarak SMS gönderilebilir. Mesaj ve veri ücretleri uygulanabilir.</translation>
+<translation id="4603232692404395592">Şifre, en fazla <ph name="MAX_PASSWORD_LENGTH" /> karakterden oluşmalıdır</translation>
 <translation id="4632709875751031323">Rusya</translation>
 <translation id="4644169548516814280">Bu e-posta adresi zaten başka bir hesap tarafından kullanılıyor</translation>
 <translation id="4692014002063276828">Polonya</translation>
@@ -311,16 +315,19 @@
 <translation id="6132202686885223981">Gelen kutunuzdaki boş alanın azalıp azalmadığını ve gelen kutusu ayarlarıyla ilgili başka bir sorun olup olmadığını kontrol edin.</translation>
 <translation id="6135589730599211649">İstemci, geçersiz aralık belirtti.</translation>
 <translation id="6143147250106939258">Bu işlemin kotası aşıldı. Daha sonra tekrar deneyin.</translation>
+<translation id="615787395595800956">Eksik şifre koşulları:</translation>
 <translation id="6189573836664806798">Paraguay</translation>
 <translation id="6192657410634245771">Cezayir</translation>
 <translation id="6213969168046789596">Çok fazla kez yanlış şifre girdiniz. Lütfen birkaç dakika içinde tekrar deneyin.</translation>
 <translation id="6216759405419177713">Norfolk Adası</translation>
-<translation id="6245066275978703471">Telefon numarası otomatik olarak doğrulandı</translation>
-<translation id="6269083314054226194">Ağ hatası, internet bağlantınızı kontrol edin.</translation>
-<translation id="6295157125625453859">Doğrulandı!</translation>
+<translation id="6238170540438416559"><ph name="PH_1" /> öğesine dokunarak <ph name="PP" /> hükümlerimizi kabul ettiğinizi bildirirsiniz. SMS gönderilebilir. Mesaj ve veri ücretleri uygulanabilir.</translation>
+<translation id="6265373887273416711">Telefon numaranızı doğrulayın</translation>
+<translation id="6283536862756552051">Şifrenizi değiştirmek için önce mevcut şifrenizi girmeniz gerekir.</translation>
+<translation id="6299890279889400823">Geri</translation>
 <translation id="6316446940976157217">Hindistan</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Devam</translation>
+<translation id="6355621963154078138">Şifre, sayısal bir karakter içermelidir</translation>
 <translation id="6359400968059656782">Artık yeni şifrenizle oturum açabilirsiniz</translation>
 <translation id="6363241121027868570">Aruba</translation>
 <translation id="6377222208046638522">Lüksemburg</translation>
@@ -419,6 +426,7 @@
 <translation id="7790301903034097323">Şifre seçin</translation>
 <translation id="7796914496604415892">Yeni bir cihaz veya tarayıcı algılandı</translation>
 <translation id="786166109137986817">Şurada oturum aç: <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">Şifre, büyük harfli karakter içermelidir</translation>
 <translation id="7868540442111212282">Çek Cumhuriyeti</translation>
 <translation id="7874584525604421364">Tuvalu</translation>
 <translation id="7926046652648626866">GitHub ile oturum aç</translation>
@@ -492,13 +500,15 @@
 <translation id="8916080112145514151">Hala <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> hesabınızı bağlamak istiyorsanız bağlantıyı oturum açma işlemini başlattığınız cihazda açın. Hesabınızı bağlamak istemiyorsanız bu cihazda oturum açmak için Devam Et'e dokunun.</translation>
 <translation id="8920674952994839257">Tekrar dene</translation>
 <translation id="8939353296336237380">İlk hedefiniz <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> hesabınızı e-posta hesabınıza bağlamaktı ancak bağlantıyı oturumunuzun açık olmadığı farklı bir cihazda açtınız.</translation>
-<translation id="8971555482255213064">0:<ph name="PH_1" /> içinde kodu yeniden gönder</translation>
+<translation id="8955469172512804617"><ph name="BTN" /> öğesine dokunarak şunu kabul ettiğinizi bildirirsiniz: <ph name="PP" />.</translation>
+<translation id="8980953965669178372">Bitti</translation>
 <translation id="8984161590699631096">Fas</translation>
 <translation id="8994098794339484800">Bu cihazı tanımıyorsanız hesabınıza başka biri erişmeye çalışıyor olabilir. <ph name="START_LINK" />Parolanızı hemen değiştirmeniz<ph name="END_LINK" /> önerilir.</translation>
 <translation id="900153878296575829">Bangladeş</translation>
 <translation id="9022632332691561239">Telefon</translation>
 <translation id="9028063588419847334">Finlandiya</translation>
 <translation id="9078135685219203661">Birleşik Arap Emirlikleri</translation>
+<translation id="9085311482535098646">Şifre, en az <ph name="MIN_PASSWORD_LENGTH" /> karakterden oluşmalıdır</translation>
 <translation id="9121203582272050974">E-posta adresiniz doğrulandı ve değiştirildi</translation>
 <translation id="9156150178611681179">Şifre</translation>
 <translation id="9168877696443530714">Orta Afrika Cumhuriyeti</translation>

--- a/translations/uk.xtb
+++ b/translations/uk.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Острови Кука</translation>
 <translation id="1870056762032541323">Неправильний код. Повторіть спробу.</translation>
 <translation id="1898579907513173256">Макао</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Вітаємо, <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Видалити обліковий запис</translation>
+<translation id="1912929493041975510">Пароль має складатися принаймні із 6 символів</translation>
+<translation id="1933044638365301516">Увійти, використовуючи <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Введіть 6-значний код, який ми надіслали на номер <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Виконайте інструкції з відновлення пароля, надіслані на адресу <ph name="PH_1" />.</translation>
 <translation id="2035855087334775326">Угорщина</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Сполучені Штати Америки</translation>
 <translation id="2049229571938383319">Сен-Бартельмі</translation>
 <translation id="2058731785647385204">Монтсеррат</translation>
-<translation id="2070709910567585968">Надійний пароль має містити принаймні 6 символів та комбінацію літер і цифр</translation>
 <translation id="2074008538308369451">Умови використання</translation>
 <translation id="2089802663554186342">Сеанс завершено</translation>
 <translation id="2108717231438756650">Велика Британія</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Алжир</translation>
 <translation id="6213969168046789596">Ви ввели неправильний пароль забагато разів. Спробуйте за кілька хвилин.</translation>
 <translation id="6216759405419177713">Острів Норфолк</translation>
-<translation id="6245066275978703471">Номер телефону підтверджено автоматично</translation>
-<translation id="6269083314054226194">Помилка мережі. Перевірте інтернет-з’єднання.</translation>
-<translation id="6295157125625453859">Підтверджено</translation>
+<translation id="6238170540438416559">Торкаючись кнопки "<ph name="PH_1" />", ви приймаєте такий документ: <ph name="PP" />. Вам може надійти SMS-повідомлення. За SMS і використання трафіку може стягуватися плата.</translation>
+<translation id="6265373887273416711">Підтвердити номер телефону</translation>
+<translation id="6283536862756552051">Щоб змінити пароль, спершу введіть поточний.</translation>
+<translation id="6299890279889400823">Назад</translation>
 <translation id="6316446940976157217">Індія</translation>
 <translation id="6327723482938582895">Бенін</translation>
 <translation id="6338643731889005578">Продовжити</translation>
@@ -369,7 +369,7 @@
 <translation id="6961220857430789248">Посилання для входу та додаткові вказівки надіслано на адресу <ph name="STRING" />. Дотримуйтеся їх, щоб увійти в обліковий запис.</translation>
 <translation id="6984204927251307445">Підтвердьте електронну адресу</translation>
 <translation id="6996552808101270965">Докладніше</translation>
-<translation id="6999773882165218263">Ім’я та прізвище</translation>
+<translation id="6999773882165218263">Ім’я і прізвище</translation>
 <translation id="7012506961150923116">Гренада</translation>
 <translation id="7024571478138322659">Західна Сахара</translation>
 <translation id="7025117765722694556">У поточному стані системи запит не можна виконати.</translation>
@@ -457,7 +457,7 @@
 <translation id="8448940737083561161">Кірибаті</translation>
 <translation id="847294590390666986">Тайвань</translation>
 <translation id="8477554788963470892">Сьєрра-Леоне</translation>
-<translation id="8498398269542501379">Перевірте – можливо, електронний лист позначено як спам або відфільтровано.</translation>
+<translation id="8498398269542501379">Перевірте – можливо, електронний лист позначено як спам або відфільтровано.</translation>
 <translation id="8505200776212389923">Підтвердження…</translation>
 <translation id="8505941919386646914">Мартиніка</translation>
 <translation id="8534746304953308378">Того</translation>

--- a/translations/vi.xtb
+++ b/translations/vi.xtb
@@ -45,8 +45,8 @@
 <translation id="1799407952500261728">Quần đảo Cook</translation>
 <translation id="1870056762032541323">Mã không chính xác. Hãy thử lại.</translation>
 <translation id="1898579907513173256">Macao</translation>
-<translation id="1929332760123475919"><ph name="P_START" />Xin chào <ph name="DISPLAY_NAME" />!<ph name="P_END" /></translation>
-<translation id="1966996824429980990">Xóa tài khoản</translation>
+<translation id="1912929493041975510">Mật khẩu phải chứa tối thiểu 6 ký tự</translation>
+<translation id="1933044638365301516">Đăng nhập bằng <ph name="STRING" /></translation>
 <translation id="1987722456379605552">Nhập mã 6 chữ số mà chúng tôi gửi đến <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /></translation>
 <translation id="2016421613709283485">Làm theo hướng dẫn gửi tới <ph name="PH_1" /> để khôi phục mật khẩu của bạn.</translation>
 <translation id="2035855087334775326">Hungary</translation>
@@ -54,7 +54,6 @@
 <translation id="2046207054419739276">Hoa Kỳ</translation>
 <translation id="2049229571938383319">Saint Barthélemy</translation>
 <translation id="2058731785647385204">Montserrat</translation>
-<translation id="2070709910567585968">Mật khẩu mạnh có ít nhất 6 ký tự, kết hợp chữ cái và số</translation>
 <translation id="2074008538308369451">Điều khoản dịch vụ</translation>
 <translation id="2089802663554186342">Phiên hoạt động đã kết thúc</translation>
 <translation id="2108717231438756650">Vương quốc Anh</translation>
@@ -314,9 +313,10 @@
 <translation id="6192657410634245771">Algeria</translation>
 <translation id="6213969168046789596">Bạn đã nhập sai mật khẩu quá nhiều lần. Vui lòng thử lại sau một vài phút.</translation>
 <translation id="6216759405419177713">Đảo Norfolk</translation>
-<translation id="6245066275978703471">Đã tự động xác minh số điện thoại</translation>
-<translation id="6269083314054226194">Đã xảy ra lỗi mạng, hãy kiểm tra kết nối Internet của bạn.</translation>
-<translation id="6295157125625453859">Đã xác minh!</translation>
+<translation id="6238170540438416559">Bằng cách nhấn vào “<ph name="PH_1" />”, bạn cho biết rằng bạn chấp nhận <ph name="PP" /> của chúng tôi. Bạn có thể nhận được một tin nhắn SMS. Cước tin nhắn và dữ liệu có thể áp dụng.</translation>
+<translation id="6265373887273416711">Xác minh số điện thoại của bạn</translation>
+<translation id="6283536862756552051">Để thay đổi mật khẩu, trước tiên bạn phải nhập mật khẩu hiện tại của bạn.</translation>
+<translation id="6299890279889400823">Quay lại</translation>
 <translation id="6316446940976157217">Ấn Độ</translation>
 <translation id="6327723482938582895">Benin</translation>
 <translation id="6338643731889005578">Tiếp tục</translation>

--- a/translations/zh-CN.xtb
+++ b/translations/zh-CN.xtb
@@ -25,17 +25,18 @@
 <translation id="137210131544215127">请输入您的密码</translation>
 <translation id="1393433815796487579">完成</translation>
 <translation id="1412449974349991050">海地</translation>
-<translation id="144766329299583285">如果您并未请求更改您的登录电子邮件地址，那么可能是有人正在试图访问您的帐号，您应该<ph name="START_LINK" />立即更改您的密码<ph name="END_LINK" />。</translation>
+<translation id="144766329299583285">如果您并未请求更改您的登录电子邮件地址，那么可能是有人正在试图访问您的账号，您应该<ph name="START_LINK" />立即更改您的密码<ph name="END_LINK" />。</translation>
 <translation id="1449981769524156676">赫德岛和麦克唐纳群岛</translation>
 <translation id="1451880131543823984"><ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> 已获授权，可以查看所请求的页面。</translation>
-<translation id="1479035434297790822">来自您的 IP 地址的帐号请求过多，请过几分钟再试。</translation>
+<translation id="1479035434297790822">来自您的 IP 地址的账号请求过多，请过几分钟再试。</translation>
 <translation id="1483249363694224399">斯里兰卡</translation>
-<translation id="1507995441600689506">现在您可以使用新帐号登录了</translation>
+<translation id="1507995441600689506">现在您可以使用新账号登录了</translation>
+<translation id="1535200361681091160">输入您的电子邮件地址</translation>
 <translation id="1544981664986460902">客户端指定了无效参数。</translation>
 <translation id="1575848116712334589">乍得</translation>
 <translation id="1630237004390596779"><ph name="STRING" /> 后可重新发送验证码</translation>
 <translation id="1653501608290591291">白俄罗斯</translation>
-<translation id="1667376103923043653">该电子邮件地址没有相匹配的现有帐号。</translation>
+<translation id="1667376103923043653">该电子邮件地址没有相匹配的现有账号。</translation>
 <translation id="173576986138855124">点按“<ph name="PH_1" />”后，系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</translation>
 <translation id="1739056958326110545">圣赫勒拿</translation>
 <translation id="1743026758446868773">巴巴多斯</translation>
@@ -45,18 +46,16 @@
 <translation id="1799407952500261728">库克群岛</translation>
 <translation id="1870056762032541323">验证码有误，请重试。</translation>
 <translation id="1898579907513173256">澳门</translation>
-<translation id="1929332760123475919"><ph name="P_START" />尊敬的<ph name="DISPLAY_NAME" />：<ph name="P_END" />
-
-您好！</translation>
-<translation id="1966996824429980990">删除帐号</translation>
+<translation id="1912929493041975510">密码长度必须至少为 6 个字符</translation>
+<translation id="1933044638365301516">使用 <ph name="STRING" /> 账号登录</translation>
 <translation id="1987722456379605552">请输入我们发送至 <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /> 的 6 位数验证码</translation>
-<translation id="2016421613709283485">请按照发送到 <ph name="PH_1" /> 的说明找回密码。</translation>
+<translation id="1999379687946415948">您的“<ph name="APP_NAME" />”验证码是 <ph name="IDV_CODE_PLACE_HOLDER" />。</translation>
+<translation id="2033662766890821456">重新发送验证码</translation>
 <translation id="2035855087334775326">匈牙利</translation>
 <translation id="2040904406955887821">苏里南</translation>
 <translation id="2046207054419739276">美国</translation>
 <translation id="2049229571938383319">圣巴泰勒米岛</translation>
 <translation id="2058731785647385204">蒙特塞拉特</translation>
-<translation id="2070709910567585968">安全系数高的密码至少包含 6 个字符，由字母和数字组成</translation>
 <translation id="2074008538308369451">服务条款</translation>
 <translation id="2089802663554186342">会话已结束</translation>
 <translation id="2108717231438756650">英国</translation>
@@ -76,6 +75,7 @@
 <translation id="2285049245646335550">佛得角</translation>
 <translation id="2301396996587599046">马其顿</translation>
 <translation id="2310948428656960769">已登录！</translation>
+<translation id="2321152797538991921">密码必须包含非字母数字字符</translation>
 <translation id="2324942959480650701">访客</translation>
 <translation id="2331781584136059536">加纳</translation>
 <translation id="2338909515537249568">您使用的浏览器不支持网络存储。请使用其他浏览器重试。</translation>
@@ -90,7 +90,7 @@
 <translation id="2451742558284013472">摩纳哥</translation>
 <translation id="2460064915291012298">塞舌尔</translation>
 <translation id="2490672522100125425">已移除用于第二步身份验证的 <ph name="START_STRONG" /><ph name="FACTOR_ID" /> <ph name="PHONE_NUMBER" /><ph name="END_STRONG" />。</translation>
-<translation id="2494962141967044042">当前匿名用户未能升级。此非匿名凭据已与另一用户帐号关联。</translation>
+<translation id="2494962141967044042">当前匿名用户未能升级。此非匿名凭据已与另一用户账号关联。</translation>
 <translation id="2541179214468543429">您输入错误密码的次数过多，请过几分钟再试。</translation>
 <translation id="2561560038714758184">安全</translation>
 <translation id="2561835578785502516">您的密码重置请求已过期，或者相关链接已被使用</translation>
@@ -105,7 +105,7 @@
 <translation id="2621854044487969847">英属维尔京群岛</translation>
 <translation id="2623430226615357954">关闭</translation>
 <translation id="2626214972556632989">请输入有效的电话号码</translation>
-<translation id="2652952163277051394">此应用不支持这种类型的帐号</translation>
+<translation id="2652952163277051394">此应用不支持这种类型的账号</translation>
 <translation id="2660271277401013037">操作代码无效。如果该代码格式有误、已过期或已被使用，就可能会发生这种情况。</translation>
 <translation id="2665022736179407256">此代码已过期。</translation>
 <translation id="2668496398414877352">科索沃</translation>
@@ -115,10 +115,10 @@
 <translation id="2741235824871026219">验证</translation>
 <translation id="2752984808025184019">南非</translation>
 <translation id="2760636260031093254">请输入您的电子邮件地址以继续</translation>
-<translation id="276938411216176478">用户帐号已被管理员停用。</translation>
+<translation id="276938411216176478">用户账号已被管理员停用。</translation>
 <translation id="2782685789517131804">系统已将登录电子邮件和附加说明发送至 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />。请查收电子邮件以完成登录。</translation>
 <translation id="2824267666257947103">输入您的密码</translation>
-<translation id="2828509010894808185">创建帐号</translation>
+<translation id="2828509010894808185">创建账号</translation>
 <translation id="2834770837848769530">阿富汗</translation>
 <translation id="2884525438023347369">点按“<ph name="BTN" />”即表示您同意 <ph name="TOS" />。</translation>
 <translation id="2909392332969582158">加拿大</translation>
@@ -141,8 +141,9 @@
 <translation id="3215050409577090361">在对您的请求进行身份验证时遇到了问题。请再次访问将您重定向至此页面的网址，以重新启动身份验证流程。</translation>
 <translation id="3216149523061905579">多米尼克</translation>
 <translation id="3223688630903046698">新密码</translation>
+<translation id="3245143966477136343">密码必须包含小写字符</translation>
 <translation id="3250864391349648273">加蓬</translation>
-<translation id="3259479674319858599">您已经使用了 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />。请使用 <ph name="IDP_DISPLAY_NAME" /> 帐号登录以继续操作。</translation>
+<translation id="3259479674319858599">您已经使用了 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />。请使用 <ph name="IDP_DISPLAY_NAME" /> 账号登录以继续操作。</translation>
 <translation id="3275852444431525182">新西兰</translation>
 <translation id="3314478375063334511">缅甸</translation>
 <translation id="3361878270020566601">冰岛</translation>
@@ -150,14 +151,14 @@
 <translation id="3372254675985592547">古巴</translation>
 <translation id="3394519231857398207">法国</translation>
 <translation id="3398534025670554188">中国</translation>
-<translation id="3409391354412142307">您已经使用了 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />。您可以先使用下方电子邮件链接登录，然后将<ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />帐号与 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> 关联起来。</translation>
+<translation id="3409391354412142307">您已经使用了 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />。您可以先使用下方电子邮件链接登录，然后将<ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />账号与 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> 关联起来。</translation>
 <translation id="3413300222170818119">赞比亚</translation>
 <translation id="3429213469114503705">梵蒂冈</translation>
 <translation id="3434621886769337032">冈比亚</translation>
 <translation id="3472358534605257432">完成</translation>
 <translation id="3479685026618611556">取消</translation>
 <translation id="3481131180097895739">出现未知的服务器错误。</translation>
-<translation id="3487364398525389372">请输入您的帐号名称</translation>
+<translation id="3487364398525389372">请输入您的账号名称</translation>
 <translation id="3521753471343796628">伊拉克</translation>
 <translation id="354888504916863713">越南</translation>
 <translation id="3550380781997195832">该电子邮件地址不正确</translation>
@@ -204,7 +205,7 @@
 <translation id="4329551945958214898">日本</translation>
 <translation id="4331763189922924781">黑山</translation>
 <translation id="4372962701784304822">莫桑比克</translation>
-<translation id="4377158577300329881">该电子邮件地址没有相匹配的现有帐号</translation>
+<translation id="4377158577300329881">该电子邮件地址没有相匹配的现有账号</translation>
 <translation id="4386334763822785837">土耳其</translation>
 <translation id="4413304190485210039">塔吉克斯坦</translation>
 <translation id="4432634970196611353">老挝</translation>
@@ -213,13 +214,14 @@
 <translation id="4498504413765490964">洪都拉斯</translation>
 <translation id="450385255996536115">操作已超时。</translation>
 <translation id="4515732781724470190">尼日尔</translation>
-<translation id="4521614244485847733">该电子邮件地址没有相匹配的现有帐号</translation>
+<translation id="4521614244485847733">该电子邮件地址没有相匹配的现有账号</translation>
 <translation id="4556476996891737119">约旦</translation>
 <translation id="4571870355114729513">请按照发送到 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> 的说明找回密码</translation>
 <translation id="4588392627302012849">使用电子邮件地址登录</translation>
 <translation id="4595119411041064617">您点按“<ph name="PH_1" />”后，系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</translation>
+<translation id="4603232692404395592">密码最多只能包含 <ph name="MAX_PASSWORD_LENGTH" /> 个字符</translation>
 <translation id="4632709875751031323">俄罗斯</translation>
-<translation id="4644169548516814280">此电子邮件地址已被其他帐号使用</translation>
+<translation id="4644169548516814280">此电子邮件地址已被其他账号使用</translation>
 <translation id="4692014002063276828">波兰</translation>
 <translation id="4723701728629289714">以色列</translation>
 <translation id="4725154639671888461">遇到错误</translation>
@@ -233,17 +235,17 @@
 <translation id="4871106926303956169">特克斯和凯科斯群岛</translation>
 <translation id="4877597386645466815"><ph name="TIME_REMAINING" /> 后可重新发送验证码</translation>
 <translation id="4900116391137165411">
-<ph name="P_START" />您在<ph name="APP_NAME" />中的帐号新增了一个电话号码 (<ph name="SECOND_FACTOR" />)，以实现两步验证。<ph name="P_END" />
+<ph name="P_START" />您在<ph name="APP_NAME" />中的账号新增了一个电话号码 (<ph name="SECOND_FACTOR" />)，以实现两步验证。<ph name="P_END" />
 <ph name="P_START" />如果您没有添加这个用于两步验证的电话号码，请点击下面的链接将其移除。<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="4923375331439013137">无法移除您的第二重身份验证</translation>
 <translation id="4955175001894453989">添加密码</translation>
 <translation id="496366313824211679">萨尔瓦多</translation>
-<translation id="4982483807073820954">要更改帐号的密码，您需要重新登录。</translation>
+<translation id="4982483807073820954">要更改账号的密码，您需要重新登录。</translation>
 <translation id="4991626049082973728">塞尔维亚</translation>
 <translation id="4991892293325936102">伯利兹</translation>
 <translation id="5042136001778337830"><ph name="START_PARAGRAPH" />电子邮件地址：<ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /><ph name="END_PARAGRAPH" /></translation>
-<translation id="5059105734231232362">为了完成此流程，顺利将您的<ph name="IDP_DISPLAY_NAME" />帐号与此电子邮件地址关联起来，您必须使用相同的设备或浏览器打开链接。</translation>
+<translation id="5059105734231232362">为了完成此流程，顺利将您的<ph name="IDP_DISPLAY_NAME" />账号与此电子邮件地址关联起来，您必须使用相同的设备或浏览器打开链接。</translation>
 <translation id="5080084639513001393">瑞典</translation>
 <translation id="5080899604429810481">圣马丁岛</translation>
 <translation id="5115661695221894994"><ph name="START_PARAGRAPH" />您要求验证并跟新电子邮件地址的请求已过期，或者相关链接已被使用。<ph name="END_PARAGRAPH" /></translation>
@@ -255,10 +257,10 @@
 <translation id="5323041129469627535">阿曼</translation>
 <translation id="5326139833547026317">荷兰加勒比</translation>
 <translation id="5347459868860672391">电子邮件地址已更新</translation>
-<translation id="5397737236938796917">您现在已成功退出帐号。</translation>
+<translation id="5397737236938796917">您现在已成功退出账号。</translation>
 <translation id="5406620662929585965">使用电话号码登录</translation>
 <translation id="5407010562344541906">电话号码</translation>
-<translation id="5409861738809250803">您已经有帐号了</translation>
+<translation id="5409861738809250803">您已经有账号了</translation>
 <translation id="5410341463946781720">泰国</translation>
 <translation id="5437927869321223252">验证码有误，请重试。</translation>
 <translation id="5444635161362535036">列支敦士登</translation>
@@ -272,7 +274,7 @@
 <translation id="5543493820882105191">输入您的名字</translation>
 <translation id="55439745111619380">阿森松岛</translation>
 <translation id="5569341882117077010">出现网络错误</translation>
-<translation id="5581239183924693195">使用 <ph name="IDP_DISPLAY_NAME" /> 帐号登录</translation>
+<translation id="5581239183924693195">使用 <ph name="IDP_DISPLAY_NAME" /> 账号登录</translation>
 <translation id="5585451911077299623">设置密码</translation>
 <translation id="5602886107840188229">英属印度洋领地</translation>
 <translation id="5604510594682955626">乌干达</translation>
@@ -287,7 +289,7 @@
 <translation id="5699028034244995851">请输入您的电子邮件地址以继续</translation>
 <translation id="5701178667798108817">验证您的电话号码</translation>
 <translation id="5715637701147651513">利比里亚</translation>
-<translation id="5747263508495256858">退出帐号</translation>
+<translation id="5747263508495256858">退出账号</translation>
 <translation id="5771034676910614239">马达加斯加</translation>
 <translation id="5818634293686963864">哈萨克斯坦</translation>
 <translation id="5829301468800336085">正在登录…</translation>
@@ -295,9 +297,9 @@
 <translation id="5840803301882074743">汤加</translation>
 <translation id="5850752921356750845">瓦利斯和富图纳</translation>
 <translation id="5853516492584814656">无法更新您的电子邮件地址</translation>
-<translation id="5905720181746284549">您已经使用 <ph name="STRING" /> 登录了，请输入该帐号的密码。</translation>
+<translation id="5905720181746284549">您已经使用 <ph name="STRING" /> 登录了，请输入该账号的密码。</translation>
 <translation id="5921101578434778028">安圭拉</translation>
-<translation id="5948592577241492942">此电子邮件地址已存在，但未指定任何登录方式。请重置密码以恢复帐号。</translation>
+<translation id="5948592577241492942">此电子邮件地址已存在，但未指定任何登录方式。请重置密码以恢复账号。</translation>
 <translation id="5985902459796151462">多米尼加共和国</translation>
 <translation id="5987586156626209007">泽西岛</translation>
 <translation id="5989709845715452405">找回密码</translation>
@@ -313,26 +315,29 @@
 <translation id="6132202686885223981">确保收件箱空间充足，且不存在其他与收件箱设置有关的问题。</translation>
 <translation id="6135589730599211649">客户端指定了无效范围。</translation>
 <translation id="6143147250106939258">已超出此操作的配额，请稍后再试。</translation>
+<translation id="615787395595800956">有密码要求未满足：</translation>
 <translation id="6189573836664806798">巴拉圭</translation>
 <translation id="6192657410634245771">阿尔及利亚</translation>
 <translation id="6213969168046789596">您输入错误密码的次数过多，请过几分钟再试。</translation>
 <translation id="6216759405419177713">诺福克岛</translation>
-<translation id="6245066275978703471">电话号码已自动验证</translation>
-<translation id="6269083314054226194">网络错误，请检查您的互联网连接。</translation>
-<translation id="6295157125625453859">已验证！</translation>
+<translation id="6238170540438416559">点按“<ph name="PH_1" />”即表示您接受我们的<ph name="PP" />。系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</translation>
+<translation id="6265373887273416711">验证您的电话号码</translation>
+<translation id="6283536862756552051">要更改密码，您需要先输入当前的密码。</translation>
+<translation id="6299890279889400823">返回</translation>
 <translation id="6316446940976157217">印度</translation>
 <translation id="6327723482938582895">贝宁</translation>
 <translation id="6338643731889005578">继续</translation>
+<translation id="6355621963154078138">密码必须包含数字字符</translation>
 <translation id="6359400968059656782">现在您可以使用新密码登录了</translation>
 <translation id="6363241121027868570">阿鲁巴</translation>
 <translation id="6377222208046638522">卢森堡</translation>
 <translation id="6381974517529371884">法罗群岛</translation>
 <translation id="6443180961828792673">科索沃</translation>
 <translation id="6450170205342035038">保加利亚</translation>
-<translation id="6470057025778734988">您将不能再使用您的帐号登录</translation>
+<translation id="6470057025778734988">您将不能再使用您的账号登录</translation>
 <translation id="6472297146424049005">检查互联网连接。</translation>
 <translation id="6483116480230343278">正在注册…</translation>
-<translation id="6494734506607758748">要更改与您的帐号相关联的电子邮件地址，您需要重新登录。</translation>
+<translation id="6494734506607758748">要更改与您的账号相关联的电子邮件地址，您需要重新登录。</translation>
 <translation id="6508909904815637928">瓦努阿图</translation>
 <translation id="6520863029476703422">美属萨摩亚</translation>
 <translation id="6527597037551425211">巴西</translation>
@@ -377,7 +382,7 @@
 <translation id="7024571478138322659">西撒哈拉</translation>
 <translation id="7025117765722694556">请求无法在当前系统状态下执行。</translation>
 <translation id="7062299334696934251">发生未知错误。</translation>
-<translation id="7064251114893721966">您已经使用 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> 登录了，请输入该帐号的密码。</translation>
+<translation id="7064251114893721966">您已经使用 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> 登录了，请输入该账号的密码。</translation>
 <translation id="7085136866191400000">已发送登录电子邮件</translation>
 <translation id="7089485669419398254">爱尔兰</translation>
 <translation id="7093343209860483088">刚果民主共和国</translation>
@@ -407,13 +412,13 @@
 <translation id="7477065998516229434">服务条款</translation>
 <translation id="7493245640904888019">直布罗陀</translation>
 <translation id="7510939244824757986">坦桑尼亚</translation>
-<translation id="7526532581122816497">已关联的帐号</translation>
+<translation id="7526532581122816497">已关联的账号</translation>
 <translation id="7560587702704358921">圣皮埃尔和密克隆群岛</translation>
 <translation id="7569285452790032317">索马里</translation>
 <translation id="7592224526951017144">德国</translation>
 <translation id="7595933825828475368">无法收到电子邮件？</translation>
 <translation id="7615083347713899917">吉尔吉斯斯坦</translation>
-<translation id="7643408533407091568">您已经使用 <ph name="EMAIL_ADDR" /> 登录了，请输入该帐号的密码。</translation>
+<translation id="7643408533407091568">您已经使用 <ph name="EMAIL_ADDR" /> 登录了，请输入该账号的密码。</translation>
 <translation id="7652546345268886994">{plural_var,plural, =1{密码的安全系数不够高。请使用至少 <ph name="PH_1" /> 个字符，并混合使用字母和数字}other{密码的安全系数不够高。请使用至少 <ph name="PH_1" /> 个字符，并混合使用字母和数字}}</translation>
 <translation id="7699755204074920022">津巴布韦</translation>
 <translation id="7746977132739352062">由于 OAuth 令牌丢失、无效或过期，请求未通过身份验证。</translation>
@@ -421,21 +426,21 @@
 <translation id="7790301903034097323">选择密码</translation>
 <translation id="7796914496604415892">检测到新设备或新浏览器</translation>
 <translation id="786166109137986817">登录<ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">密码必须包含大写字符</translation>
 <translation id="7868540442111212282">捷克</translation>
 <translation id="7874584525604421364">图瓦卢</translation>
-<translation id="7926046652648626866">使用 GitHub 帐号登录</translation>
+<translation id="7926046652648626866">使用 GitHub 账号登录</translation>
 <translation id="792838323404934335">格陵兰</translation>
 <translation id="7956645158976161232">利比亚</translation>
 <translation id="8017277252219866084">肯尼亚</translation>
-<translation id="8028653067082554952">此操作将清空与您的帐号相关联的所有数据，并且无法撤消。确定要删除帐号吗？</translation>
+<translation id="8028653067082554952">此操作将清空与您的账号相关联的所有数据，并且无法撤消。确定要删除账号吗？</translation>
 <translation id="8033786138248870436">点按“验证”后，系统会向您发送一条短信。这可能会产生短信费用和上网流量费。</translation>
 <translation id="8047183472745080590">玻利维亚</translation>
 <translation id="8047565947836609247">波多黎各</translation>
-<translation id="8055755007915250245">要取消帐号关联吗？</translation>
+<translation id="8055755007915250245">要取消账号关联吗？</translation>
 <translation id="8063505483150915580">圣诞岛</translation>
 <translation id="8077378925683571933">
 <ph name="P_START" />此致<ph name="P_END" />
-
 <ph name="P_START" /><ph name="APP_NAME" />团队敬上<ph name="P_END" /></translation>
 <translation id="8130982192244529100">要发送验证码，请提供接收人的电话号码。</translation>
 <translation id="8138904368098176683">苏丹</translation>
@@ -447,7 +452,7 @@
 <translation id="8283013172847705078">哥斯达黎加</translation>
 <translation id="8289427665929658971">萨摩亚</translation>
 <translation id="8320813901740734879">
-<ph name="P_START" />您在<ph name="APP_NAME" />中的帐号新增了<ph name="SECOND_FACTOR" />，以实现双重身份验证。<ph name="P_END" />
+<ph name="P_START" />您在<ph name="APP_NAME" />中的账号新增了<ph name="SECOND_FACTOR" />，以实现双重身份验证。<ph name="P_END" />
 <ph name="P_START" />如果您没有请求过此项修改，请使用以下链接撤销该更改。<ph name="P_END" />
 <ph name="P_START" /><ph name="START_LINK" /><ph name="CONFIRM_LINK" /><ph name="END_LINK" /><ph name="P_END" /></translation>
 <translation id="8335491854074085727">马里</translation>
@@ -470,8 +475,8 @@
 <translation id="8505200776212389923">正在验证…</translation>
 <translation id="8505941919386646914">马提尼克</translation>
 <translation id="8534746304953308378">多哥</translation>
-<translation id="8572093925387077451">您已经有帐号了</translation>
-<translation id="8585285847459057945">您的“<ph name="APP_NAME" />”帐号的登录电子邮件地址已更改</translation>
+<translation id="8572093925387077451">您已经有账号了</translation>
+<translation id="8585285847459057945">您的“<ph name="APP_NAME" />”账号的登录电子邮件地址已更改</translation>
 <translation id="8585655327529919573">向此电子邮件地址发送关于如何重置密码的说明</translation>
 <translation id="8652838224332661203">瑙鲁</translation>
 <translation id="8657280305228520442">文莱</translation>
@@ -492,16 +497,18 @@
 <translation id="8869797682387766327">马恩岛</translation>
 <translation id="8893950153780006385">马来西亚</translation>
 <translation id="8895840173743975193">科科斯（基林）群岛</translation>
-<translation id="8916080112145514151">如果您仍希望关联您的<ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />帐号，请在您最初开始登录时所用的设备上打开此链接。否则，请点按“继续”以在当前设备上登录。</translation>
+<translation id="8916080112145514151">如果您仍希望关联您的<ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />账号，请在您最初开始登录时所用的设备上打开此链接。否则，请点按“继续”以在当前设备上登录。</translation>
 <translation id="8920674952994839257">重试</translation>
-<translation id="8939353296336237380">您最初的目的是将<ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />与您的电子邮件帐号关联起来，但是您换用其他未登录的设备打开了此链接。</translation>
-<translation id="8971555482255213064"><ph name="PH_1" /> 后可重新发送验证码</translation>
+<translation id="8939353296336237380">您最初的目的是将<ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" />与您的电子邮件账号关联起来，但是您换用其他未登录的设备打开了此链接。</translation>
+<translation id="8955469172512804617">点按“<ph name="BTN" />”即表示您同意 <ph name="PP" />。</translation>
+<translation id="8980953965669178372">完成</translation>
 <translation id="8984161590699631096">摩洛哥</translation>
-<translation id="8994098794339484800">如果您不认识此设备，那么可能是有人在试图访问您的帐号。建议您<ph name="START_LINK" />立即更改密码<ph name="END_LINK" />。</translation>
+<translation id="8994098794339484800">如果您不认识此设备，那么可能是有人在试图访问您的账号。建议您<ph name="START_LINK" />立即更改密码<ph name="END_LINK" />。</translation>
 <translation id="900153878296575829">孟加拉国</translation>
 <translation id="9022632332691561239">电话号码</translation>
 <translation id="9028063588419847334">芬兰</translation>
 <translation id="9078135685219203661">阿拉伯联合酋长国</translation>
+<translation id="9085311482535098646">密码必须包含至少 <ph name="MIN_PASSWORD_LENGTH" /> 个字符</translation>
 <translation id="9121203582272050974">您的电子邮件地址已经验证并更改</translation>
 <translation id="9156150178611681179">密码</translation>
 <translation id="9168877696443530714">中非共和国</translation>

--- a/translations/zh-TW.xtb
+++ b/translations/zh-TW.xtb
@@ -31,6 +31,7 @@
 <translation id="1479035434297790822">您的 IP 位址傳送的建立帳戶要求次數過多，請於幾分鐘後再試一次。</translation>
 <translation id="1483249363694224399">斯里蘭卡</translation>
 <translation id="1507995441600689506">現在您可以登入新的帳戶</translation>
+<translation id="1535200361681091160">輸入您的電子郵件</translation>
 <translation id="1544981664986460902">用戶端指定的引數無效。</translation>
 <translation id="1575848116712334589">查德</translation>
 <translation id="1630237004390596779">於 <ph name="STRING" /> 後重新傳送驗證碼</translation>
@@ -45,16 +46,16 @@
 <translation id="1799407952500261728">庫克群島</translation>
 <translation id="1870056762032541323">驗證碼錯誤，請再試一次。</translation>
 <translation id="1898579907513173256">澳門特別行政區</translation>
-<translation id="1929332760123475919"><ph name="P_START" /><ph name="DISPLAY_NAME" /> 您好：<ph name="P_END" /></translation>
-<translation id="1966996824429980990">刪除帳戶</translation>
+<translation id="1912929493041975510">密碼的長度至少須為 6 個字元</translation>
+<translation id="1933044638365301516">使用 <ph name="STRING" /> 帳戶登入</translation>
 <translation id="1987722456379605552">請輸入我們發送至 <ph name="START_LINK" /><ph name="PHONE_NUMBER" /><ph name="END_LINK" /> 的 6 位數驗證碼</translation>
-<translation id="2016421613709283485">請依照傳送至 <ph name="PH_1" /> 的操作說明，重新取得密碼。</translation>
+<translation id="1999379687946415948">你的「<ph name="APP_NAME" />」驗證碼是 <ph name="IDV_CODE_PLACE_HOLDER" />。</translation>
+<translation id="2033662766890821456">重新傳送驗證碼</translation>
 <translation id="2035855087334775326">匈牙利</translation>
 <translation id="2040904406955887821">蘇利南</translation>
 <translation id="2046207054419739276">美國</translation>
 <translation id="2049229571938383319">聖巴瑟米</translation>
 <translation id="2058731785647385204">蒙哲臘</translation>
-<translation id="2070709910567585968">安全強度高的密碼至少需有 6 個字元並混用字母和數字</translation>
 <translation id="2074008538308369451">服務條款</translation>
 <translation id="2089802663554186342">工作階段已結束</translation>
 <translation id="2108717231438756650">英國</translation>
@@ -74,6 +75,7 @@
 <translation id="2285049245646335550">維德角</translation>
 <translation id="2301396996587599046">馬其頓</translation>
 <translation id="2310948428656960769">登入成功！</translation>
+<translation id="2321152797538991921">密碼必須包含非英數字元</translation>
 <translation id="2324942959480650701">訪客</translation>
 <translation id="2331781584136059536">迦納</translation>
 <translation id="2338909515537249568">您使用的瀏覽器不支援網路儲存空間，請改用其他瀏覽器並再試一次。</translation>
@@ -139,6 +141,7 @@
 <translation id="3215050409577090361">驗證您的要求時發生問題。請再次點選當初將您重新導向至這個頁面的網址，以便重新啟動驗證程序。</translation>
 <translation id="3216149523061905579">多米尼克</translation>
 <translation id="3223688630903046698">新密碼</translation>
+<translation id="3245143966477136343">密碼必須包含小寫字元</translation>
 <translation id="3250864391349648273">加彭</translation>
 <translation id="3259479674319858599">目前您使用的是 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" />。如要繼續，請使用 <ph name="IDP_DISPLAY_NAME" /> 帳戶登入。</translation>
 <translation id="3275852444431525182">紐西蘭</translation>
@@ -216,6 +219,7 @@
 <translation id="4571870355114729513">請按照傳送至 <ph name="START_STRONG" /><ph name="EMAIL" /><ph name="END_STRONG" /> 的操作說明，重新取得密碼</translation>
 <translation id="4588392627302012849">使用電子郵件地址登入</translation>
 <translation id="4595119411041064617">輕觸 [<ph name="PH_1" />] 後，系統將會傳送一封簡訊。您可能需支付簡訊和數據傳輸費用。</translation>
+<translation id="4603232692404395592">密碼不得超過 <ph name="MAX_PASSWORD_LENGTH" /> 個字元</translation>
 <translation id="4632709875751031323">俄羅斯</translation>
 <translation id="4644169548516814280">已有其他帳戶使用這個電子郵件地址</translation>
 <translation id="4692014002063276828">波蘭</translation>
@@ -310,16 +314,19 @@
 <translation id="6132202686885223981">確認收件匣的儲存空間是否足夠，或檢查與收件匣設定相關的其他問題。</translation>
 <translation id="6135589730599211649">用戶端指定的範圍無效。</translation>
 <translation id="6143147250106939258">已超出這項作業的配額上限，請稍後再試。</translation>
+<translation id="615787395595800956">不符合密碼要求：</translation>
 <translation id="6189573836664806798">巴拉圭</translation>
 <translation id="6192657410634245771">阿爾及利亞</translation>
 <translation id="6213969168046789596">您輸入錯誤密碼的次數過多，請於幾分鐘後再試一次。</translation>
 <translation id="6216759405419177713">諾福克島</translation>
-<translation id="6245066275978703471">已自動驗證電話號碼</translation>
-<translation id="6269083314054226194">網路發生錯誤，請檢查您的網際網路連線。</translation>
-<translation id="6295157125625453859">已驗證！</translation>
+<translation id="6238170540438416559">輕觸 [<ph name="PH_1" />] 即表示您同意接受我們的《<ph name="PP" />》。系統將會傳送簡訊給您，不過您可能需要支付簡訊和數據傳輸費用。</translation>
+<translation id="6265373887273416711">驗證您的電話號碼</translation>
+<translation id="6283536862756552051">如要變更密碼，請先輸入目前的密碼。</translation>
+<translation id="6299890279889400823">上一步</translation>
 <translation id="6316446940976157217">印度</translation>
 <translation id="6327723482938582895">貝南</translation>
 <translation id="6338643731889005578">繼續</translation>
+<translation id="6355621963154078138">密碼必須包含數字</translation>
 <translation id="6359400968059656782">現在您可以使用新密碼登入帳戶</translation>
 <translation id="6363241121027868570">阿魯巴島</translation>
 <translation id="6377222208046638522">盧森堡</translation>
@@ -419,6 +426,7 @@
 <translation id="7790301903034097323">選擇密碼</translation>
 <translation id="7796914496604415892">系統偵測到新的裝置或瀏覽器</translation>
 <translation id="786166109137986817">登入 <ph name="DISPLAY_NAME" /></translation>
+<translation id="7863575218808091551">密碼必須包含大寫字元</translation>
 <translation id="7868540442111212282">捷克共和國</translation>
 <translation id="7874584525604421364">吐瓦魯</translation>
 <translation id="7926046652648626866">使用 GitHub 登入</translation>
@@ -490,13 +498,15 @@
 <translation id="8916080112145514151">如果您仍想連結您的 <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> 帳戶，請在開始登入程序的同一部裝置上開啟連結。如不想連結帳戶，請輕觸 [繼續] 以在這部裝置上進行登入程序。</translation>
 <translation id="8920674952994839257">重試</translation>
 <translation id="8939353296336237380">您原先想將 <ph name="START_STRONG" /><ph name="IDP_DISPLAY_NAME" /><ph name="END_STRONG" /> 連結至您的電子郵件帳戶，卻在另一部未登入帳戶的裝置上開啟了連結。</translation>
-<translation id="8971555482255213064">0:<ph name="PH_1" /> 秒後將重新發送驗證碼</translation>
+<translation id="8955469172512804617">輕觸 [<ph name="BTN" />] 即表示您同意《<ph name="PP" />》。</translation>
+<translation id="8980953965669178372">完成</translation>
 <translation id="8984161590699631096">摩洛哥</translation>
 <translation id="8994098794339484800">如果您不認識這部裝置，可能是有人試圖存取您的帳戶。建議您<ph name="START_LINK" />立即變更密碼<ph name="END_LINK" />。</translation>
 <translation id="900153878296575829">孟加拉</translation>
 <translation id="9022632332691561239">電話</translation>
 <translation id="9028063588419847334">芬蘭</translation>
 <translation id="9078135685219203661">阿拉伯聯合大公國</translation>
+<translation id="9085311482535098646">密碼不得少於 <ph name="MIN_PASSWORD_LENGTH" /> 個字元</translation>
 <translation id="9121203582272050974">您的電子郵件地址已通過驗證並變更完成</translation>
 <translation id="9156150178611681179">密碼</translation>
 <translation id="9168877696443530714">中非共和國</translation>


### PR DESCRIPTION
See notes about the translations: b/308003001#comment2 (internal link)

**Testing:**
I tested with the demo app and verified that the following work:
- Password policy errors (English)
- Weak password error (English)
- Sign in/up with password
- Sign in with Google (redirect + popup)
- Sign in with phone number
- Sign in anonymously
