### PR TITLE
fix(react,angular): Ensure SMS MFA Assertion uses correct form schema

### DIFF
--- a/packages/angular/src/lib/auth/forms/mfa/sms-multi-factor-assertion-form.spec.ts
+++ b/packages/angular/src/lib/auth/forms/mfa/sms-multi-factor-assertion-form.spec.ts
@@ -32,7 +32,7 @@ describe("<fui-sms-multi-factor-assertion-form>", () => {
     const {
       injectTranslation,
       injectUI,
-      injectMultiFactorPhoneAuthNumberFormSchema,
+      injectMultiFactorPhoneAuthAssertionFormSchema,
       injectMultiFactorPhoneAuthVerifyFormSchema,
       injectRecaptchaVerifier,
     } = require("../../../tests/test-helpers");
@@ -58,7 +58,7 @@ describe("<fui-sms-multi-factor-assertion-form>", () => {
       });
     });
 
-    injectMultiFactorPhoneAuthNumberFormSchema.mockReturnValue(() => {
+    injectMultiFactorPhoneAuthAssertionFormSchema.mockReturnValue(() => {
       const { z } = require("zod");
       return z.object({
         phoneNumber: z.string().min(1, "Phone number is required"),
@@ -186,7 +186,7 @@ describe("<fui-sms-multi-factor-assertion-phone-form>", () => {
     const {
       injectTranslation,
       injectUI,
-      injectMultiFactorPhoneAuthNumberFormSchema,
+      injectMultiFactorPhoneAuthAssertionFormSchema,
     } = require("../../../tests/test-helpers");
 
     injectTranslation.mockImplementation((category: string, key: string) => {
@@ -208,7 +208,7 @@ describe("<fui-sms-multi-factor-assertion-phone-form>", () => {
       });
     });
 
-    injectMultiFactorPhoneAuthNumberFormSchema.mockReturnValue(() => {
+    injectMultiFactorPhoneAuthAssertionFormSchema.mockReturnValue(() => {
       const { z } = require("zod");
       return z.object({
         phoneNumber: z.string().min(1, "Phone number is required"),

--- a/packages/angular/src/lib/auth/forms/mfa/sms-multi-factor-assertion-form.ts
+++ b/packages/angular/src/lib/auth/forms/mfa/sms-multi-factor-assertion-form.ts
@@ -17,7 +17,7 @@ import { Component, ElementRef, effect, input, signal, output, computed, viewChi
 import { CommonModule } from "@angular/common";
 import { injectForm, injectStore, TanStackAppField, TanStackField } from "@tanstack/angular-form";
 import {
-  injectMultiFactorPhoneAuthNumberFormSchema,
+  injectMultiFactorPhoneAuthAssertionFormSchema,
   injectMultiFactorPhoneAuthVerifyFormSchema,
   injectRecaptchaVerifier,
   injectTranslation,
@@ -67,7 +67,7 @@ type PhoneMultiFactorInfo = MultiFactorInfo & {
 })
 export class SmsMultiFactorAssertionPhoneFormComponent {
   private ui = injectUI();
-  private formSchema = injectMultiFactorPhoneAuthNumberFormSchema();
+  private formSchema = injectMultiFactorPhoneAuthAssertionFormSchema();
 
   hint = input.required<MultiFactorInfo>();
   onSubmit = output<string>();

--- a/packages/angular/src/lib/provider.ts
+++ b/packages/angular/src/lib/provider.ts
@@ -35,6 +35,7 @@ import {
   createSignInAuthFormSchema,
   createSignUpAuthFormSchema,
   createMultiFactorPhoneAuthNumberFormSchema,
+  createMultiFactorPhoneAuthAssertionFormSchema,
   createMultiFactorPhoneAuthVerifyFormSchema,
   createMultiFactorTotpAuthNumberFormSchema,
   createMultiFactorTotpAuthVerifyFormSchema,
@@ -149,6 +150,13 @@ export function injectMultiFactorPhoneAuthNumberFormSchema(): Signal<
 > {
   const ui = injectUI();
   return computed(() => createMultiFactorPhoneAuthNumberFormSchema(ui()));
+}
+
+export function injectMultiFactorPhoneAuthAssertionFormSchema(): Signal<
+  ReturnType<typeof createMultiFactorPhoneAuthAssertionFormSchema>
+> {
+  const ui = injectUI();
+  return computed(() => createMultiFactorPhoneAuthAssertionFormSchema(ui()));
 }
 
 export function injectMultiFactorPhoneAuthVerifyFormSchema(): Signal<

--- a/packages/angular/src/lib/tests/test-helpers.ts
+++ b/packages/angular/src/lib/tests/test-helpers.ts
@@ -238,6 +238,13 @@ export const injectMultiFactorPhoneAuthNumberFormSchema = jest.fn().mockReturnVa
   });
 });
 
+export const injectMultiFactorPhoneAuthAssertionFormSchema = jest.fn().mockReturnValue(() => {
+  const { z } = require("zod");
+  return z.object({
+    phoneNumber: z.string().min(1, "Phone number is required"),
+  });
+});
+
 export const injectMultiFactorPhoneAuthVerifyFormSchema = jest.fn().mockReturnValue(() => {
   const { z } = require("zod");
   return z.object({

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -3,7 +3,7 @@ import { createMockUI } from "~/tests/utils";
 import {
   createEmailLinkAuthFormSchema,
   createForgotPasswordAuthFormSchema,
-  createMultiFactorPhoneAuthAssertionNumberFormSchema,
+  createMultiFactorPhoneAuthAssertionFormSchema,
   createPhoneAuthNumberFormSchema,
   createPhoneAuthVerifyFormSchema,
   createSignInAuthFormSchema,
@@ -311,11 +311,11 @@ describe("createPhoneAuthVerifyFormSchema", () => {
   });
 });
 
-describe("createMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
-  it("should create a multi-factor phone auth assertion number form schema and show missing phone number error", () => {
+describe("createMultiFactorPhoneAuthAssertionFormSchema", () => {
+  it("should create a multi-factor phone auth assertion form schema and show missing phone number error", () => {
     const testLocale = registerLocale("test", {
       errors: {
-        missingPhoneNumber: "createMultiFactorPhoneAuthAssertionNumberFormSchema + missingPhoneNumber",
+        missingPhoneNumber: "createMultiFactorPhoneAuthAssertionFormSchema + missingPhoneNumber",
       },
     });
 
@@ -323,7 +323,7 @@ describe("createMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
       locale: testLocale,
     });
 
-    const schema = createMultiFactorPhoneAuthAssertionNumberFormSchema(mockUI);
+    const schema = createMultiFactorPhoneAuthAssertionFormSchema(mockUI);
 
     const result = schema.safeParse({
       phoneNumber: "",
@@ -331,15 +331,13 @@ describe("createMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
-    expect(result.error?.issues[0]?.message).toBe(
-      "createMultiFactorPhoneAuthAssertionNumberFormSchema + missingPhoneNumber"
-    );
+    expect(result.error?.issues[0]?.message).toBe("createMultiFactorPhoneAuthAssertionFormSchema + missingPhoneNumber");
   });
 
-  it("should create a multi-factor phone auth assertion number form schema and show an error if the phone number is too long", () => {
+  it("should create a multi-factor phone auth assertion form schema and show an error if the phone number is too long", () => {
     const testLocale = registerLocale("test", {
       errors: {
-        invalidPhoneNumber: "createMultiFactorPhoneAuthAssertionNumberFormSchema + invalidPhoneNumber",
+        invalidPhoneNumber: "createMultiFactorPhoneAuthAssertionFormSchema + invalidPhoneNumber",
       },
     });
 
@@ -347,7 +345,7 @@ describe("createMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
       locale: testLocale,
     });
 
-    const schema = createMultiFactorPhoneAuthAssertionNumberFormSchema(mockUI);
+    const schema = createMultiFactorPhoneAuthAssertionFormSchema(mockUI);
 
     const result = schema.safeParse({
       phoneNumber: "12345678901",
@@ -355,9 +353,7 @@ describe("createMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
-    expect(result.error?.issues[0]?.message).toBe(
-      "createMultiFactorPhoneAuthAssertionNumberFormSchema + invalidPhoneNumber"
-    );
+    expect(result.error?.issues[0]?.message).toBe("createMultiFactorPhoneAuthAssertionFormSchema + invalidPhoneNumber");
   });
 
   it("should accept valid phone number without requiring displayName", () => {
@@ -372,7 +368,7 @@ describe("createMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
       locale: testLocale,
     });
 
-    const schema = createMultiFactorPhoneAuthAssertionNumberFormSchema(mockUI);
+    const schema = createMultiFactorPhoneAuthAssertionFormSchema(mockUI);
 
     const result = schema.safeParse({
       phoneNumber: "1234567890",

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -80,7 +80,7 @@ export function createMultiFactorPhoneAuthNumberFormSchema(ui: FirebaseUI) {
   });
 }
 
-export function createMultiFactorPhoneAuthAssertionNumberFormSchema(ui: FirebaseUI) {
+export function createMultiFactorPhoneAuthAssertionFormSchema(ui: FirebaseUI) {
   return createPhoneAuthNumberFormSchema(ui);
 }
 

--- a/packages/react/src/auth/forms/mfa/sms-multi-factor-assertion-form.tsx
+++ b/packages/react/src/auth/forms/mfa/sms-multi-factor-assertion-form.tsx
@@ -10,7 +10,7 @@ import {
 import { signInWithMultiFactorAssertion, FirebaseUIError, getTranslation, verifyPhoneNumber } from "@firebase-ui/core";
 import { form } from "~/components/form";
 import {
-  useMultiFactorPhoneAuthAssertionNumberFormSchema,
+  useMultiFactorPhoneAuthAssertionFormSchema,
   useMultiFactorPhoneAuthVerifyFormSchema,
   useRecaptchaVerifier,
   useUI,
@@ -43,7 +43,7 @@ export function useSmsMultiFactorAssertionPhoneForm({
   onSuccess,
 }: UseSmsMultiFactorAssertionPhoneForm) {
   const action = useSmsMultiFactorAssertionPhoneFormAction();
-  const schema = useMultiFactorPhoneAuthAssertionNumberFormSchema();
+  const schema = useMultiFactorPhoneAuthAssertionFormSchema();
 
   return form.useAppForm({
     defaultValues: {

--- a/packages/react/src/hooks.test.tsx
+++ b/packages/react/src/hooks.test.tsx
@@ -24,7 +24,7 @@ import {
   useSignUpAuthFormSchema,
   useForgotPasswordAuthFormSchema,
   useEmailLinkAuthFormSchema,
-  useMultiFactorPhoneAuthAssertionNumberFormSchema,
+  useMultiFactorPhoneAuthAssertionFormSchema,
   usePhoneAuthNumberFormSchema,
   usePhoneAuthVerifyFormSchema,
   useRecaptchaVerifier,
@@ -713,7 +713,7 @@ describe("usePhoneAuthVerifyFormSchema", () => {
   });
 });
 
-describe("useMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
+describe("useMultiFactorPhoneAuthAssertionFormSchema", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cleanup();
@@ -722,7 +722,7 @@ describe("useMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
   it("returns schema with default English error messages", () => {
     const mockUI = createMockUI();
 
-    const { result } = renderHook(() => useMultiFactorPhoneAuthAssertionNumberFormSchema(), {
+    const { result } = renderHook(() => useMultiFactorPhoneAuthAssertionFormSchema(), {
       wrapper: ({ children }) => createFirebaseUIProvider({ children, ui: mockUI }),
     });
 
@@ -745,7 +745,7 @@ describe("useMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
     const customLocale = registerLocale("es-ES", customTranslations);
     const mockUI = createMockUI({ locale: customLocale });
 
-    const { result } = renderHook(() => useMultiFactorPhoneAuthAssertionNumberFormSchema(), {
+    const { result } = renderHook(() => useMultiFactorPhoneAuthAssertionFormSchema(), {
       wrapper: ({ children }) => createFirebaseUIProvider({ children, ui: mockUI }),
     });
 
@@ -761,7 +761,7 @@ describe("useMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
   it("returns stable reference when UI hasn't changed", () => {
     const mockUI = createMockUI();
 
-    const { result, rerender } = renderHook(() => useMultiFactorPhoneAuthAssertionNumberFormSchema(), {
+    const { result, rerender } = renderHook(() => useMultiFactorPhoneAuthAssertionFormSchema(), {
       wrapper: ({ children }) => createFirebaseUIProvider({ children, ui: mockUI }),
     });
 
@@ -775,7 +775,7 @@ describe("useMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
   it("returns new schema when locale changes", () => {
     const mockUI = createMockUI();
 
-    const { result, rerender } = renderHook(() => useMultiFactorPhoneAuthAssertionNumberFormSchema(), {
+    const { result, rerender } = renderHook(() => useMultiFactorPhoneAuthAssertionFormSchema(), {
       wrapper: ({ children }) => createFirebaseUIProvider({ children, ui: mockUI }),
     });
 
@@ -807,7 +807,7 @@ describe("useMultiFactorPhoneAuthAssertionNumberFormSchema", () => {
   it("accepts valid phone number without requiring displayName", () => {
     const mockUI = createMockUI();
 
-    const { result } = renderHook(() => useMultiFactorPhoneAuthAssertionNumberFormSchema(), {
+    const { result } = renderHook(() => useMultiFactorPhoneAuthAssertionFormSchema(), {
       wrapper: ({ children }) => createFirebaseUIProvider({ children, ui: mockUI }),
     });
 

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -20,7 +20,7 @@ import {
   createEmailLinkAuthFormSchema,
   createForgotPasswordAuthFormSchema,
   createMultiFactorPhoneAuthNumberFormSchema,
-  createMultiFactorPhoneAuthAssertionNumberFormSchema,
+  createMultiFactorPhoneAuthAssertionFormSchema,
   createMultiFactorPhoneAuthVerifyFormSchema,
   createMultiFactorTotpAuthNumberFormSchema,
   createMultiFactorTotpAuthVerifyFormSchema,
@@ -93,9 +93,9 @@ export function useMultiFactorPhoneAuthNumberFormSchema() {
   return useMemo(() => createMultiFactorPhoneAuthNumberFormSchema(ui), [ui]);
 }
 
-export function useMultiFactorPhoneAuthAssertionNumberFormSchema() {
+export function useMultiFactorPhoneAuthAssertionFormSchema() {
   const ui = useUI();
-  return useMemo(() => createMultiFactorPhoneAuthAssertionNumberFormSchema(ui), [ui]);
+  return useMemo(() => createMultiFactorPhoneAuthAssertionFormSchema(ui), [ui]);
 }
 
 export function useMultiFactorPhoneAuthVerifyFormSchema() {


### PR DESCRIPTION
BB-47

Check if angular should make use of the createMultiFactorPhoneAuthAssertionNumberFormSchema schema like react