### PR TITLE
docs(*): updated documentation to fix prop from config={ui} to ui={ui}

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const ui = initializeUI({ app });
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ConfigProvider config={ui}>
+    <ConfigProvider ui={ui}>
       <App />
     </ConfigProvider>
   </StrictMode>

--- a/packages/firebaseui-core/src/config.ts
+++ b/packages/firebaseui-core/src/config.ts
@@ -59,15 +59,17 @@ export function initializeUI(config: FirebaseUIConfigurationOptions, name: strin
 
   config.translations ??= [];
 
-  // TODO: Is this right?
-  config.translations.push(english);
-
-  const translations = config.translations?.reduce((acc, translation) => {
-    return {
-      ...acc,
-      [translation.locale]: translation.translations,
-    };
-  }, {} as TranslationsConfig);
+  // Map the translations to a TranslationsConfig object.
+  // If no translations are provided, use the English translations as default.
+  const translations = config.translations?.reduce(
+    (acc, translation) => {
+      return {
+        ...acc,
+        [translation.locale]: translation.translations,
+      };
+    },
+    { [english.locale]: english.translations } as TranslationsConfig
+  );
 
   $config.setKey(
     name,

--- a/packages/firebaseui-core/src/config.ts
+++ b/packages/firebaseui-core/src/config.ts
@@ -68,6 +68,7 @@ export function initializeUI(config: FirebaseUIConfigurationOptions, name: strin
         [translation.locale]: translation.translations,
       };
     },
+    //TODO: Do we always want to include English here?
     { [english.locale]: english.translations } as TranslationsConfig
   );
 

--- a/packages/firebaseui-core/tests/unit/translations.test.ts
+++ b/packages/firebaseui-core/tests/unit/translations.test.ts
@@ -142,4 +142,29 @@ describe('getTranslation', () => {
     const translation = getTranslation(mockUi as any, 'errors', 'userNotFound');
     expect(translation).toBe('No account found with this email address');
   });
+
+  it('should allow custom en-US translation to overwrite the default one', () => {
+    const customEnUs = {
+      locale: 'en-US',
+      translations: {
+        errors: {
+          userNotFound: 'Custom override message',
+        },
+      },
+    };
+
+    const config = {
+      translations: [customEnUs],
+    };
+
+    const result = config.translations.reduce(
+      (acc, t) => ({
+        ...acc,
+        [t.locale]: t.translations,
+      }),
+      { [english.locale]: english.translations }
+    );
+
+    expect(result['en-US'].errors.userNotFound).toBe('Custom override message');
+  });
 });

--- a/packages/firebaseui-react/README.md
+++ b/packages/firebaseui-react/README.md
@@ -56,7 +56,7 @@ import { ConfigProvider } from "@firebase-ui/react";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ConfigProvider config={ui}>
+    <ConfigProvider ui={ui}>
       <App />
     </ConfigProvider>
   </StrictMode>


### PR DESCRIPTION
I found some typos.

```shell
$ rg 'config=\{ui\}'
README.md
93:    <ConfigProvider config={ui}>

packages/firebaseui-react/README.md
59:    <ConfigProvider config={ui}>
```