### PR TITLE
fix(ci): remove .npmrc registry override that breaks all CI workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
           chmod +x /usr/local/bin/addlicense
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build packages
         run: pnpm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://wombat-dressing-room.appspot.com

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -2,6 +2,9 @@
   "name": "@firebase-oss/ui-angular",
   "version": "7.0.3",
   "repository": "firebase/firebaseui-web",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
   "files": [
     "dist"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,9 @@
   "name": "@firebase-oss/ui-core",
   "version": "7.0.3",
   "repository": "firebase/firebaseui-web",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
   "description": "Core authentication service for Firebase UI",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,9 @@
   "name": "@firebase-oss/ui-react",
   "version": "7.0.3",
   "repository": "firebase/firebaseui-web",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -2,6 +2,9 @@
   "name": "@firebase-oss/ui-shadcn",
   "version": "7.0.3",
   "repository": "firebase/firebaseui-web",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
   "type": "module",
   "bin": {
     "ui-shadcn": "dist/bin/cli.js"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -2,6 +2,9 @@
   "name": "@firebase-oss/ui-styles",
   "version": "7.0.3",
   "repository": "firebase/firebaseui-web",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
   "type": "module",
   "zshy": {
     "exports": {

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -2,6 +2,9 @@
   "name": "@firebase-oss/ui-translations",
   "version": "7.0.3",
   "repository": "firebase/firebaseui-web",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
   "description": "Translations for Firebase UI",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Removes `.npmrc` that was accidentally included in the "beta → GA" merge (`d82655d4`), which redirects **all** package resolution to `wombat-dressing-room.appspot.com` — a publish-only proxy that doesn't mirror the full npm registry.
- Scoped publish registry on a per package basis now (i.e. in each package.json).
- Adds `--frozen-lockfile` to `test.yaml` for consistency with `lint.yaml` and `e2e.yaml`

## Root cause

The `.npmrc` contains `registry=https://wombat-dressing-room.appspot.com`, causing 404s for non-Google packages (e.g. `@eslint/css@1.4.0`). This breaks:
- `pnpm install` (Lint + Test workflows)
- `npm i -g firebase-tools` (Test workflow)
- `npx firebase-tools` emulator startup (E2E workflow)

**All CI on main has been red since Jul 23** because of this.

## Why this is safe

Publishing is **not affected** — `publish.sh` already:
1. Overwrites `.npmrc` at runtime with the npm auth token
2. Passes `--registry https://wombat-dressing-room.appspot.com` directly on the `pnpm publish` command

## Verified locally

- **With `.npmrc`**: `pnpm install --frozen-lockfile` → immediate `ERR_PNPM_FETCH_404` on `@eslint/css`
- **Without `.npmrc`**: `pnpm install --frozen-lockfile` → completes successfully in ~50s

## Test plan

- [ ] CI Lint passes
- [ ] CI Test passes
- [ ] CI E2E passes (emulator starts successfully)