### PR TITLE
fix(docs): OKF conformance of developer-docs + CI validation

### DIFF
--- a/.github/workflows/developer-docs.yaml
+++ b/.github/workflows/developer-docs.yaml
@@ -1,0 +1,33 @@
+name: Developer Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'developer-docs/**'
+      - '.github/workflows/developer-docs.yaml'
+  pull_request:
+    paths:
+      - 'developer-docs/**'
+      - '.github/workflows/developer-docs.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate OKF bundle
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate developer-docs
+        uses: galkleinman/okf-toolkit@c7c29e678f37c990fb0b04ca08411bb2e5bdf3bf # v0.2.1
+        with:
+          path: developer-docs
+          command: validate

--- a/developer-docs/index.md
+++ b/developer-docs/index.md
@@ -1,10 +1,5 @@
 ---
-type: Index
-title: developer-docs
-description: OKF knowledge bundle entry point for firebaseui-web.
-tags: [okf, documentation]
 okf_version: "0.1"
-timestamp: 2026-07-03T00:00:00Z
 ---
 
 # developer-docs


### PR DESCRIPTION
`developer-docs/` does not currently pass OKF v0.1 conformance, so tooling that reads the bundle rejects it before reading any of the content.

### What fails

Every key on the bundle-root `index.md` except `okf_version`. [§8](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) is explicit that index files carry no frontmatter, with exactly one exception — a bundle-root `index.md` may declare `okf_version` (§12) — and §11.3 makes the reserved-filename structure a conformance requirement:

```
developer-docs/index.md
  2  error  `index.md` must not carry frontmatter key `type`
  3  error  `index.md` must not carry frontmatter key `title`
  4  error  `index.md` must not carry frontmatter key `description`
  5  error  `index.md` must not carry frontmatter key `tags`
  7  error  `index.md` must not carry frontmatter key `timestamp`
```

Nothing is lost by removing them. The body's `# developer-docs` heading and opening line already carry the title and description, and an index file is not a concept document, so `type`, `tags`, and `timestamp` have no defined meaning on one. The rest of the bundle is already conformant — this is the only file that fails.

This matches `developer-docs/documentation-policy.md`, which requires frontmatter with a `type` on *concept* files and says nothing about index files.

### CI

Adds `.github/workflows/developer-docs.yaml`, running conformance only (§11: parseable frontmatter, non-empty `type`, reserved-file structure). §11 forbids consumers from rejecting a bundle for broken cross-links, unknown `type` values, unknown keys, or missing optional fields, so this gate cannot fail on any of those — it catches the structural breakage above and nothing else. The bundle is also clean of advisory warnings today, if you would rather run `command: lint` instead.

Path-scoped so it runs only when `developer-docs/` changes, action pinned by SHA and `permissions: contents: read`, matching `lint.yaml`.

The action is [okf-toolkit](https://github.com/galkleinman/okf-toolkit), Apache-2.0. Happy to swap it for a plain `curl`-and-run step, or to drop the CI commit entirely and keep just the fix, whichever you prefer.