### PR TITLE
docs: drop @beta tags from web agent skill and align to SKILL.md layout

### DIFF
--- a/.agents/skills/firebaseui-web-getting-started/SKILL.md
+++ b/.agents/skills/firebaseui-web-getting-started/SKILL.md
@@ -29,13 +29,13 @@ Authoritative docs:
 React:
 
 ```bash
-npm install firebase @firebase-oss/ui-core @firebase-oss/ui-react@beta @firebase-oss/ui-styles
+npm install firebase @firebase-oss/ui-core @firebase-oss/ui-react @firebase-oss/ui-styles
 ```
 
 shadcn/ui:
 
 ```bash
-npm install firebase @firebase-oss/ui-core @firebase-oss/ui-react@beta
+npm install firebase @firebase-oss/ui-core @firebase-oss/ui-react
 ```
 
 Then add the Firebase registry to `components.json`:
@@ -57,7 +57,7 @@ npx shadcn@latest add @firebase/sign-in-auth-screen
 Angular:
 
 ```bash
-npm install firebase @angular/fire @firebase-oss/ui-core @firebase-oss/ui-angular@beta @firebase-oss/ui-styles
+npm install firebase @angular/fire @firebase-oss/ui-core @firebase-oss/ui-angular @firebase-oss/ui-styles
 ```
 
 Adapt commands for `pnpm`, `yarn`, or `bun` if that is the repo's package manager.


### PR DESCRIPTION
Follow-up to #1364.

The skill's install commands pinned `@firebase-oss/ui-react@beta` and `@firebase-oss/ui-angular@beta`, but v7 went to general release in #1427, so agents following the skill would install beta packages. Dropped the tags from all three install commands — no other `@beta` references remain in the repo.

Also moved the file to `.agents/skills/firebaseui-web-getting-started/SKILL.md`.