### PR TITLE
docs: extract work queue vocab from the playwright queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,10 @@ Start at [developer-docs/index.md](developer-docs/index.md).
 
 For architecture or testing work, also read:
 
-* [developer-docs/decisions.md](developer-docs/decisions.md) — `AD-<number>` decision log
-* [developer-docs/work-queues/playwright-e2e-smoke.md](developer-docs/work-queues/playwright-e2e-smoke.md) — active Playwright backlog
+* [developer-docs/decisions.md](developer-docs/decisions.md): `AD-<number>` decision log
+* [developer-docs/testing/iteration-vocabulary.md](developer-docs/testing/iteration-vocabulary.md): work type, tier, and queue field identifiers
+* [developer-docs/testing/change-authoring-workflow.md](developer-docs/testing/change-authoring-workflow.md): verified change loop
+* [developer-docs/work-queues/playwright-e2e-smoke.md](developer-docs/work-queues/playwright-e2e-smoke.md): active Playwright backlog
 
 **Before commit or push** on dependency, CI, workflow, or e2e/example changes: complete [developer-docs/playbooks/change-authoring-verification.md](developer-docs/playbooks/change-authoring-verification.md) ([AD-10](developer-docs/decisions.md#ad-10-change-authoring-requires-ci-parity-verification-before-commit)). Dependency bumps: also [dependency-update-verification.md](developer-docs/playbooks/dependency-update-verification.md).
 

--- a/developer-docs/documentation-policy.md
+++ b/developer-docs/documentation-policy.md
@@ -30,6 +30,9 @@ Applies to all durable documentation in this repository: the [developer-docs](in
 | Content | Owner document |
 |---------|----------------|
 | Architecture shape, inventories | `developer-docs/architecture/` |
+| Work-queue term ids | `developer-docs/testing/iteration-vocabulary.md` |
+| Change loop, gates, frozen tree | `developer-docs/testing/change-authoring-workflow.md` |
+| CI-parity command sequence | `developer-docs/playbooks/change-authoring-verification.md` |
 | Hard-to-reverse decisions | `developer-docs/decisions.md` |
 | Step-by-step procedures | `developer-docs/playbooks/` or root guides (pick one owner) |
 | Implementation backlogs | `developer-docs/work-queues/` |

--- a/developer-docs/index.md
+++ b/developer-docs/index.md
@@ -23,6 +23,11 @@ OKF knowledge bundle for firebaseui-web: architecture, decisions, playbooks, and
 - [architecture/examples-inventory.md](architecture/examples-inventory.md) — example apps, ports, dev commands, emulator wiring
 - [architecture/testing-strategy.md](architecture/testing-strategy.md) — unit, build, and e2e verification layers
 
+# Testing
+
+- [testing/iteration-vocabulary.md](testing/iteration-vocabulary.md) — work type, tier, and queue field identifiers
+- [testing/change-authoring-workflow.md](testing/change-authoring-workflow.md) — verified change loop, gates, frozen tree
+
 # Playbooks
 
 - [playbooks/change-authoring-verification.md](playbooks/change-authoring-verification.md) — **required before commit/push** on deps, CI, or e2e changes ([AD-10](decisions.md#ad-10-change-authoring-requires-ci-parity-verification-before-commit))

--- a/developer-docs/playbooks/change-authoring-verification.md
+++ b/developer-docs/playbooks/change-authoring-verification.md
@@ -69,6 +69,8 @@ pnpm test:e2e
 
 | Topic | Document |
 |-------|----------|
+| Term ids | [testing/iteration-vocabulary.md](../testing/iteration-vocabulary.md) |
+| Change loop / gates | [testing/change-authoring-workflow.md](../testing/change-authoring-workflow.md) |
 | Test layers | [architecture/testing-strategy.md](../architecture/testing-strategy.md) |
 | Dependency bumps | [dependency-update-verification.md](dependency-update-verification.md) |
 | E2E scope | [decisions.md](../decisions.md) AD-3, AD-4, AD-6 |

--- a/developer-docs/testing/change-authoring-workflow.md
+++ b/developer-docs/testing/change-authoring-workflow.md
@@ -1,0 +1,92 @@
+---
+type: Reference
+title: Change authoring workflow
+description: Verified product change loop for firebaseui-web.
+tags: [testing, validation, workflow]
+---
+
+# Change authoring workflow
+
+How to author and verify a product change in this repo. Term ids: [iteration vocabulary](iteration-vocabulary.md). Exact commands: [change-authoring-verification.md](../playbooks/change-authoring-verification.md). Test layers: [testing-strategy.md](../architecture/testing-strategy.md). Do not duplicate command lines here.
+
+## Primary loop
+
+```text
+gap-analysis (if needed)
+        |
+implementation  (tier: unit-focused)
+        |
+independent-review  (tier: area-focused, frozen tree)
+        |
+documentation (if user-facing or OKF changed)
+        |
+commit
+        |
+pre-merge-validation (tier: full) when the branch is ready to merge
+```
+
+## Work types
+
+| Work type | When | Validation tier | Product edits | Commit |
+|-----------|------|-----------------|---------------|--------|
+| `gap-analysis` | Unclear feasibility | none | read-only | no |
+| `baseline-capture` | Need a before snapshot | `area-focused` | no | no |
+| `implementation` | Author fix/feature + tests | `unit-focused` | yes | no |
+| `independent-review` | Verify frozen diff | `area-focused` | no, [frozen tree](#frozen-tree) | no |
+| `documentation` | User docs + durable OKF | none | docs only | no |
+| `commit` | Gates closed | none | staging only | yes |
+| `pre-merge-validation` | Branch merge gate | `full` | no | no |
+
+## Validation tiers
+
+This repo's mapping. Command owner: [change-authoring-verification.md](../playbooks/change-authoring-verification.md).
+
+| Tier | When | What |
+|------|------|------|
+| `unit-focused` | `implementation` | `pnpm build:packages`, the targeted example spec (`pnpm test:e2e:<example>`) when e2e/examples changed, `pnpm lint:check` on the diff. Package-only: `pnpm test` for touched packages. |
+| `area-focused` | `independent-review` (frozen) | Full smoke for the changed example(s) on a frozen tree, plus `pnpm test` / lint / format as applicable |
+| `full` | `pre-merge-validation` | The playbook sequence: `pnpm build`, `pnpm test`, lint/format, `pnpm test:e2e` |
+
+`test.only` / focused Playwright files are OK during `unit-focused` only. Never commit them.
+
+## Gates
+
+| Gate | Closes when |
+|------|-------------|
+| `implementation` | `unit-focused` green with [validation evidence](#validation-evidence-blocking) |
+| `review` | `area-focused` green on a [frozen tree](#frozen-tree); every review finding resolved |
+| `commit` | Durable commit exists after prior gates closed with evidence |
+
+**Trust rule:** Code on disk or in git with `review_gate` still **open** is unverified until `independent-review` closes the gate.
+
+`independent-review` classifies findings **critical / serious / minor / nit**. The review gate closes only when every finding is fixed, unless the user confirms an acceptable exception (intractable limitation with evidence, or an explicit deferral with rationale). "Green with minors" is not green.
+
+<a id="validation-evidence-blocking"></a>
+
+### Validation evidence (blocking)
+
+Gates close only when recorded evidence shows the required tier ran and passed. Summaries without exit codes do not close a gate.
+
+| Gate | Minimum evidence |
+|------|------------------|
+| **`implementation`** | Canonical pnpm command(s) + exit 0 |
+| **`review`** | Frozen-tree re-run of `area-focused` commands, exit 0 |
+| **`commit`** | Prior gates closed with evidence; no `test.only` staged |
+| **Publication** | `review_gate` closed on the exact commits being published |
+
+On deps, CI, or e2e/example changes, also complete [change-authoring-verification.md](../playbooks/change-authoring-verification.md) before commit/push ([AD-10](../decisions.md#ad-10-change-authoring-requires-ci-parity-verification-before-commit)).
+
+History rewrite (rebase, amend) invalidates prior green. Re-run the required tier.
+
+## Frozen tree
+
+Required for `independent-review`:
+
+- No edits to `packages/**`, `examples/**`, or `e2e/**` during the run (except reverting accidental `test.only`).
+- Wait for or cancel in-flight Playwright / pnpm test before editing again.
+
+Keep `implementation` and `independent-review` in separate passes.
+
+## Host rule
+
+Do not overlap `unit-focused` and `area-focused` Playwright on the same host. Serial e2e already uses `workers: 1` and a shared Auth emulator on `:9099` ([AD-4](../decisions.md#ad-4-playwright-managed-dev-servers-serial-shared-emulator)).

--- a/developer-docs/testing/iteration-vocabulary.md
+++ b/developer-docs/testing/iteration-vocabulary.md
@@ -1,0 +1,67 @@
+---
+type: Reference
+title: Iteration vocabulary
+description: Identifier glossary and work-queue field schema. Not workflow rules or commands.
+tags: [testing, validation, workflow, work-queue]
+---
+
+# Iteration vocabulary
+
+Glossary of **string identifiers** used across this bundle. This doc does not define procedures or pnpm commands.
+
+**Policy:** [documentation policy](../documentation-policy.md).
+
+| Topic | Owner |
+|-------|--------|
+| Change loop, gates, frozen tree | [change authoring workflow](change-authoring-workflow.md) |
+| Canonical verification commands | [change-authoring-verification.md](../playbooks/change-authoring-verification.md) |
+| Test layers | [testing-strategy.md](../architecture/testing-strategy.md) |
+
+## Work type identifiers
+
+| Work type | Brief meaning |
+|-----------|---------------|
+| `gap-analysis` | Read-only feasibility check |
+| `baseline-capture` | Record a before snapshot (rarely needed) |
+| `implementation` | Author product code and tests |
+| `independent-review` | Verify a frozen diff |
+| `documentation` | User docs and durable OKF updates |
+| `commit` | Stage and create one commit |
+| `pre-merge-validation` | Branch-wide merge gate |
+
+## Validation tier identifiers
+
+| Tier id | Brief meaning |
+|---------|---------------|
+| `unit-focused` | Fast validation while product code is changing |
+| `area-focused` | Changed example(s) plus package tests / lint on a frozen tree |
+| `full` | CI-equivalent: build, unit, lint/format, all Playwright smoke |
+
+Commands per tier: [change authoring](change-authoring-workflow.md#validation-tiers). There is no Jest / Detox / `:test-cover` stack here.
+
+## Gate identifiers
+
+Work queues use these **field names** (values: `open` | `closed`):
+
+| Field | Tracks |
+|-------|--------|
+| `implementation_gate` | `implementation` work type complete |
+| `review_gate` | `independent-review` work type complete |
+| `commit_gate` | Durable commit exists after prior gates closed with evidence |
+
+Items may also be marked **`blocked`**.
+
+## Work-queue fields
+
+| Field | Allowed values / meaning |
+|-------|--------------------------|
+| `next_work_type` | A work type identifier above |
+| `validation_tier` | `unit-focused` \| `area-focused` \| `full` |
+| `platform` | Optional; this repo is web. Use an example id if needed (`react`, `angular-example`, …) |
+| `implementation_gate` | `open` \| `closed` |
+| `review_gate` | `open` \| `closed` |
+| `commit_gate` | `open` \| `closed` |
+| `commit_subject` | Planned Conventional Commits first line. Set before `git commit`. Do not record SHAs. |
+| `blocked` | Item or dependency blocked |
+
+Queues record **state**, not who executes the work.

--- a/developer-docs/work-queues/playwright-e2e-smoke.md
+++ b/developer-docs/work-queues/playwright-e2e-smoke.md
@@ -13,19 +13,13 @@ A fully automated e2e framework that validates each monorepo example **loads and
 
 # Work-queue conventions
 
-Ephemeral tracker; policy: [documentation-policy.md](../documentation-policy.md). This queue records **state** (gates, next step) using neutral OKF work-queue field conventions — not agent roles, dispatch, or session choreography.
+Ephemeral tracker; policy: [documentation-policy.md](../documentation-policy.md). This queue records **state** (gates, next step). It does not define term ids, gate rules, or command tables.
 
-**Work types** (`next_work_type`): `gap-analysis` (read-only feasibility) · `implementation` (author code + tests) · `independent-review` (verify a frozen diff) · `documentation` (durable doc/OKF updates) · `commit` (one focused commit).
+- Term ids: [iteration vocabulary](../testing/iteration-vocabulary.md)
+- Loop, gates, frozen tree: [change authoring workflow](../testing/change-authoring-workflow.md)
+- Commands: [change-authoring-verification.md](../playbooks/change-authoring-verification.md)
 
-**Validation tiers** (`validation_tier`), mapped to this repo:
-
-| Tier           | Meaning here                                                                                                                                    |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `unit-focused` | Fast local check while authoring: `pnpm build:packages`, the targeted example's spec (`pnpm test:e2e:<example>`), `pnpm lint:check` on the diff |
-| `area-focused` | Full smoke for the changed example(s) on a frozen tree, plus `pnpm test` / lint / format as applicable                                          |
-| `full`         | `pnpm build` + `pnpm test` + whole `pnpm test:e2e` across all examples before merge                                                             |
-
-**Gates** (`open` | `closed` | `deferred`): `implementation_gate` (implementation complete + `unit-focused` green) · `review_gate` (independent review complete on frozen tree + `area-focused` green) · `commit_gate` (durable commit exists whose subject matches `commit_subject`). `deferred` = optional work parked until a trigger (e.g. flakiness) re-opens it. Code with `review_gate: open` is untrusted until review closes it. `commit_subject` is the planned Conventional Commit subject, set **before** `git commit` and staged in the same commit; never record SHAs.
+Parked optional work (Phase 5) uses Notes, not a new gate value. Existing `deferred` rows below are historical.
 
 # Smoke scenarios (MVP)
 


### PR DESCRIPTION
Work-queue term ids and the change loop were inlined in `developer-docs/work-queues/playwright-e2e-smoke.md`, so WQO bootstrap had nowhere durable to bind.

- Add `developer-docs/testing/iteration-vocabulary.md` and `change-authoring-workflow.md`
- Point `AGENTS.md` and the index at those docs
- Queue file keeps Playwright state only; it links out for vocab, gates, and commands
