### PR TITLE
fix(*): Rename FirebaseUIConfiguration -> FirebaseUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,11 @@ The initializeUI function accepts an options object that allows you to customize
 ### Type Definition
 
 ```js
-type FirebaseUIConfigurationOptions = {
+type FirebaseUIOptions = {
   app: FirebaseApp;
-  locale?: Locale | undefined;
-  translations?: RegisteredTranslations[] | undefined;
-  behaviors?: Partial<Behavior<keyof BehaviorHandlers>>[] | undefined;
-  recaptchaMode?: 'normal' | 'invisible' | undefined;
+  auth?: Auth;
+  locale?: Locale;
+  behaviors?: Behavior<any>[];
 };
 ```
 
@@ -290,7 +289,7 @@ const ui = initializeUI({
 Configuration Type:
 
 ```js
-type FirebaseUIConfigurationOptions = {
+type FirebaseUIOptions = {
   app: FirebaseApp;
   locale?: Locale | undefined;
   translations?: RegisteredTranslations[] | undefined;
@@ -303,61 +302,61 @@ type FirebaseUIConfigurationOptions = {
 
 **signInWithEmailAndPassword**: Signs in the user based on an email/password credential.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _email_: string
 - _password_: string
 
 **createUserWithEmailAndPassword**: Creates a user account based on an email/password credential.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _email_: string
 - _password_: string
 
 **signInWithPhoneNumber**: Signs in the user based on a provided phone number, using ReCaptcha to verify the sign-in.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _phoneNumber_: string
 - _recaptchaVerifier_: string
 
 **confirmPhoneNumber**: Verifies the phonenumber credential and signs in the user.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _confirmationResult_: [ConfirmationResult](https://firebase.google.com/docs/reference/node/firebase.auth.ConfirmationResult)
 - _verificationCode_: string
 
 **sendPasswordResetEmail**: Sends password reset instructions to an email account.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _email_: string
 
 **sendSignInLinkToEmail**: Send an sign-in links to an email account.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _email_: string
 
 **signInWithEmailLink**: Signs in with the user with the email link. If `autoUpgradeAnonymousCredential` then a pending credential will be handled.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _email_: string
 - _link_: string
 
 **signInAnonymously**: Signs in as an anonymous user.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 
 **signInWithOAuth**: Signs in with a provider such as Google via a redirect link. If `autoUpgradeAnonymousCredential` then the account will upgraded.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _provider_: [AuthProvider](https://firebase.google.com/docs/reference/node/firebase.auth.AuthProvider)
 
 **completeEmailLinkSignIn**: Completes the signing process based on a user signing in with an email link.
 
-- _ui_: FirebaseUIConfiguration
+- _ui_: FirebaseUI
 - _currentUrl_: string
 
 #### Provide a Store via Context
 
-Using the returned `FirebaseUIConfiguration`, it is reccomended to use local context/providers/dependency-injection to expose the FirebaseUIConfiguration to the application. Here is an example context wrapper which accepts the configuration as a `ui` parameter:
+Using the returned `FirebaseUI`, it is reccomended to use local context/providers/dependency-injection to expose the FirebaseUI to the application. Here is an example context wrapper which accepts the configuration as a `ui` parameter:
 
 ```js
 /** Creates a framework-agnostic context for Firebase UI configuration **/
@@ -391,7 +390,7 @@ export function createFirebaseUIContext(initialConfig) {
 FirebaseUI Configuration Type:
 
 ```js
-export type FirebaseUIConfiguration = {
+export type FirebaseUI = {
   app: FirebaseApp,
   getAuth: () => Auth,
   setLocale: (locale: Locale) => void,
@@ -556,7 +555,7 @@ The core library provides a function for handling errors.
 
 ```js
 export function handleFirebaseError(
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   error: any,
   opts?: {
     enableHandleExistingCredential?: boolean;

--- a/packages/angular/src/lib/auth/forms/email-link-form/email-link-form.component.ts
+++ b/packages/angular/src/lib/auth/forms/email-link-form/email-link-form.component.ts
@@ -25,7 +25,7 @@ import {
   FirebaseUIError,
   completeEmailLinkSignIn,
   sendSignInLinkToEmail,
-  FirebaseUIConfiguration,
+  FirebaseUI,
 } from "@firebase-ui/core";
 import { firstValueFrom } from "rxjs";
 
@@ -75,7 +75,7 @@ export class EmailLinkFormComponent implements OnInit {
   formError: string | null = null;
   emailSent = false;
   private formSchema: any;
-  private config: FirebaseUIConfiguration;
+  private config: FirebaseUI;
 
   form = injectForm({
     defaultValues: {

--- a/packages/angular/src/lib/auth/forms/email-password-form/email-password-form.component.ts
+++ b/packages/angular/src/lib/auth/forms/email-password-form/email-password-form.component.ts
@@ -23,7 +23,7 @@ import { TermsAndPrivacyComponent } from "../../../components/terms-and-privacy/
 import {
   createEmailFormSchema,
   EmailFormSchema,
-  FirebaseUIConfiguration,
+  FirebaseUI,
   FirebaseUIError,
   signInWithEmailAndPassword,
 } from "@firebase-ui/core";
@@ -111,7 +111,7 @@ export class EmailPasswordFormComponent implements OnInit {
 
   formError: string | null = null;
   private formSchema: any;
-  private config: FirebaseUIConfiguration;
+  private config: FirebaseUI;
 
   form = injectForm({
     defaultValues: {

--- a/packages/angular/src/lib/auth/forms/forgot-password-form/forgot-password-form.component.ts
+++ b/packages/angular/src/lib/auth/forms/forgot-password-form/forgot-password-form.component.ts
@@ -21,12 +21,7 @@ import { FirebaseUI } from "../../../provider";
 import { Auth } from "@angular/fire/auth";
 import { ButtonComponent } from "../../../components/button/button.component";
 import { TermsAndPrivacyComponent } from "../../../components/terms-and-privacy/terms-and-privacy.component";
-import {
-  createForgotPasswordFormSchema,
-  FirebaseUIConfiguration,
-  FirebaseUIError,
-  sendPasswordResetEmail,
-} from "@firebase-ui/core";
+import { createForgotPasswordFormSchema, FirebaseUI, FirebaseUIError, sendPasswordResetEmail } from "@firebase-ui/core";
 import { firstValueFrom } from "rxjs";
 import { Router } from "@angular/router";
 
@@ -85,7 +80,7 @@ export class ForgotPasswordFormComponent implements OnInit {
   formError: string | null = null;
   emailSent = false;
   private formSchema: any;
-  private config: FirebaseUIConfiguration;
+  private config: FirebaseUI;
 
   form = injectForm({
     defaultValues: {

--- a/packages/angular/src/lib/auth/forms/phone-form/phone-form.component.ts
+++ b/packages/angular/src/lib/auth/forms/phone-form/phone-form.component.ts
@@ -31,7 +31,7 @@ import {
   formatPhoneNumberWithCountry,
   confirmPhoneNumber,
   signInWithPhoneNumber,
-  FirebaseUIConfiguration,
+  FirebaseUI,
 } from "@firebase-ui/core";
 import { interval, Subscription, firstValueFrom } from "rxjs";
 import { Router } from "@angular/router";
@@ -103,7 +103,7 @@ export class PhoneNumberFormComponent implements OnInit, OnDestroy {
   recaptchaVerifier: RecaptchaVerifier | null = null;
   selectedCountry: CountryData = countryData[0];
   private formSchema: any;
-  private config: FirebaseUIConfiguration;
+  private config: FirebaseUI;
 
   form = injectForm({
     defaultValues: {

--- a/packages/angular/src/lib/auth/forms/register-form/register-form.component.ts
+++ b/packages/angular/src/lib/auth/forms/register-form/register-form.component.ts
@@ -24,7 +24,7 @@ import {
   EmailFormSchema,
   FirebaseUIError,
   createUserWithEmailAndPassword,
-  FirebaseUIConfiguration,
+  FirebaseUI,
 } from "@firebase-ui/core";
 import { Auth } from "@angular/fire/auth";
 import { TermsAndPrivacyComponent } from "../../../components/terms-and-privacy/terms-and-privacy.component";
@@ -106,7 +106,7 @@ export class RegisterFormComponent implements OnInit {
 
   formError: string | null = null;
   private formSchema: any;
-  private config: FirebaseUIConfiguration;
+  private config: FirebaseUI;
 
   form = injectForm({
     defaultValues: {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -33,13 +33,13 @@ import {
   type PhoneInfoOptions,
 } from "firebase/auth";
 import QRCode from "qrcode-generator";
-import { type FirebaseUIConfiguration } from "./config";
+import { type FirebaseUI } from "./config";
 import { handleFirebaseError } from "./errors";
 import { hasBehavior, getBehavior } from "./behaviors/index";
 import { FirebaseError } from "firebase/app";
 import { getTranslation } from "./translations";
 
-async function handlePendingCredential(_ui: FirebaseUIConfiguration, user: UserCredential): Promise<UserCredential> {
+async function handlePendingCredential(_ui: FirebaseUI, user: UserCredential): Promise<UserCredential> {
   const pendingCredString = window.sessionStorage.getItem("pendingCred");
   if (!pendingCredString) return user;
 
@@ -55,7 +55,7 @@ async function handlePendingCredential(_ui: FirebaseUIConfiguration, user: UserC
 }
 
 export async function signInWithEmailAndPassword(
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   email: string,
   password: string
 ): Promise<UserCredential> {
@@ -81,7 +81,7 @@ export async function signInWithEmailAndPassword(
 }
 
 export async function createUserWithEmailAndPassword(
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   email: string,
   password: string,
   displayName?: string
@@ -121,7 +121,7 @@ export async function createUserWithEmailAndPassword(
 }
 
 export async function verifyPhoneNumber(
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   phoneNumber: PhoneInfoOptions | string,
   appVerifier: ApplicationVerifier
 ): Promise<string> {
@@ -137,7 +137,7 @@ export async function verifyPhoneNumber(
 }
 
 export async function confirmPhoneNumber(
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   verificationId: string,
   verificationCode: string
 ): Promise<UserCredential> {
@@ -163,7 +163,7 @@ export async function confirmPhoneNumber(
   }
 }
 
-export async function sendPasswordResetEmail(ui: FirebaseUIConfiguration, email: string): Promise<void> {
+export async function sendPasswordResetEmail(ui: FirebaseUI, email: string): Promise<void> {
   try {
     ui.setState("pending");
     await _sendPasswordResetEmail(ui.auth, email);
@@ -174,7 +174,7 @@ export async function sendPasswordResetEmail(ui: FirebaseUIConfiguration, email:
   }
 }
 
-export async function sendSignInLinkToEmail(ui: FirebaseUIConfiguration, email: string): Promise<void> {
+export async function sendSignInLinkToEmail(ui: FirebaseUI, email: string): Promise<void> {
   try {
     ui.setState("pending");
     const actionCodeSettings = {
@@ -193,19 +193,12 @@ export async function sendSignInLinkToEmail(ui: FirebaseUIConfiguration, email: 
   }
 }
 
-export async function signInWithEmailLink(
-  ui: FirebaseUIConfiguration,
-  email: string,
-  link: string
-): Promise<UserCredential> {
+export async function signInWithEmailLink(ui: FirebaseUI, email: string, link: string): Promise<UserCredential> {
   const credential = EmailAuthProvider.credentialWithLink(email, link);
   return signInWithCredential(ui, credential);
 }
 
-export async function signInWithCredential(
-  ui: FirebaseUIConfiguration,
-  credential: AuthCredential
-): Promise<UserCredential> {
+export async function signInWithCredential(ui: FirebaseUI, credential: AuthCredential): Promise<UserCredential> {
   try {
     ui.setState("pending");
     if (hasBehavior(ui, "autoUpgradeAnonymousCredential")) {
@@ -227,7 +220,7 @@ export async function signInWithCredential(
   }
 }
 
-export async function signInAnonymously(ui: FirebaseUIConfiguration): Promise<UserCredential> {
+export async function signInAnonymously(ui: FirebaseUI): Promise<UserCredential> {
   try {
     ui.setState("pending");
     const result = await _signInAnonymously(ui.auth);
@@ -239,10 +232,7 @@ export async function signInAnonymously(ui: FirebaseUIConfiguration): Promise<Us
   }
 }
 
-export async function signInWithProvider(
-  ui: FirebaseUIConfiguration,
-  provider: AuthProvider
-): Promise<UserCredential | never> {
+export async function signInWithProvider(ui: FirebaseUI, provider: AuthProvider): Promise<UserCredential | never> {
   try {
     ui.setState("pending");
     if (hasBehavior(ui, "autoUpgradeAnonymousProvider")) {
@@ -268,10 +258,7 @@ export async function signInWithProvider(
   }
 }
 
-export async function completeEmailLinkSignIn(
-  ui: FirebaseUIConfiguration,
-  currentUrl: string
-): Promise<UserCredential | null> {
+export async function completeEmailLinkSignIn(ui: FirebaseUI, currentUrl: string): Promise<UserCredential | null> {
   try {
     if (!_isSignInWithEmailLink(ui.auth, currentUrl)) {
       return null;
@@ -291,12 +278,7 @@ export async function completeEmailLinkSignIn(
   }
 }
 
-export function generateTotpQrCode(
-  ui: FirebaseUIConfiguration,
-  secret: TotpSecret,
-  accountName?: string,
-  issuer?: string
-): string {
+export function generateTotpQrCode(ui: FirebaseUI, secret: TotpSecret, accountName?: string, issuer?: string): string {
   const currentUser = ui.auth.currentUser;
 
   if (!currentUser) {

--- a/packages/core/src/behaviors/anonymous-upgrade.ts
+++ b/packages/core/src/behaviors/anonymous-upgrade.ts
@@ -1,15 +1,11 @@
 import { type AuthCredential, type AuthProvider, linkWithCredential, type UserCredential } from "firebase/auth";
-import { type FirebaseUIConfiguration } from "~/config";
+import { type FirebaseUI } from "~/config";
 import { getBehavior } from "~/behaviors";
 
-export type OnUpgradeCallback = (
-  ui: FirebaseUIConfiguration,
-  oldUserId: string,
-  credential: UserCredential
-) => Promise<void> | void;
+export type OnUpgradeCallback = (ui: FirebaseUI, oldUserId: string, credential: UserCredential) => Promise<void> | void;
 
 export const autoUpgradeAnonymousCredentialHandler = async (
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   credential: AuthCredential,
   onUpgrade?: OnUpgradeCallback
 ) => {
@@ -31,7 +27,7 @@ export const autoUpgradeAnonymousCredentialHandler = async (
 };
 
 export const autoUpgradeAnonymousProviderHandler = async (
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   provider: AuthProvider,
   onUpgrade?: OnUpgradeCallback
 ) => {
@@ -61,7 +57,7 @@ export const autoUpgradeAnonymousProviderHandler = async (
 };
 
 export const autoUpgradeAnonymousUserRedirectHandler = async (
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   credential: UserCredential | null,
   onUpgrade?: OnUpgradeCallback
 ) => {

--- a/packages/core/src/behaviors/index.ts
+++ b/packages/core/src/behaviors/index.ts
@@ -1,4 +1,4 @@
-import type { FirebaseUIConfiguration } from "~/config";
+import type { FirebaseUI } from "~/config";
 import type { RecaptchaVerifier, UserCredential } from "firebase/auth";
 import * as anonymousUpgradeHandlers from "./anonymous-upgrade";
 import * as autoAnonymousLoginHandlers from "./auto-anonymous-login";
@@ -24,17 +24,15 @@ type Registry = {
   autoUpgradeAnonymousProvider: CallableBehavior<typeof anonymousUpgradeHandlers.autoUpgradeAnonymousProviderHandler>;
   autoUpgradeAnonymousUserRedirectHandler: RedirectBehavior<
     (
-      ui: FirebaseUIConfiguration,
+      ui: FirebaseUI,
       credential: UserCredential | null,
       onUpgrade?: anonymousUpgradeHandlers.OnUpgradeCallback
     ) => ReturnType<typeof anonymousUpgradeHandlers.autoUpgradeAnonymousUserRedirectHandler>
   >;
-  recaptchaVerification: CallableBehavior<(ui: FirebaseUIConfiguration, element: HTMLElement) => RecaptchaVerifier>;
+  recaptchaVerification: CallableBehavior<(ui: FirebaseUI, element: HTMLElement) => RecaptchaVerifier>;
   providerSignInStrategy: CallableBehavior<providerStrategyHandlers.ProviderSignInStrategyHandler>;
   providerLinkStrategy: CallableBehavior<providerStrategyHandlers.ProviderLinkStrategyHandler>;
-  oneTapSignIn: InitBehavior<
-    (ui: FirebaseUIConfiguration) => ReturnType<typeof oneTapSignInHandlers.oneTapSignInHandler>
-  >;
+  oneTapSignIn: InitBehavior<(ui: FirebaseUI) => ReturnType<typeof oneTapSignInHandlers.oneTapSignInHandler>>;
   requireDisplayName: CallableBehavior<typeof requireDisplayNameHandlers.requireDisplayNameHandler>;
   countryCodes: CallableBehavior<typeof countryCodesHandlers.countryCodesHandler>;
 };
@@ -114,11 +112,11 @@ export function countryCodes(options?: countryCodesHandlers.CountryCodesOptions)
   };
 }
 
-export function hasBehavior<T extends keyof Registry>(ui: FirebaseUIConfiguration, key: T): boolean {
+export function hasBehavior<T extends keyof Registry>(ui: FirebaseUI, key: T): boolean {
   return !!ui.behaviors[key];
 }
 
-export function getBehavior<T extends keyof Registry>(ui: FirebaseUIConfiguration, key: T): Registry[T]["handler"] {
+export function getBehavior<T extends keyof Registry>(ui: FirebaseUI, key: T): Registry[T]["handler"] {
   if (!hasBehavior(ui, key)) {
     throw new Error(`Behavior ${key} not found`);
   }

--- a/packages/core/src/behaviors/one-tap.ts
+++ b/packages/core/src/behaviors/one-tap.ts
@@ -1,6 +1,6 @@
 import { GoogleAuthProvider } from "firebase/auth";
 import type { IdConfiguration } from "google-one-tap";
-import type { FirebaseUIConfiguration } from "~/config";
+import type { FirebaseUI } from "~/config";
 import { signInWithCredential } from "~/auth";
 
 export type OneTapSignInOptions = {
@@ -12,7 +12,7 @@ export type OneTapSignInOptions = {
   logLevel?: IdConfiguration["log_level"];
 };
 
-export const oneTapSignInHandler = async (ui: FirebaseUIConfiguration, options: OneTapSignInOptions) => {
+export const oneTapSignInHandler = async (ui: FirebaseUI, options: OneTapSignInOptions) => {
   // Only show one-tap if user is not signed in OR if they are anonymous.
   // Don't show if user is already signed in with a real account.
   if (ui.auth.currentUser && !ui.auth.currentUser.isAnonymous) {

--- a/packages/core/src/behaviors/provider-strategy.ts
+++ b/packages/core/src/behaviors/provider-strategy.ts
@@ -7,14 +7,11 @@ import {
   type User,
   type UserCredential,
 } from "firebase/auth";
-import { type FirebaseUIConfiguration } from "~/config";
+import { type FirebaseUI } from "~/config";
 
-export type ProviderSignInStrategyHandler = (
-  ui: FirebaseUIConfiguration,
-  provider: AuthProvider
-) => Promise<never | UserCredential>;
+export type ProviderSignInStrategyHandler = (ui: FirebaseUI, provider: AuthProvider) => Promise<never | UserCredential>;
 export type ProviderLinkStrategyHandler = (
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   user: User,
   provider: AuthProvider
 ) => Promise<never | UserCredential>;

--- a/packages/core/src/behaviors/recaptcha.test.ts
+++ b/packages/core/src/behaviors/recaptcha.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { RecaptchaVerifier } from "firebase/auth";
 import { recaptchaVerificationHandler, type RecaptchaVerificationOptions } from "./recaptcha";
-import type { FirebaseUIConfiguration } from "~/config";
+import type { FirebaseUI } from "~/config";
 import { createMockUI } from "~/tests/utils";
 
 vi.mock("firebase/auth", () => ({
@@ -79,7 +79,7 @@ describe("Recaptcha Verification Handler", () => {
     it("should pass correct auth instance", () => {
       const mockUI = createMockUI();
       const customAuth = { uid: "test-uid" } as any;
-      const customUI = { auth: customAuth } as FirebaseUIConfiguration;
+      const customUI = { auth: customAuth } as FirebaseUI;
 
       recaptchaVerificationHandler(customUI, mockElement);
 

--- a/packages/core/src/behaviors/recaptcha.ts
+++ b/packages/core/src/behaviors/recaptcha.ts
@@ -1,5 +1,5 @@
 import { RecaptchaVerifier } from "firebase/auth";
-import { type FirebaseUIConfiguration } from "~/config";
+import { type FirebaseUI } from "~/config";
 
 export type RecaptchaVerificationOptions = {
   size?: "normal" | "invisible" | "compact";
@@ -8,7 +8,7 @@ export type RecaptchaVerificationOptions = {
 };
 
 export const recaptchaVerificationHandler = (
-  ui: FirebaseUIConfiguration,
+  ui: FirebaseUI,
   element: HTMLElement,
   options?: RecaptchaVerificationOptions
 ) => {

--- a/packages/core/src/behaviors/require-display-name.ts
+++ b/packages/core/src/behaviors/require-display-name.ts
@@ -1,6 +1,6 @@
 import { updateProfile, type User } from "firebase/auth";
-import { type FirebaseUIConfiguration } from "~/config";
+import { type FirebaseUI } from "~/config";
 
-export const requireDisplayNameHandler = async (_: FirebaseUIConfiguration, user: User, displayName: string) => {
+export const requireDisplayNameHandler = async (_: FirebaseUI, user: User, displayName: string) => {
   await updateProfile(user, { displayName });
 };

--- a/packages/core/src/behaviors/utils.test.ts
+++ b/packages/core/src/behaviors/utils.test.ts
@@ -11,7 +11,7 @@ import {
   type InitHandler,
 } from "./utils";
 import type { UserCredential } from "firebase/auth";
-import type { FirebaseUIConfiguration } from "~/config";
+import type { FirebaseUI } from "~/config";
 
 describe("Behaviors Utils", () => {
   describe("callableBehavior", () => {
@@ -75,7 +75,7 @@ describe("Behaviors Utils", () => {
       expect(behavior.type).toBe("redirect");
       expect(behavior.handler).toBe(handler);
 
-      const mockUI = {} as FirebaseUIConfiguration;
+      const mockUI = {} as FirebaseUI;
       const mockResult = {} as UserCredential;
 
       await behavior.handler(mockUI, mockResult);
@@ -110,7 +110,7 @@ describe("Behaviors Utils", () => {
       expect(behavior.type).toBe("init");
       expect(behavior.handler).toBe(handler);
 
-      const mockUI = {} as FirebaseUIConfiguration;
+      const mockUI = {} as FirebaseUI;
 
       await behavior.handler(mockUI);
       expect(handler).toHaveBeenCalledWith(mockUI);
@@ -123,7 +123,7 @@ describe("Behaviors Utils", () => {
       expect(behavior.type).toBe("init");
       expect(behavior.handler).toBe(handler);
 
-      const mockUI = {} as FirebaseUIConfiguration;
+      const mockUI = {} as FirebaseUI;
 
       behavior.handler(mockUI);
       expect(handler).toHaveBeenCalledWith(mockUI);

--- a/packages/core/src/behaviors/utils.ts
+++ b/packages/core/src/behaviors/utils.ts
@@ -1,10 +1,10 @@
 import type { UserCredential } from "firebase/auth";
-import type { FirebaseUIConfiguration } from "~/config";
+import type { FirebaseUI } from "~/config";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CallableHandler<T extends (...args: any[]) => any = (...args: any[]) => any> = T;
-export type InitHandler = (ui: FirebaseUIConfiguration) => Promise<void> | void;
-export type RedirectHandler = (ui: FirebaseUIConfiguration, result: UserCredential | null) => Promise<void> | void;
+export type InitHandler = (ui: FirebaseUI) => Promise<void> | void;
+export type RedirectHandler = (ui: FirebaseUI, result: UserCredential | null) => Promise<void> | void;
 
 export type CallableBehavior<T extends CallableHandler = CallableHandler> = {
   type: "callable";

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,9 +1,9 @@
 import { FirebaseApp } from "firebase/app";
 import { Auth, MultiFactorResolver } from "firebase/auth";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { initializeUI } from "./config";
 import { enUs, registerLocale } from "@firebase-ui/translations";
-import { autoUpgradeAnonymousUsers, autoAnonymousLogin, defaultBehaviors } from "./behaviors";
+import { autoUpgradeAnonymousUsers, autoAnonymousLogin } from "./behaviors";
 
 // Mock Firebase Auth
 vi.mock("firebase/auth", () => ({

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -22,7 +22,7 @@ import { type Behavior, type Behaviors, defaultBehaviors } from "./behaviors";
 import type { InitBehavior, RedirectBehavior } from "./behaviors/utils";
 import { type FirebaseUIState } from "./state";
 
-export type FirebaseUIConfigurationOptions = {
+export type FirebaseUIOptions = {
   app: FirebaseApp;
   auth?: Auth;
   locale?: RegisteredLocale;
@@ -30,7 +30,7 @@ export type FirebaseUIConfigurationOptions = {
   behaviors?: Behavior<any>[];
 };
 
-export type FirebaseUIConfiguration = {
+export type FirebaseUI = {
   app: FirebaseApp;
   auth: Auth;
   setLocale: (locale: RegisteredLocale) => void;
@@ -42,11 +42,11 @@ export type FirebaseUIConfiguration = {
   setMultiFactorResolver: (multiFactorResolver?: MultiFactorResolver) => void;
 };
 
-export const $config = map<Record<string, DeepMapStore<FirebaseUIConfiguration>>>({});
+export const $config = map<Record<string, DeepMapStore<FirebaseUI>>>({});
 
-export type FirebaseUI = DeepMapStore<FirebaseUIConfiguration>;
+export type FirebaseUIStore = DeepMapStore<FirebaseUI>;
 
-export function initializeUI(config: FirebaseUIConfigurationOptions, name: string = "[DEFAULT]"): FirebaseUI {
+export function initializeUI(config: FirebaseUIOptions, name: string = "[DEFAULT]"): FirebaseUIStore {
   // Reduce the behaviors to a single object.
   const behaviors = config.behaviors?.reduce<Behavior>((acc, behavior) => {
     return {
@@ -57,7 +57,7 @@ export function initializeUI(config: FirebaseUIConfigurationOptions, name: strin
 
   $config.setKey(
     name,
-    deepMap<FirebaseUIConfiguration>({
+    deepMap<FirebaseUI>({
       app: config.app,
       auth: config.auth || getAuth(config.app),
       locale: config.locale ?? enUs,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -17,10 +17,10 @@
 import { ERROR_CODE_MAP, type ErrorCode } from "@firebase-ui/translations";
 import { FirebaseError } from "firebase/app";
 import { type AuthCredential, getMultiFactorResolver, type MultiFactorError } from "firebase/auth";
-import { type FirebaseUIConfiguration } from "./config";
+import { type FirebaseUI } from "./config";
 import { getTranslation } from "./translations";
 export class FirebaseUIError extends FirebaseError {
-  constructor(ui: FirebaseUIConfiguration, error: FirebaseError) {
+  constructor(ui: FirebaseUI, error: FirebaseError) {
     const message = getTranslation(ui, "errors", ERROR_CODE_MAP[error.code as ErrorCode]);
     super(error.code, message || error.message);
 
@@ -29,7 +29,7 @@ export class FirebaseUIError extends FirebaseError {
   }
 }
 
-export function handleFirebaseError(ui: FirebaseUIConfiguration, error: unknown): never {
+export function handleFirebaseError(ui: FirebaseUI, error: unknown): never {
   // If it's not a Firebase error, then we just throw it and preserve the original error.
   if (!isFirebaseError(error)) {
     throw error;

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -16,21 +16,21 @@
 
 import * as z from "zod";
 import { getTranslation } from "./translations";
-import { type FirebaseUIConfiguration } from "./config";
+import { type FirebaseUI } from "./config";
 import { hasBehavior } from "./behaviors";
 
 export const LoginTypes = ["email", "phone", "anonymous", "emailLink", "google"] as const;
 export type LoginType = (typeof LoginTypes)[number];
 export type AuthMode = "signIn" | "signUp";
 
-export function createSignInAuthFormSchema(ui: FirebaseUIConfiguration) {
+export function createSignInAuthFormSchema(ui: FirebaseUI) {
   return z.object({
     email: z.email(getTranslation(ui, "errors", "invalidEmail")),
     password: z.string().min(8, getTranslation(ui, "errors", "weakPassword")),
   });
 }
 
-export function createSignUpAuthFormSchema(ui: FirebaseUIConfiguration) {
+export function createSignUpAuthFormSchema(ui: FirebaseUI) {
   const requireDisplayName = hasBehavior(ui, "requireDisplayName");
   const displayNameRequiredMessage = getTranslation(ui, "errors", "displayNameRequired");
 
@@ -43,19 +43,19 @@ export function createSignUpAuthFormSchema(ui: FirebaseUIConfiguration) {
   });
 }
 
-export function createForgotPasswordAuthFormSchema(ui: FirebaseUIConfiguration) {
+export function createForgotPasswordAuthFormSchema(ui: FirebaseUI) {
   return z.object({
     email: z.email(getTranslation(ui, "errors", "invalidEmail")),
   });
 }
 
-export function createEmailLinkAuthFormSchema(ui: FirebaseUIConfiguration) {
+export function createEmailLinkAuthFormSchema(ui: FirebaseUI) {
   return z.object({
     email: z.email(getTranslation(ui, "errors", "invalidEmail")),
   });
 }
 
-export function createPhoneAuthNumberFormSchema(ui: FirebaseUIConfiguration) {
+export function createPhoneAuthNumberFormSchema(ui: FirebaseUI) {
   return z.object({
     phoneNumber: z
       .string()
@@ -64,7 +64,7 @@ export function createPhoneAuthNumberFormSchema(ui: FirebaseUIConfiguration) {
   });
 }
 
-export function createPhoneAuthVerifyFormSchema(ui: FirebaseUIConfiguration) {
+export function createPhoneAuthVerifyFormSchema(ui: FirebaseUI) {
   return z.object({
     verificationId: z.string().min(1, getTranslation(ui, "errors", "missingVerificationId")),
     verificationCode: z.string().refine((val) => !val || val.length >= 6, {

--- a/packages/core/src/translations.ts
+++ b/packages/core/src/translations.ts
@@ -19,12 +19,8 @@ import {
   type TranslationCategory,
   type TranslationKey,
 } from "@firebase-ui/translations";
-import { type FirebaseUIConfiguration } from "./config";
+import { type FirebaseUI } from "./config";
 
-export function getTranslation<T extends TranslationCategory>(
-  ui: FirebaseUIConfiguration,
-  category: T,
-  key: TranslationKey<T>
-) {
+export function getTranslation<T extends TranslationCategory>(ui: FirebaseUI, category: T, key: TranslationKey<T>) {
   return _getTranslation(ui.locale, category, key);
 }

--- a/packages/core/tests/utils.ts
+++ b/packages/core/tests/utils.ts
@@ -3,9 +3,9 @@ import { vi } from "vitest";
 import type { FirebaseApp } from "firebase/app";
 import type { Auth } from "firebase/auth";
 import { enUs } from "@firebase-ui/translations";
-import { FirebaseUIConfiguration } from "../src/config";
+import { FirebaseUI } from "../src/config";
 
-export function createMockUI(overrides?: Partial<FirebaseUIConfiguration>): FirebaseUIConfiguration {
+export function createMockUI(overrides?: Partial<FirebaseUI>): FirebaseUI {
   return {
     app: {} as FirebaseApp,
     auth: {} as Auth,

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { type FirebaseUIConfiguration, type FirebaseUI } from "@firebase-ui/core";
+import { type FirebaseUIStore, type FirebaseUI } from "@firebase-ui/core";
 import { useStore } from "@nanostores/react";
 import { type PolicyProps, PolicyProvider } from "~/components/policies";
 import { createContext } from "react";
 
-export const FirebaseUIContext = createContext<FirebaseUIConfiguration>({} as FirebaseUIConfiguration);
+export const FirebaseUIContext = createContext<FirebaseUI>({} as FirebaseUI);
 
 export type FirebaseUIProviderProps = {
   children: React.ReactNode;
-  ui: FirebaseUI;
+  ui: FirebaseUIStore;
   policies?: PolicyProps;
 };
 

--- a/packages/react/tests/utils.tsx
+++ b/packages/react/tests/utils.tsx
@@ -1,10 +1,10 @@
 import type { FirebaseApp } from "firebase/app";
 import type { Auth } from "firebase/auth";
 import { enUs } from "@firebase-ui/translations";
-import { Behavior, FirebaseUI, FirebaseUIConfigurationOptions, initializeUI } from "@firebase-ui/core";
+import { Behavior, FirebaseUI, FirebaseUIOptions, initializeUI } from "@firebase-ui/core";
 import { FirebaseUIProvider } from "../src/context";
 
-export function createMockUI(overrides?: Partial<FirebaseUIConfigurationOptions>): FirebaseUI {
+export function createMockUI(overrides?: Partial<FirebaseUIOptions>): FirebaseUI {
   return initializeUI({
     app: {} as FirebaseApp,
     auth: {} as Auth,


### PR DESCRIPTION
This PR aligns the public typescript API closely with what is in the spec, and most likely expected from usage:

1. `initializeUI` now returns a `FirebaseUIStore` - signalling it's a reactive store, rather than an object/type.
2. In frameworks, `useUI`/`injectUI` now returns a `FirebaseUI` instance, rather than `FirebaseUIConfiguration` type (poorly named).
3. The exposed auth methods (e.g. `signInWithX`) accept a `FirebaseUI` type now, aligning to the spec.