### PR TITLE
Use inclusive language in signup form

### DIFF
--- a/soy/elements.soy
+++ b/soy/elements.soy
@@ -324,13 +324,13 @@
 
 
 /**
- * Renders two text input fields for setting first and last name.
+ * Renders a text input fields for setting displayName.
  */
 {template .name}
   {@param? name: string} /** The display name to prefill. */
   <div class="firebaseui-textfield mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
     <label class="mdl-textfield__label firebaseui-label" for="ui-sign-in-name-input">
-      {msg desc="Label of a field for setting the user's name."}First &amp; last name{/msg}
+      {msg desc="Label of a field for setting the user's name."}Full name{/msg}
     </label>
     <input
         type="text"

--- a/translations/en-GB.xtb
+++ b/translations/en-GB.xtb
@@ -377,7 +377,7 @@
 <translation id="6961220857430789248">A sign-in email with additional instructions was sent to <ph name="STRING" />. Check your email to complete sign-in.</translation>
 <translation id="6984204927251307445">Confirm email</translation>
 <translation id="6996552808101270965">Learn more</translation>
-<translation id="6999773882165218263">First name &amp;amp; surname</translation>
+<translation id="6999773882165218263">Full name</translation>
 <translation id="7012506961150923116">Grenada</translation>
 <translation id="7024571478138322659">Western Sahara</translation>
 <translation id="7025117765722694556">Request can not be executed in the current system state.</translation>


### PR DESCRIPTION
Not all of the people in the world have a first and last name.

See https://atlassian.design/content/inclusive-writing
> If you need to collect information about people’s identities, give people the option to choose not to answer, or to give a self-defined answer. When gathering information about names, use a “Full name” field instead of separating names by first name, last name, and salutation.

I recommend "Display Name" since this is the internal firebase name (`displayName`) but full name is a good start