### PR TITLE
fix(auth): ensure pending credential is rehydrated before linkWithCredential

### DIFF
--- a/packages/core/src/auth.test.ts
+++ b/packages/core/src/auth.test.ts
@@ -1104,6 +1104,20 @@ describe("handlePendingCredential", () => {
     expect(window.sessionStorage.getItem("pendingCred")).toBeNull();
   });
 
+  it("should return the original user and clear storage when the stored credential is invalid JSON", async () => {
+    const mockUI = createMockUI();
+    window.sessionStorage.setItem("pendingCred", "{invalid-json");
+
+    vi.mocked(_signInAnonymously).mockResolvedValue(mockUserCredential);
+
+    const result = await signInAnonymously(mockUI);
+
+    expect(OAuthProvider.credentialFromJSON).not.toHaveBeenCalled();
+    expect(_linkWithCredential).not.toHaveBeenCalled();
+    expect(result).toBe(mockUserCredential);
+    expect(window.sessionStorage.getItem("pendingCred")).toBeNull();
+  });
+
   it("should return the original user and clear storage when linkWithCredential fails", async () => {
     const mockUI = createMockUI();
     const storedJSON = { providerId: "google.com", signInMethod: "google.com", idToken: "fake-id-token" };

--- a/packages/core/src/auth.test.ts
+++ b/packages/core/src/auth.test.ts
@@ -48,6 +48,12 @@ vi.mock("firebase/auth", () => ({
   PhoneAuthProvider: Object.assign(vi.fn(), {
     credential: vi.fn(),
   }),
+  OAuthProvider: {
+    credentialFromJSON: vi.fn(),
+  },
+  SAMLAuthProvider: {
+    credentialFromJSON: vi.fn(),
+  },
   linkWithCredential: vi.fn(),
 }));
 
@@ -64,6 +70,9 @@ import {
   signInWithCredential as _signInWithCredential,
   EmailAuthProvider,
   PhoneAuthProvider,
+  OAuthProvider,
+  SAMLAuthProvider,
+  linkWithCredential as _linkWithCredential,
   createUserWithEmailAndPassword as _createUserWithEmailAndPassword,
   sendPasswordResetEmail as _sendPasswordResetEmail,
   sendSignInLinkToEmail as _sendSignInLinkToEmail,
@@ -80,8 +89,6 @@ import { handleFirebaseError } from "./errors";
 import { FirebaseError } from "firebase/app";
 
 import { createMockUI } from "~/tests/utils";
-
-// TODO(ehesp): Add tests for handlePendingCredential.
 
 describe("signInWithEmailAndPassword", () => {
   beforeEach(() => {
@@ -1004,6 +1011,117 @@ describe("signInAnonymously", () => {
     expect(handleFirebaseError).toHaveBeenCalledWith(mockUI, error);
 
     expect(vi.mocked(mockUI.setState).mock.calls).toEqual([["pending"], ["idle"]]);
+  });
+});
+
+describe("handlePendingCredential", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  const mockUserCredential = {
+    user: { uid: "anonymous-uid" },
+    providerId: "anonymous",
+    operationType: "signIn",
+  } as UserCredential;
+
+  it("should return the user unchanged when there is no pending credential", async () => {
+    const mockUI = createMockUI();
+    vi.mocked(_signInAnonymously).mockResolvedValue(mockUserCredential);
+
+    const result = await signInAnonymously(mockUI);
+
+    expect(OAuthProvider.credentialFromJSON).not.toHaveBeenCalled();
+    expect(_linkWithCredential).not.toHaveBeenCalled();
+    expect(result).toBe(mockUserCredential);
+  });
+
+  it("should rehydrate an OAuth credential via OAuthProvider.credentialFromJSON and link it", async () => {
+    const mockUI = createMockUI();
+    const storedJSON = { providerId: "google.com", signInMethod: "google.com", idToken: "fake-id-token" };
+    window.sessionStorage.setItem("pendingCred", JSON.stringify(storedJSON));
+
+    const rehydratedCredential = { providerId: "google.com" } as any;
+    const linkedUserCredential = { ...mockUserCredential, providerId: "google.com" } as UserCredential;
+
+    vi.mocked(_signInAnonymously).mockResolvedValue(mockUserCredential);
+    vi.mocked(OAuthProvider.credentialFromJSON).mockReturnValue(rehydratedCredential);
+    vi.mocked(_linkWithCredential).mockResolvedValue(linkedUserCredential);
+
+    const result = await signInAnonymously(mockUI);
+
+    expect(OAuthProvider.credentialFromJSON).toHaveBeenCalledWith(storedJSON);
+    expect(_linkWithCredential).toHaveBeenCalledWith(mockUserCredential.user, rehydratedCredential);
+    expect(result).toBe(linkedUserCredential);
+    expect(window.sessionStorage.getItem("pendingCred")).toBeNull();
+  });
+
+  it("should fall back to SAMLAuthProvider when OAuthProvider cannot rehydrate the credential", async () => {
+    const mockUI = createMockUI();
+    const storedJSON = { providerId: "saml.my-provider", signInMethod: "saml.my-provider", pendingToken: "abc" };
+    window.sessionStorage.setItem("pendingCred", JSON.stringify(storedJSON));
+
+    const rehydratedCredential = { providerId: "saml.my-provider" } as any;
+    const linkedUserCredential = { ...mockUserCredential, providerId: "saml.my-provider" } as UserCredential;
+
+    vi.mocked(_signInAnonymously).mockResolvedValue(mockUserCredential);
+    vi.mocked(OAuthProvider.credentialFromJSON).mockImplementation(() => {
+      throw new Error("not an OAuth credential");
+    });
+    vi.mocked(SAMLAuthProvider.credentialFromJSON).mockReturnValue(rehydratedCredential);
+    vi.mocked(_linkWithCredential).mockResolvedValue(linkedUserCredential);
+
+    const result = await signInAnonymously(mockUI);
+
+    expect(SAMLAuthProvider.credentialFromJSON).toHaveBeenCalledWith(storedJSON);
+    expect(_linkWithCredential).toHaveBeenCalledWith(mockUserCredential.user, rehydratedCredential);
+    expect(result).toBe(linkedUserCredential);
+    expect(window.sessionStorage.getItem("pendingCred")).toBeNull();
+  });
+
+  it("should return the original user and clear storage when the credential cannot be rehydrated", async () => {
+    const mockUI = createMockUI();
+    const storedJSON = { providerId: "unknown", signInMethod: "unknown" };
+    window.sessionStorage.setItem("pendingCred", JSON.stringify(storedJSON));
+
+    vi.mocked(_signInAnonymously).mockResolvedValue(mockUserCredential);
+    vi.mocked(OAuthProvider.credentialFromJSON).mockImplementation(() => {
+      throw new Error("not an OAuth credential");
+    });
+    vi.mocked(SAMLAuthProvider.credentialFromJSON).mockImplementation(() => {
+      throw new Error("not a SAML credential");
+    });
+
+    const result = await signInAnonymously(mockUI);
+
+    expect(_linkWithCredential).not.toHaveBeenCalled();
+    expect(result).toBe(mockUserCredential);
+    expect(window.sessionStorage.getItem("pendingCred")).toBeNull();
+  });
+
+  it("should return the original user and clear storage when linkWithCredential fails", async () => {
+    const mockUI = createMockUI();
+    const storedJSON = { providerId: "google.com", signInMethod: "google.com", idToken: "fake-id-token" };
+    window.sessionStorage.setItem("pendingCred", JSON.stringify(storedJSON));
+
+    const rehydratedCredential = { providerId: "google.com" } as any;
+
+    vi.mocked(_signInAnonymously).mockResolvedValue(mockUserCredential);
+    vi.mocked(OAuthProvider.credentialFromJSON).mockReturnValue(rehydratedCredential);
+    vi.mocked(_linkWithCredential).mockRejectedValue(
+      new FirebaseError("auth/credential-already-in-use", "Credential already in use")
+    );
+
+    const result = await signInAnonymously(mockUI);
+
+    expect(_linkWithCredential).toHaveBeenCalledWith(mockUserCredential.user, rehydratedCredential);
+    expect(result).toBe(mockUserCredential);
+    expect(window.sessionStorage.getItem("pendingCred")).toBeNull();
   });
 });
 

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -57,7 +57,11 @@ import { getTranslation } from "./translations";
  * @param json - The parsed JSON representation of the credential.
  * @returns The rehydrated `AuthCredential`, or `null` if it could not be rehydrated.
  */
-function credentialFromJSON(json: object): AuthCredential | null {
+function credentialFromJSON(json: unknown): AuthCredential | null {
+  if (typeof json !== "object" || json === null) {
+    return null;
+  }
+
   try {
     return OAuthProvider.credentialFromJSON(json);
   } catch {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -24,7 +24,9 @@ import {
   signInWithCustomToken as _signInWithCustomToken,
   EmailAuthProvider,
   linkWithCredential,
+  OAuthProvider,
   PhoneAuthProvider,
+  SAMLAuthProvider,
   TotpMultiFactorGenerator,
   multiFactor,
   type ActionCodeSettings,
@@ -44,17 +46,43 @@ import { hasBehavior, getBehavior } from "./behaviors/index";
 import { FirebaseError } from "firebase/app";
 import { getTranslation } from "./translations";
 
+/**
+ * Rehydrates a plain object (produced by `AuthCredential.toJSON()` and round-tripped
+ * through `JSON.stringify`/`JSON.parse`) back into a real `AuthCredential` instance.
+ *
+ * `linkWithCredential` requires an actual `AuthCredential` - a plain object lacks the
+ * internal methods (e.g. `_linkToIdToken`) that Firebase Auth relies on, so it must be
+ * rehydrated via the relevant provider's `credentialFromJSON` before use.
+ *
+ * @param json - The parsed JSON representation of the credential.
+ * @returns The rehydrated `AuthCredential`, or `null` if it could not be rehydrated.
+ */
+function credentialFromJSON(json: object): AuthCredential | null {
+  try {
+    return OAuthProvider.credentialFromJSON(json);
+  } catch {
+    // Not an OAuth credential - fall through and try other providers below.
+  }
+
+  try {
+    return SAMLAuthProvider.credentialFromJSON(json);
+  } catch {
+    return null;
+  }
+}
+
 async function handlePendingCredential(_ui: FirebaseUI, user: UserCredential): Promise<UserCredential> {
   const pendingCredString = window.sessionStorage.getItem("pendingCred");
   if (!pendingCredString) return user;
 
+  window.sessionStorage.removeItem("pendingCred");
+
   try {
-    const pendingCred = JSON.parse(pendingCredString);
-    const result = await linkWithCredential(user.user, pendingCred);
-    window.sessionStorage.removeItem("pendingCred");
-    return result;
+    const pendingCred = credentialFromJSON(JSON.parse(pendingCredString));
+    if (!pendingCred) return user;
+
+    return await linkWithCredential(user.user, pendingCred);
   } catch {
-    window.sessionStorage.removeItem("pendingCred");
     return user;
   }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -52,6 +52,7 @@ export function handleFirebaseError(ui: FirebaseUI, error: unknown): never {
 
   // TODO(ehesp): Type error as unknown, check instance of FirebaseError
   // TODO(ehesp): Support via behavior
+  // Note: the credential is stored via `toJSON()`; it must be rehydrated (see handlePendingCredential in auth.ts) before being passed to linkWithCredential.
   if (error.code === "auth/account-exists-with-different-credential" && errorContainsCredential(error)) {
     window.sessionStorage.setItem("pendingCred", JSON.stringify(error.credential.toJSON()));
   }


### PR DESCRIPTION
- Fixes #1391

## Problem

In the `auth/account-exists-with-different-credential` recovery flow, the pending credential is captured with `error.credential.toJSON()` and stored in `sessionStorage` (`errors.ts`). When the user later signs back in, `handlePendingCredential` (`auth.ts`) read that string back with a bare `JSON.parse` and passed the resulting **plain object** straight to `linkWithCredential`.

A plain object doesn't have the internal methods (e.g. `_linkToIdToken`) that Firebase Auth's `AuthCredential` implementations rely on, so linking failed. The `catch` block then silently discarded the pending credential and returned the already-signed-in user — so the account-linking recovery flow appeared to work but never actually linked the second provider, with no error surfaced to the app or the user.

## Fix

- Added a `credentialFromJSON` helper in `auth.ts` that rehydrates the parsed JSON back into a real `AuthCredential`, trying `OAuthProvider.credentialFromJSON` first and falling back to `SAMLAuthProvider.credentialFromJSON`.
- The helper takes `unknown` (not `object`) and validates the input is a non-null object before calling either provider, since the value is really the untyped output of `JSON.parse`.
- `handlePendingCredential` now rehydrates before calling `linkWithCredential`, and unconditionally clears `pendingCred` from `sessionStorage` up front so it's never left dangling regardless of outcome.
- Added a clarifying comment in `errors.ts` at the point the credential is serialized, pointing at the rehydration step in `auth.ts`.

## Testing

Added a `describe("handlePendingCredential", ...)` block in `auth.test.ts` (using `signInAnonymously` as the calling vehicle, since it invokes `handlePendingCredential` internally) covering:

- No pending credential → user returned unchanged, no rehydration/linking attempted.
- OAuth credential rehydrates via `OAuthProvider.credentialFromJSON` and links successfully.
- Falls back to `SAMLAuthProvider.credentialFromJSON` when OAuth rehydration throws.
- Returns the original user and clears storage when neither provider can rehydrate the credential.
- Returns the original user and clears storage when `linkWithCredential` itself fails.
- Returns the original user and clears storage when the stored value is invalid/unparseable JSON.

All 247 tests in `packages/core` pass; `pnpm lint:check` and `pnpm build` are unaffected (no new type errors).

### Why no e2e (Playwright) coverage

This is a pure logic fix with no rendering surface — `handlePendingCredential` runs silently in the background after a successful re-sign-in; it doesn't drive a screen, message, or visible state that Playwright could assert on distinctly from "sign-in succeeded." The unit tests above mock the exact Firebase SDK contract points (`OAuthProvider`/`SAMLAuthProvider`/`linkWithCredential`) and exercise every branch of the fix directly.

It's also out of this repo's current e2e scope: per the `developer-docs` architecture decision log ([AD-3](developer-docs/decisions.md#ad-3-playwright-example-smoke-tests-mvp-scope-dev-server)), Playwright smoke tests are UI-render-only (form fields, validation, navigation) and explicitly exclude OAuth and real sign-in. Reproducing this bug end-to-end would require a real `account-exists-with-different-credential` collision across two federated providers (e.g. Google then GitHub on the same email), which the Auth emulator doesn't support and would mean driving live provider consent screens in CI — a disproportionate cost for a scenario the unit tests already pin down precisely.

### Why no `developer-docs` update

`developer-docs/` is scoped (see [documentation-policy.md](developer-docs/documentation-policy.md)) to architecture shape, **hard-to-reverse decisions**, step-by-step playbooks, and living backlogs — not individual bug fixes. Every existing `AD-*` entry in [decisions.md](developer-docs/decisions.md) covers dependency/CI/build-tooling tradeoffs that are expensive to revisit later. This fix has no alternative path that was considered and rejected — once the bug is understood, the fix is the only reasonable one — so there's no decision to record.

Per the policy's "single owner per fact" rule, the explanation lives where a future reader will actually encounter it: a JSDoc comment on `credentialFromJSON` explaining why rehydration is required, a short pointer comment in `errors.ts`, and the test suite itself documenting the expected behavior for each branch.
