### PR TITLE
feat(core): Support autoUpgradeAnonymousUsers onUpgrade callback

### DIFF
--- a/packages/core/src/behaviors/anonymous-upgrade.test.ts
+++ b/packages/core/src/behaviors/anonymous-upgrade.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Auth, AuthCredential, AuthProvider, linkWithCredential, linkWithRedirect, User } from "firebase/auth";
-import { autoUpgradeAnonymousCredentialHandler, autoUpgradeAnonymousProviderHandler } from "./anonymous-upgrade";
+import { Auth, AuthCredential, AuthProvider, linkWithCredential, linkWithRedirect, User, UserCredential } from "firebase/auth";
+import { autoUpgradeAnonymousCredentialHandler, autoUpgradeAnonymousProviderHandler, autoUpgradeAnonymousUserRedirectHandler, OnUpgradeCallback } from "./anonymous-upgrade";
 import { createMockUI } from "~/tests/utils";
+import { getBehavior } from "~/behaviors";
 
 vi.mock("firebase/auth", () => ({
   linkWithCredential: vi.fn(),
   linkWithRedirect: vi.fn(),
+}));
+
+vi.mock("~/behaviors", () => ({
+  getBehavior: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -28,6 +33,38 @@ describe("autoUpgradeAnonymousCredentialHandler", () => {
     expect(mockUI.setState).toHaveBeenCalledWith("pending");
     expect(mockUI.setState).toHaveBeenCalledWith("idle");
     expect(result).toBe(mockResult);
+  });
+
+  it("should call onUpgrade callback when provided", async () => {
+    const mockUser = { isAnonymous: true, uid: "anonymous-123" } as User;
+    const mockAuth = { currentUser: mockUser } as Auth;
+    const mockUI = createMockUI({ auth: mockAuth });
+    const mockCredential = { providerId: "password" } as AuthCredential;
+    const mockResult = { user: { uid: "upgraded-123" } } as UserCredential;
+    
+    vi.mocked(linkWithCredential).mockResolvedValue(mockResult);
+    
+    const onUpgrade = vi.fn().mockResolvedValue(undefined);
+    
+    const result = await autoUpgradeAnonymousCredentialHandler(mockUI, mockCredential, onUpgrade);
+
+    expect(onUpgrade).toHaveBeenCalledWith(mockUI, "anonymous-123", mockResult);
+    expect(result).toBe(mockResult);
+  });
+
+  it("should handle onUpgrade callback errors", async () => {
+    const mockUser = { isAnonymous: true, uid: "anonymous-123" } as User;
+    const mockAuth = { currentUser: mockUser } as Auth;
+    const mockUI = createMockUI({ auth: mockAuth });
+    const mockCredential = { providerId: "password" } as AuthCredential;
+    const mockResult = { user: { uid: "upgraded-123" } } as UserCredential;
+    
+    vi.mocked(linkWithCredential).mockResolvedValue(mockResult);
+    
+    const onUpgrade = vi.fn().mockRejectedValue(new Error("Callback error"));
+    
+    await expect(autoUpgradeAnonymousCredentialHandler(mockUI, mockCredential, onUpgrade))
+      .rejects.toThrow("Callback error");
   });
 
   it("should not upgrade when user is not anonymous", async () => {
@@ -62,14 +99,55 @@ describe("autoUpgradeAnonymousProviderHandler", () => {
     const mockAuth = { currentUser: mockUser } as Auth;
     const mockUI = createMockUI({ auth: mockAuth });
     const mockProvider = { providerId: "google.com" } as AuthProvider;
+    const mockResult = { user: { uid: "upgraded-123" } } as UserCredential;
 
-    vi.mocked(linkWithRedirect).mockResolvedValue({} as never);
+    const mockProviderLinkStrategy = vi.fn().mockResolvedValue(mockResult);
+    vi.mocked(getBehavior).mockReturnValue(mockProviderLinkStrategy);
 
-    await autoUpgradeAnonymousProviderHandler(mockUI, mockProvider);
+    const localStorageSpy = vi.spyOn(Storage.prototype, 'setItem');
+    const localStorageRemoveSpy = vi.spyOn(Storage.prototype, 'removeItem');
 
-    expect(linkWithRedirect).toHaveBeenCalledWith(mockUser, mockProvider);
-    expect(mockUI.setState).toHaveBeenCalledWith("pending");
-    expect(mockUI.setState).not.toHaveBeenCalledWith("idle");
+    const result = await autoUpgradeAnonymousProviderHandler(mockUI, mockProvider);
+
+    expect(getBehavior).toHaveBeenCalledWith(mockUI, "providerLinkStrategy");
+    expect(mockProviderLinkStrategy).toHaveBeenCalledWith(mockUI, mockUser, mockProvider);
+    expect(localStorageSpy).toHaveBeenCalledWith("fbui:upgrade:oldUserId", "anonymous-123");
+    expect(localStorageRemoveSpy).toHaveBeenCalledWith("fbui:upgrade:oldUserId");
+    expect(result).toBe(mockResult);
+  });
+
+  it("should call onUpgrade callback when provided", async () => {
+    const mockUser = { isAnonymous: true, uid: "anonymous-123" } as User;
+    const mockAuth = { currentUser: mockUser } as Auth;
+    const mockUI = createMockUI({ auth: mockAuth });
+    const mockProvider = { providerId: "google.com" } as AuthProvider;
+    const mockResult = { user: { uid: "upgraded-123" } } as UserCredential;
+
+    const mockProviderLinkStrategy = vi.fn().mockResolvedValue(mockResult);
+    vi.mocked(getBehavior).mockReturnValue(mockProviderLinkStrategy);
+
+    const onUpgrade = vi.fn().mockResolvedValue(undefined);
+
+    const result = await autoUpgradeAnonymousProviderHandler(mockUI, mockProvider, onUpgrade);
+
+    expect(onUpgrade).toHaveBeenCalledWith(mockUI, "anonymous-123", mockResult);
+    expect(result).toBe(mockResult);
+  });
+
+  it("should handle onUpgrade callback errors", async () => {
+    const mockUser = { isAnonymous: true, uid: "anonymous-123" } as User;
+    const mockAuth = { currentUser: mockUser } as Auth;
+    const mockUI = createMockUI({ auth: mockAuth });
+    const mockProvider = { providerId: "google.com" } as AuthProvider;
+    const mockResult = { user: { uid: "upgraded-123" } } as UserCredential;
+
+    const mockProviderLinkStrategy = vi.fn().mockResolvedValue(mockResult);
+    vi.mocked(getBehavior).mockReturnValue(mockProviderLinkStrategy);
+
+    const onUpgrade = vi.fn().mockRejectedValue(new Error("Callback error"));
+
+    await expect(autoUpgradeAnonymousProviderHandler(mockUI, mockProvider, onUpgrade))
+      .rejects.toThrow("Callback error");
   });
 
   it("should not upgrade when user is not anonymous", async () => {
@@ -93,5 +171,79 @@ describe("autoUpgradeAnonymousProviderHandler", () => {
 
     expect(linkWithRedirect).not.toHaveBeenCalled();
     expect(mockUI.setState).not.toHaveBeenCalled();
+  });
+});
+
+describe("autoUpgradeAnonymousUserRedirectHandler", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("should call onUpgrade callback when oldUserId exists in localStorage", async () => {
+    const mockUI = createMockUI();
+    const mockCredential = { user: { uid: "upgraded-123" } } as UserCredential;
+    const oldUserId = "anonymous-123";
+    
+    window.localStorage.setItem("fbui:upgrade:oldUserId", oldUserId);
+    
+    const onUpgrade = vi.fn().mockResolvedValue(undefined);
+    
+    await autoUpgradeAnonymousUserRedirectHandler(mockUI, mockCredential, onUpgrade);
+    
+    expect(onUpgrade).toHaveBeenCalledWith(mockUI, oldUserId, mockCredential);
+    expect(window.localStorage.getItem("fbui:upgrade:oldUserId")).toBeNull();
+  });
+
+  it("should not call onUpgrade callback when no oldUserId in localStorage", async () => {
+    const mockUI = createMockUI();
+    const mockCredential = { user: { uid: "upgraded-123" } } as UserCredential;
+    
+    const onUpgrade = vi.fn().mockResolvedValue(undefined);
+    
+    await autoUpgradeAnonymousUserRedirectHandler(mockUI, mockCredential, onUpgrade);
+    
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("should not call onUpgrade callback when no credential provided", async () => {
+    const mockUI = createMockUI();
+    const oldUserId = "anonymous-123";
+    
+    window.localStorage.setItem("fbui:upgrade:oldUserId", oldUserId);
+    
+    const onUpgrade = vi.fn().mockResolvedValue(undefined);
+    
+    await autoUpgradeAnonymousUserRedirectHandler(mockUI, null, onUpgrade);
+    
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("should not call onUpgrade callback when no onUpgrade callback provided", async () => {
+    const mockUI = createMockUI();
+    const mockCredential = { user: { uid: "upgraded-123" } } as UserCredential;
+    const oldUserId = "anonymous-123";
+    
+    window.localStorage.setItem("fbui:upgrade:oldUserId", oldUserId);
+    
+    await autoUpgradeAnonymousUserRedirectHandler(mockUI, mockCredential);
+    
+    // Should not throw and should clean up localStorage even when no callback provided
+    expect(window.localStorage.getItem("fbui:upgrade:oldUserId")).toBeNull();
+  });
+
+  it("should handle onUpgrade callback errors", async () => {
+    const mockUI = createMockUI();
+    const mockCredential = { user: { uid: "upgraded-123" } } as UserCredential;
+    const oldUserId = "anonymous-123";
+    
+    window.localStorage.setItem("fbui:upgrade:oldUserId", oldUserId);
+    
+    const onUpgrade = vi.fn().mockRejectedValue(new Error("Callback error"));
+    
+    await expect(autoUpgradeAnonymousUserRedirectHandler(mockUI, mockCredential, onUpgrade))
+      .rejects.toThrow("Callback error");
+    
+    // Should clean up localStorage even when callback throws error
+    expect(window.localStorage.getItem("fbui:upgrade:oldUserId")).toBeNull();
   });
 });

--- a/packages/core/src/behaviors/anonymous-upgrade.ts
+++ b/packages/core/src/behaviors/anonymous-upgrade.ts
@@ -1,32 +1,66 @@
-import { AuthCredential, AuthProvider, linkWithCredential, linkWithRedirect } from "firebase/auth";
+import { AuthCredential, AuthProvider, linkWithCredential, linkWithRedirect, UserCredential } from "firebase/auth";
 import { FirebaseUIConfiguration } from "~/config";
-import { RedirectHandler } from "./utils";
 import { getBehavior } from "~/behaviors";
 
-export const autoUpgradeAnonymousCredentialHandler = async (ui: FirebaseUIConfiguration, credential: AuthCredential) => {
+export type OnUpgradeCallback = (ui: FirebaseUIConfiguration, oldUserId: string, credential: UserCredential) => Promise<void> | void;
+
+export const autoUpgradeAnonymousCredentialHandler = async (ui: FirebaseUIConfiguration, credential: AuthCredential, onUpgrade?: OnUpgradeCallback) => {
   const currentUser = ui.auth.currentUser;
 
   if (!currentUser?.isAnonymous) {
     return;
   }
 
+  const oldUserId = currentUser.uid;
+
   ui.setState("pending");
   const result = await linkWithCredential(currentUser, credential);
+
+  if (onUpgrade) {
+    await onUpgrade(ui, oldUserId, result);
+  }
 
   ui.setState("idle");
   return result;
 };
 
-export const autoUpgradeAnonymousProviderHandler = async (ui: FirebaseUIConfiguration, provider: AuthProvider) => {
+export const autoUpgradeAnonymousProviderHandler = async (ui: FirebaseUIConfiguration, provider: AuthProvider, onUpgrade?: OnUpgradeCallback) => {
   const currentUser = ui.auth.currentUser;
 
   if (!currentUser?.isAnonymous) {
     return;
   }
 
-  return getBehavior(ui, "providerLinkStrategy")(ui, currentUser, provider);
+  const oldUserId = currentUser.uid;
+
+  window.localStorage.setItem("fbui:upgrade:oldUserId", oldUserId);
+
+  const result = await getBehavior(ui, "providerLinkStrategy")(ui, currentUser, provider);
+
+  // If we got here, the user has been linked via a popup, so we need to call the onUpgrade callback
+  // and delete the oldUserId from localStorage.
+  // If we didn't get here, they'll be redirected and we'll handle the result inside of the autoUpgradeAnonymousUserRedirectHandler.
+
+  window.localStorage.removeItem("fbui:upgrade:oldUserId");
+
+  if (onUpgrade) {
+    await onUpgrade(ui, oldUserId, result);
+  }
+
+  return result;
 };
 
-export const autoUpgradeAnonymousUserRedirectHandler: RedirectHandler = async () => {
-  // TODO
+export const autoUpgradeAnonymousUserRedirectHandler = async (ui: FirebaseUIConfiguration, credential: UserCredential | null, onUpgrade?: OnUpgradeCallback) => {
+  const oldUserId = window.localStorage.getItem("fbui:upgrade:oldUserId");
+
+  // Always clean up localStorage once we've retrieved the oldUserId
+  if (oldUserId) {
+    window.localStorage.removeItem("fbui:upgrade:oldUserId");
+  }
+
+  if (!onUpgrade || !oldUserId || !credential) {
+    return;
+  }
+
+  await onUpgrade(ui, oldUserId, credential);
 };


### PR DESCRIPTION
Supports allowing the users to define a callback which is called on a successful account upgrade:

```
autoUpgradeAnonymousUsers({
  onUpgrade: (ui, oldUserId, cred) => {
    // Perform some async logic to merge accounts for example.
  },
})
```