### PR TITLE
fix(react): Pass display name to TOTP enrollment (not verification code)

### DIFF
--- a/packages/react/src/auth/forms/mfa/totp-multi-factor-enrollment-form.test.tsx
+++ b/packages/react/src/auth/forms/mfa/totp-multi-factor-enrollment-form.test.tsx
@@ -123,7 +123,7 @@ describe("useMultiFactorEnrollmentVerifyTotpFormAction", () => {
     });
 
     expect(TotpMultiFactorGeneratorAssertionMock).toHaveBeenCalledWith(mockSecret, "123456");
-    expect(enrollWithMultiFactorAssertionMock).toHaveBeenCalledWith(expect.any(Object), mockAssertion, "123456");
+    expect(enrollWithMultiFactorAssertionMock).toHaveBeenCalledWith(expect.any(Object), mockAssertion, "Test User");
   });
 
   it("should throw an unknown error when its not a FirebaseUIError", async () => {

--- a/packages/react/src/auth/forms/mfa/totp-multi-factor-enrollment-form.tsx
+++ b/packages/react/src/auth/forms/mfa/totp-multi-factor-enrollment-form.tsx
@@ -82,9 +82,17 @@ function TotpMultiFactorSecretGenerationForm(props: TotpMultiFactorSecretGenerat
 export function useMultiFactorEnrollmentVerifyTotpFormAction() {
   const ui = useUI();
   return useCallback(
-    async ({ secret, verificationCode }: { secret: TotpSecret; verificationCode: string; displayName: string }) => {
+    async ({
+      secret,
+      verificationCode,
+      displayName,
+    }: {
+      secret: TotpSecret;
+      verificationCode: string;
+      displayName: string;
+    }) => {
       const assertion = TotpMultiFactorGenerator.assertionForEnrollment(secret, verificationCode);
-      return await enrollWithMultiFactorAssertion(ui, assertion, verificationCode);
+      return await enrollWithMultiFactorAssertion(ui, assertion, displayName);
     },
     [ui]
   );


### PR DESCRIPTION
BB-23

The display name provided to firebase is the code the user entered on TOTP - needs to pass the correct value