### PR TITLE
build(deps): dependabot cooldown configs / supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,5 @@ updates:
       interval: 'daily'
     cooldown:
       default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
     labels:
       - 'dependencies'


### PR DESCRIPTION
Remove unsupported semver cooldown params from the github-actions ecosystem; npm block unchanged.

- Related #1378