### PR TITLE
feat(core): Add registerFramework util

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import { registerFramework } from "./register-framework";
+import pkgJson from '../package.json';
+
+registerFramework("core", pkgJson.version);
+
 export * from "./auth";
 export * from "./behaviors";
 export * from "./config";
@@ -21,3 +26,5 @@ export * from "./errors";
 export * from "./schemas";
 export * from "./country-data";
 export * from "./translations";
+export * from "./register-framework";
+

--- a/packages/core/src/register-framework.test.ts
+++ b/packages/core/src/register-framework.test.ts
@@ -18,7 +18,7 @@ describe("registerFramework", () => {
 
     registerFramework(framework, version);
 
-    expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+    expect(registerVersion).toHaveBeenCalledWith("firebase-ui-web", version, framework);
     expect(registerVersion).toHaveBeenCalledTimes(1);
   });
 
@@ -32,7 +32,7 @@ describe("registerFramework", () => {
 
     expect(registerVersion).toHaveBeenCalledTimes(frameworks.length);
     frameworks.forEach((framework) => {
-      expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+      expect(registerVersion).toHaveBeenCalledWith("firebase-ui-web", version, framework);
     });
   });
 
@@ -46,18 +46,8 @@ describe("registerFramework", () => {
 
     expect(registerVersion).toHaveBeenCalledTimes(versions.length);
     versions.forEach((version) => {
-      expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+      expect(registerVersion).toHaveBeenCalledWith("firebase-ui-web", version, framework);
     });
-  });
-
-  it("should handle empty string parameters", () => {
-    const framework = "";
-    const version = "";
-
-    registerFramework(framework, version);
-
-    expect(registerVersion).toHaveBeenCalledWith("firebase-ui", "", "");
-    expect(registerVersion).toHaveBeenCalledTimes(1);
   });
 
   it("should handle special characters in parameters", () => {
@@ -66,7 +56,7 @@ describe("registerFramework", () => {
 
     registerFramework(framework, version);
 
-    expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+    expect(registerVersion).toHaveBeenCalledWith("firebase-ui-web", version, framework);
     expect(registerVersion).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/register-framework.test.ts
+++ b/packages/core/src/register-framework.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerFramework } from "./register-framework";
+
+vi.mock("firebase/app", () => ({
+  registerVersion: vi.fn(),
+}));
+
+import { registerVersion } from "firebase/app";
+
+describe("registerFramework", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call registerVersion with correct parameters", () => {
+    const framework = "react";
+    const version = "1.0.0";
+
+    registerFramework(framework, version);
+
+    expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+    expect(registerVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle different framework types", () => {
+    const frameworks = ["react", "angular"];
+    const version = "2.0.0";
+
+    frameworks.forEach((framework) => {
+      registerFramework(framework, version);
+    });
+
+    expect(registerVersion).toHaveBeenCalledTimes(frameworks.length);
+    frameworks.forEach((framework) => {
+      expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+    });
+  });
+
+  it("should handle different version formats", () => {
+    const framework = "react";
+    const versions = ["1.0.0", "2.1.3", "0.0.1", "10.20.30"];
+
+    versions.forEach((version) => {
+      registerFramework(framework, version);
+    });
+
+    expect(registerVersion).toHaveBeenCalledTimes(versions.length);
+    versions.forEach((version) => {
+      expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+    });
+  });
+
+  it("should handle empty string parameters", () => {
+    const framework = "";
+    const version = "";
+
+    registerFramework(framework, version);
+
+    expect(registerVersion).toHaveBeenCalledWith("firebase-ui", "", "");
+    expect(registerVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle special characters in parameters", () => {
+    const framework = "react";
+    const version = "1.0.0-beta.1";
+
+    registerFramework(framework, version);
+
+    expect(registerVersion).toHaveBeenCalledWith("firebase-ui", version, framework);
+    expect(registerVersion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/register-framework.ts
+++ b/packages/core/src/register-framework.ts
@@ -1,0 +1,11 @@
+import { registerVersion } from "firebase/app";
+
+/**
+ * Register a framework with the FirebaseUI configuration.
+ * @internal
+ * @param framework The type of framework being registered.
+ * @param version The version of the framework being registered.
+ */
+export function registerFramework(framework: string, version: string) {
+  registerVersion("firebase-ui", version, framework);
+}

--- a/packages/core/src/register-framework.ts
+++ b/packages/core/src/register-framework.ts
@@ -7,5 +7,5 @@ import { registerVersion } from "firebase/app";
  * @param version The version of the framework being registered.
  */
 export function registerFramework(framework: string, version: string) {
-  registerVersion("firebase-ui", version, framework);
+  registerVersion("firebase-ui-web", version, framework);
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import { registerFramework } from "@firebase-ui/core";
+import pkgJson from '../package.json';
+
+registerFramework("react", pkgJson.version);
+
 export * from "./auth";
 export * from "./hooks";
 export * from "./components";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,9 +17,9 @@
 import { registerFramework } from "@firebase-ui/core";
 import pkgJson from '../package.json';
 
-registerFramework("react", pkgJson.version);
-
 export * from "./auth";
 export * from "./hooks";
 export * from "./components";
 export { FirebaseUIProvider, type FirebaseUIProviderProps } from "./context";
+
+registerFramework("react", pkgJson.version);


### PR DESCRIPTION
Adds an internal API called `registerFramework` which sets a component within the firebase js sdk for tracking