### PR TITLE
chore(deps): add dependabot config for pnpm and github-actions ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    allow:
+      - dependency-type: 'production'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
+    target-branch: dependency-updates
+    labels:
+      - 'dependencies'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
+    target-branch: dependency-updates
+    labels:
+      - 'dependencies'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 7
-    target-branch: dependency-updates
     labels:
       - 'dependencies'
 
@@ -24,6 +23,5 @@ updates:
       semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 7
-    target-branch: dependency-updates
     labels:
       - 'dependencies'


### PR DESCRIPTION
Adds dependabot.yml to keep   dependencies and GitHub Actions up to date on a daily schedule with 7-day cooldown. 